### PR TITLE
feat: Eintrag löschen im Admin-Bereich

### DIFF
--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -1,12 +1,20 @@
+export const dynamic = 'force-dynamic'
+
 import Link from 'next/link'
 import { prisma } from '@/lib/db'
 import { getDayNumber } from '@/lib/journal'
+import { DeleteEntryButton } from '@/components/admin/DeleteEntryButton'
+import { FlashMessage } from '@/components/admin/FlashMessage'
 
 function formatDate(date: Date): string {
   return date.toLocaleDateString('de-CH', { year: 'numeric', month: 'long', day: 'numeric' })
 }
 
-export default async function EntriesPage() {
+interface EntriesPageProps {
+  searchParams: { deleted?: string }
+}
+
+export default async function EntriesPage({ searchParams }: EntriesPageProps) {
   const entries = await prisma.journalEntry.findMany({
     orderBy: { date: 'desc' },
     select: {
@@ -35,6 +43,10 @@ export default async function EntriesPage() {
           Neuer Eintrag
         </Link>
       </div>
+
+      {searchParams.deleted && (
+        <FlashMessage message="Eintrag wurde erfolgreich gelöscht." />
+      )}
 
       {entries.length === 0 ? (
         <div className="text-center py-16 text-sand-400">
@@ -84,6 +96,7 @@ export default async function EntriesPage() {
                   >
                     Bearbeiten
                   </Link>
+                  <DeleteEntryButton id={entry.id} title={entry.title} />
                 </div>
               </div>
             )

--- a/src/components/admin/DeleteEntryButton.tsx
+++ b/src/components/admin/DeleteEntryButton.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { deleteEntry } from '@/app/admin/entries/actions'
+
+interface DeleteEntryButtonProps {
+  id: string
+  title: string
+}
+
+export function DeleteEntryButton({ id, title }: DeleteEntryButtonProps) {
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const result = await deleteEntry(id)
+      if (result.error) {
+        setError(result.error)
+        setShowConfirm(false)
+      } else {
+        router.push('/admin/entries?deleted=1')
+      }
+    })
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => { setError(null); setShowConfirm(true) }}
+        className="text-xs px-3 py-1.5 border border-red-200 dark:border-red-900/50 rounded-lg text-red-500 dark:text-red-400 hover:border-red-300 dark:hover:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 hover:text-red-700 dark:hover:text-red-300 transition-colors"
+      >
+        Löschen
+      </button>
+
+      {error && (
+        <span className="text-xs text-red-500 ml-2">{error}</span>
+      )}
+
+      {showConfirm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-dialog-title"
+        >
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            onClick={() => !isPending && setShowConfirm(false)}
+          />
+
+          {/* Dialog */}
+          <div className="relative bg-white dark:bg-[#2d2926] rounded-2xl border border-sand-200 dark:border-[#4a4540] shadow-xl p-6 max-w-sm w-full space-y-4">
+            <div className="flex items-start gap-3">
+              <span className="text-2xl leading-none mt-0.5" aria-hidden="true">🗑️</span>
+              <div>
+                <h2
+                  id="delete-dialog-title"
+                  className="font-display font-bold text-lg text-[#1a1714] dark:text-[#faf9f7] leading-tight"
+                >
+                  Eintrag löschen?
+                </h2>
+                <p className="text-sm text-sand-500 dark:text-sand-400 mt-1">
+                  <span className="font-medium text-[#1a1714] dark:text-[#faf9f7]">&bdquo;{title}&ldquo;</span>{' '}
+                  wird dauerhaft gelöscht &mdash; inklusive aller Reaktionen.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-3 justify-end pt-1">
+              <button
+                onClick={() => setShowConfirm(false)}
+                disabled={isPending}
+                className="px-4 py-2 text-sm border border-sand-200 dark:border-[#4a4540] rounded-xl text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-[#5a5550] hover:text-[#1a1714] dark:hover:text-[#faf9f7] transition-colors disabled:opacity-50"
+              >
+                Abbrechen
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={isPending}
+                className="px-4 py-2 text-sm bg-red-600 text-white rounded-xl hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+              >
+                {isPending ? 'Wird gelöscht…' : 'Endgültig löschen'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/admin/FlashMessage.tsx
+++ b/src/components/admin/FlashMessage.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+
+interface FlashMessageProps {
+  message: string
+  type?: 'success' | 'error'
+}
+
+export function FlashMessage({ message, type = 'success' }: FlashMessageProps) {
+  const [visible, setVisible] = useState(true)
+  const router = useRouter()
+  const pathname = usePathname()
+
+  // Auto-dismiss after 4 seconds and clean the URL param
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setVisible(false)
+      router.replace(pathname)
+    }, 4000)
+    return () => clearTimeout(t)
+  }, [router, pathname])
+
+  const dismiss = () => {
+    setVisible(false)
+    router.replace(pathname)
+  }
+
+  if (!visible) return null
+
+  const styles =
+    type === 'success'
+      ? 'bg-movement-100 dark:bg-movement-600/10 border-movement-200 dark:border-movement-600/20 text-movement-800 dark:text-movement-300'
+      : 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900/50 text-red-700 dark:text-red-400'
+
+  const icon = type === 'success' ? '✓' : '✕'
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`flex items-center justify-between gap-3 px-4 py-3 mb-5 rounded-xl border text-sm font-medium ${styles}`}
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true">{icon}</span>
+        {message}
+      </div>
+      <button
+        onClick={dismiss}
+        aria-label="Meldung schließen"
+        className="opacity-60 hover:opacity-100 transition-opacity text-base leading-none"
+      >
+        ×
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **DeleteEntryButton** (`src/components/admin/DeleteEntryButton.tsx`): client component with a modal confirmation dialog — shows entry title, pending/loading state during deletion, inline error on failure, redirects to `/admin/entries?deleted=1` on success
- **FlashMessage** (`src/components/admin/FlashMessage.tsx`): client component shown when `?deleted=1` is in the URL — auto-dismisses after 4 seconds and cleans the URL param; can also be closed manually
- **Admin entries page**: delete button added next to each entry row; `FlashMessage` rendered when `searchParams.deleted` is set

## How it works

- Cascade delete: the Prisma schema already has `onDelete: Cascade` on `Reaction.journalEntry`, so reactions are automatically removed when the entry is deleted
- Server action: `deleteEntry(id)` was already implemented in `actions.ts` — no changes needed there
- Auth guard: `requireAdmin()` in the server action prevents unauthorized deletion

## Test plan

- [ ] Navigate to `/admin/entries`
- [ ] Click "Löschen" on an entry — confirmation dialog appears with the entry title
- [ ] Click "Abbrechen" — dialog closes, nothing deleted
- [ ] Click "Endgültig löschen" — button shows "Wird gelöscht…", then redirects to entries list with success banner
- [ ] Success banner auto-dismisses after 4 seconds; URL param `?deleted=1` is cleaned up
- [ ] Entry no longer appears in the list; public journal URL returns 404

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)