### PR TITLE
feat: Admin-Link auf Startseite für eingeloggte User

### DIFF
--- a/src/components/journal/JournalPost.tsx
+++ b/src/components/journal/JournalPost.tsx
@@ -4,6 +4,7 @@ import type { JournalEntry } from '@/lib/journal'
 import { getDayNumber } from '@/lib/journal'
 import { HabitBadges } from './HabitBadges'
 import { ReactionBar } from '@/components/reactions/ReactionBar'
+import { getAuthSession } from '@/lib/auth'
 
 interface JournalPostProps {
   entry: JournalEntry
@@ -18,7 +19,9 @@ function formatDate(dateStr: string): string {
   })
 }
 
-export function JournalPost({ entry }: JournalPostProps) {
+export async function JournalPost({ entry }: JournalPostProps) {
+  const session = await getAuthSession()
+  const isAdmin = !!session?.user?.isAdmin
   const dayNumber = getDayNumber(entry.date)
 
   return (
@@ -45,6 +48,17 @@ export function JournalPost({ entry }: JournalPostProps) {
           <time className="text-sm text-sand-400" dateTime={entry.date}>
             {formatDate(entry.date)}
           </time>
+          {isAdmin && (
+            <>
+              <span className="text-sand-300 dark:text-[#4a4540] select-none" aria-hidden="true">·</span>
+              <Link
+                href={`/admin/entries/${entry.id}/edit`}
+                className="text-xs font-medium text-nutrition-600 dark:text-nutrition-500 hover:text-nutrition-700 dark:hover:text-nutrition-400 transition-colors"
+              >
+                Bearbeiten ✎
+              </Link>
+            </>
+          )}
         </div>
 
         <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight text-[#1a1714] dark:text-[#faf9f7] mb-5">

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,8 +1,12 @@
 import Link from 'next/link'
 import { ThemeToggle } from './ThemeToggle'
 import { SearchModal } from '@/components/search/SearchModal'
+import { getAuthSession } from '@/lib/auth'
 
-export function Navigation() {
+export async function Navigation() {
+  const session = await getAuthSession()
+  const isAdmin = !!session?.user?.isAdmin
+
   return (
     <nav className="flex items-center gap-2" aria-label="Hauptnavigation">
       <Link
@@ -12,6 +16,15 @@ export function Navigation() {
         Journal
       </Link>
       <SearchModal />
+      {isAdmin && (
+        <Link
+          href="/admin"
+          className="text-sm font-medium text-nutrition-600 dark:text-nutrition-500 hover:text-nutrition-700 dark:hover:text-nutrition-400 transition-colors"
+          title="Admin-Bereich"
+        >
+          Admin
+        </Link>
+      )}
       <ThemeToggle />
     </nav>
   )

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -20,6 +20,7 @@ export interface HabitsFrontmatter {
 }
 
 export interface JournalEntry {
+  id: string
   slug: string
   title: string
   date: string // YYYY-MM-DD
@@ -61,6 +62,7 @@ function toDateString(date: Date): string {
 
 function toMeta(entry: PrismaJournalEntry): JournalEntryMeta {
   return {
+    id: entry.id,
     slug: entry.slug,
     title: entry.title,
     date: toDateString(entry.date),


### PR DESCRIPTION
## Summary

- **Navigation admin link**: `Navigation` is now an async server component — calls `getAuthSession()` and renders an amber-colored "Admin" link (→ `/admin`) between the search icon and the theme toggle, only when `session.user.isAdmin` is true. Invisible to all regular visitors.

- **Journal entry edit link**: `JournalPost` is now an async server component — calls `getAuthSession()` and injects a "Bearbeiten ✎" link inline in the entry header (after the date), linking directly to `/admin/entries/${entry.id}/edit`. Requires `id` on the `JournalEntry` type.

- **`JournalEntry.id`**: added `id: string` to the `JournalEntry` interface and `JournalEntryMeta` (via `toMeta`). Purely additive — no existing code is affected.

## Test plan

- [ ] Logged out: "Admin" not visible in navigation, no "Bearbeiten" link on journal entries
- [ ] Logged in as admin: "Admin" link appears in nav header; clicking → `/admin`
- [ ] On a journal entry page while logged in: "Bearbeiten ✎" link appears in the header metadata row; clicking → `/admin/entries/{id}/edit`

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)