### PR TITLE
feat: translation cache & admin UI for translations (#57)

### DIFF
--- a/src/app/admin/entries/actions.ts
+++ b/src/app/admin/entries/actions.ts
@@ -64,7 +64,7 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
 
     revalidatePath('/')
     revalidatePath('/admin/entries')
-    revalidatePath(`/journal/${data.slug}`)
+    revalidatePath(`/de/journal/${data.slug}`)
 
     return { slug: data.slug }
   } catch (e) {
@@ -99,7 +99,9 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
 
     revalidatePath('/')
     revalidatePath('/admin/entries')
-    revalidatePath(`/journal/${entry.slug}`)
+    revalidatePath('/admin/translations')
+    revalidatePath(`/de/journal/${entry.slug}`)
+    revalidatePath(`/en/journal/${entry.slug}`)
 
     return { slug: entry.slug }
   } catch (e) {

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -24,10 +24,11 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
       title: true,
       date: true,
       published: true,
+      updatedAt: true,
       movement: true,
       nutrition: true,
       smoking: true,
-      translation: { select: { id: true } },
+      translation: { select: { updatedAt: true } },
     },
   })
 
@@ -62,6 +63,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
           {entries.map((entry) => {
             const dateStr = entry.date.toISOString().slice(0, 10)
             const isTranslated = !!entry.translation
+            const isStale = isTranslated && entry.translation!.updatedAt < entry.updatedAt
             return (
               <div
                 key={entry.id}
@@ -86,7 +88,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0">
-                  <TranslateButton id={entry.id} isTranslated={isTranslated} />
+                  <TranslateButton id={entry.id} isTranslated={isTranslated} isStale={isStale} />
                   <Link
                     href={`/journal/${entry.slug}`}
                     target="_blank"

--- a/src/app/admin/translations/[entryId]/page.tsx
+++ b/src/app/admin/translations/[entryId]/page.tsx
@@ -1,0 +1,137 @@
+export const dynamic = 'force-dynamic'
+
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { prisma } from '@/lib/db'
+import { getDayNumber } from '@/lib/journal'
+import { TranslationEditForm } from '@/components/admin/TranslationEditForm'
+
+interface TranslationDetailPageProps {
+  params: { entryId: string }
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('de-CH', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+export default async function TranslationDetailPage({ params }: TranslationDetailPageProps) {
+  const entry = await prisma.journalEntry.findUnique({
+    where: { id: params.entryId },
+    include: { translation: true },
+  })
+
+  if (!entry) notFound()
+
+  const dateStr = entry.date.toISOString().slice(0, 10)
+  const isStale = entry.translation
+    ? entry.translation.updatedAt < entry.updatedAt
+    : false
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-start justify-between mb-6 gap-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <Link
+              href="/admin/translations"
+              className="text-sm text-sand-400 hover:text-[#1a1714] dark:hover:text-[#faf9f7] transition-colors"
+            >
+              ← Übersetzungen
+            </Link>
+          </div>
+          <h1 className="font-display text-2xl font-bold text-[#1a1714] dark:text-[#faf9f7]">
+            {entry.title}
+          </h1>
+          <div className="flex items-center gap-3 mt-1">
+            <span className="text-xs font-mono text-sand-400">Tag {getDayNumber(dateStr)}</span>
+            <span className="text-xs text-sand-400">{formatDate(entry.date)}</span>
+            {entry.translation && isStale && (
+              <span className="text-xs px-2 py-0.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-full">
+                Veraltet
+              </span>
+            )}
+            {entry.translation && !isStale && (
+              <span className="text-xs px-2 py-0.5 bg-movement-100 dark:bg-movement-900/30 text-movement-700 dark:text-movement-400 rounded-full">
+                Übersetzt
+              </span>
+            )}
+            {!entry.translation && (
+              <span className="text-xs px-2 py-0.5 bg-sand-100 dark:bg-[#3a3531] text-sand-500 rounded-full">
+                Nicht übersetzt
+              </span>
+            )}
+          </div>
+        </div>
+        {entry.translation && (
+          <Link
+            href={`/en/journal/${entry.slug}`}
+            target="_blank"
+            className="shrink-0 text-xs text-sand-400 hover:text-[#1a1714] dark:hover:text-[#faf9f7] transition-colors"
+          >
+            EN-Seite ansehen ↗
+          </Link>
+        )}
+      </div>
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Left: German original (read-only) */}
+        <div className="space-y-4">
+          <h2 className="text-sm font-semibold text-sand-500 uppercase tracking-wide flex items-center gap-2">
+            <span className="text-xs px-1.5 py-0.5 bg-sand-100 dark:bg-[#3a3531] text-sand-600 dark:text-sand-400 rounded font-mono">DE</span>
+            Original
+          </h2>
+
+          <div className="rounded-xl border border-sand-200 dark:border-[#4a4540] bg-white dark:bg-[#2d2926] p-4 space-y-4">
+            <div>
+              <p className="text-xs font-medium text-sand-400 uppercase tracking-wide mb-1">Titel</p>
+              <p className="text-sm font-semibold text-[#1a1714] dark:text-[#faf9f7]">{entry.title}</p>
+            </div>
+            {entry.excerpt && (
+              <div>
+                <p className="text-xs font-medium text-sand-400 uppercase tracking-wide mb-1">Excerpt</p>
+                <p className="text-sm text-sand-600 dark:text-sand-400">{entry.excerpt}</p>
+              </div>
+            )}
+            <div>
+              <p className="text-xs font-medium text-sand-400 uppercase tracking-wide mb-1">Inhalt (HTML)</p>
+              <div className="text-xs font-mono text-sand-500 dark:text-sand-400 bg-sand-50 dark:bg-[#1a1714] rounded-lg p-3 max-h-64 overflow-y-auto whitespace-pre-wrap break-all">
+                {entry.content}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Right: English translation (editable) */}
+        <div className="space-y-4">
+          <h2 className="text-sm font-semibold text-sand-500 uppercase tracking-wide flex items-center gap-2">
+            <span className="text-xs px-1.5 py-0.5 bg-nutrition-100 dark:bg-nutrition-900/30 text-nutrition-700 dark:text-nutrition-400 rounded font-mono">EN</span>
+            Übersetzung
+          </h2>
+
+          <div className="rounded-xl border border-sand-200 dark:border-[#4a4540] bg-white dark:bg-[#2d2926] p-4">
+            {entry.translation ? (
+              <TranslationEditForm
+                entryId={entry.id}
+                initialTitle={entry.translation.title}
+                initialExcerpt={entry.translation.excerpt ?? ''}
+                initialContent={entry.translation.content}
+              />
+            ) : (
+              <div className="text-center py-8 space-y-3">
+                <p className="text-sm text-sand-400">Noch keine Übersetzung vorhanden.</p>
+                <TranslationEditForm
+                  entryId={entry.id}
+                  initialTitle=""
+                  initialExcerpt=""
+                  initialContent=""
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/translations/actions.ts
+++ b/src/app/admin/translations/actions.ts
@@ -1,0 +1,51 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+
+export interface TranslationEditData {
+  title: string
+  excerpt: string
+  content: string
+}
+
+export interface ActionResult {
+  error?: string
+}
+
+export async function updateTranslation(entryId: string, data: TranslationEditData): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  if (!data.title.trim()) return { error: 'Titel ist erforderlich' }
+  if (!data.content.trim()) return { error: 'Inhalt ist erforderlich' }
+
+  const entry = await prisma.journalEntry.findUnique({
+    where: { id: entryId },
+    select: { slug: true },
+  })
+  if (!entry) return { error: 'Eintrag nicht gefunden' }
+
+  await prisma.translation.upsert({
+    where: { entryId },
+    create: {
+      entryId,
+      locale: 'en',
+      title: data.title.trim(),
+      excerpt: data.excerpt.trim(),
+      content: data.content.trim(),
+    },
+    update: {
+      title: data.title.trim(),
+      excerpt: data.excerpt.trim(),
+      content: data.content.trim(),
+    },
+  })
+
+  revalidatePath('/admin/translations')
+  revalidatePath(`/admin/translations/${entryId}`)
+  revalidatePath(`/en/journal/${entry.slug}`)
+
+  return {}
+}

--- a/src/app/admin/translations/page.tsx
+++ b/src/app/admin/translations/page.tsx
@@ -1,0 +1,141 @@
+export const dynamic = 'force-dynamic'
+
+import Link from 'next/link'
+import { prisma } from '@/lib/db'
+import { getDayNumber } from '@/lib/journal'
+import { TranslateButton } from '@/components/admin/TranslateButton'
+
+type TranslationStatus = 'current' | 'stale' | 'missing'
+
+function getStatus(
+  entryUpdatedAt: Date,
+  translation: { updatedAt: Date } | null,
+): TranslationStatus {
+  if (!translation) return 'missing'
+  return translation.updatedAt >= entryUpdatedAt ? 'current' : 'stale'
+}
+
+function StatusBadge({ status }: { status: TranslationStatus }) {
+  if (status === 'current') {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-movement-100 dark:bg-movement-900/30 text-movement-700 dark:text-movement-400 rounded-full">
+        <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+        Übersetzt
+      </span>
+    )
+  }
+  if (status === 'stale') {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-full">
+        <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        Veraltet
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-sand-100 dark:bg-[#3a3531] text-sand-500 rounded-full">
+      <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+      Fehlt
+    </span>
+  )
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('de-CH', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+export default async function TranslationsPage() {
+  const entries = await prisma.journalEntry.findMany({
+    orderBy: { date: 'desc' },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      date: true,
+      updatedAt: true,
+      translation: { select: { updatedAt: true } },
+    },
+  })
+
+  const statuses = entries.map((e) => getStatus(e.updatedAt, e.translation))
+  const countCurrent = statuses.filter((s) => s === 'current').length
+  const countStale = statuses.filter((s) => s === 'stale').length
+  const countMissing = statuses.filter((s) => s === 'missing').length
+
+  return (
+    <div>
+      <h1 className="font-display text-2xl font-bold text-[#1a1714] dark:text-[#faf9f7] mb-6">
+        Übersetzungen
+      </h1>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-3 mb-6">
+        <div className="bg-white dark:bg-[#2d2926] rounded-xl border border-sand-200 dark:border-[#4a4540] px-5 py-4">
+          <p className="text-2xl font-bold font-display text-movement-600 dark:text-movement-400">{countCurrent}</p>
+          <p className="text-xs text-sand-400 mt-0.5">Übersetzt</p>
+        </div>
+        <div className="bg-white dark:bg-[#2d2926] rounded-xl border border-sand-200 dark:border-[#4a4540] px-5 py-4">
+          <p className="text-2xl font-bold font-display text-amber-600 dark:text-amber-400">{countStale}</p>
+          <p className="text-xs text-sand-400 mt-0.5">Veraltet</p>
+        </div>
+        <div className="bg-white dark:bg-[#2d2926] rounded-xl border border-sand-200 dark:border-[#4a4540] px-5 py-4">
+          <p className="text-2xl font-bold font-display text-sand-500">{countMissing}</p>
+          <p className="text-xs text-sand-400 mt-0.5">Fehlen</p>
+        </div>
+      </div>
+
+      {/* Entry list */}
+      {entries.length === 0 ? (
+        <div className="text-center py-16 text-sand-400">
+          <p>Noch keine Einträge vorhanden.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {entries.map((entry, i) => {
+            const status = statuses[i]
+            const dateStr = entry.date.toISOString().slice(0, 10)
+            return (
+              <div
+                key={entry.id}
+                className="bg-white dark:bg-[#2d2926] rounded-xl border border-sand-200 dark:border-[#4a4540] px-5 py-4 flex items-center gap-4 hover:border-sand-300 dark:hover:border-[#5a5550] transition-colors"
+              >
+                <span className="text-xs font-mono text-sand-400 shrink-0 w-8 text-right">
+                  {getDayNumber(dateStr)}
+                </span>
+
+                <div className="flex-1 min-w-0">
+                  <p className="font-display font-semibold text-[#1a1714] dark:text-[#faf9f7] truncate text-sm">
+                    {entry.title}
+                  </p>
+                  <time className="text-xs text-sand-400">{formatDate(entry.date)}</time>
+                </div>
+
+                <StatusBadge status={status} />
+
+                <div className="flex items-center gap-2 shrink-0">
+                  <TranslateButton
+                    id={entry.id}
+                    isTranslated={status !== 'missing'}
+                    isStale={status === 'stale'}
+                  />
+                  <Link
+                    href={`/admin/translations/${entry.id}`}
+                    className="text-xs px-3 py-1.5 border border-sand-200 dark:border-[#4a4540] rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-[#5a5550] hover:text-[#1a1714] dark:hover:text-[#faf9f7] transition-colors"
+                  >
+                    Bearbeiten
+                  </Link>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -7,6 +7,7 @@ import { clsx } from 'clsx'
 const navItems = [
   { href: '/admin', label: 'Dashboard', exact: true },
   { href: '/admin/entries', label: 'Einträge', exact: false },
+  { href: '/admin/translations', label: 'Übersetzungen', exact: false },
   { href: '/admin/metrics', label: 'Metriken', exact: false },
   { href: '/admin/fitbit', label: 'Fitbit', exact: false },
 ]

--- a/src/components/admin/TranslateButton.tsx
+++ b/src/components/admin/TranslateButton.tsx
@@ -6,9 +6,10 @@ import { translateEntry } from '@/app/admin/entries/actions'
 interface TranslateButtonProps {
   id: string
   isTranslated: boolean
+  isStale?: boolean
 }
 
-export function TranslateButton({ id, isTranslated }: TranslateButtonProps) {
+export function TranslateButton({ id, isTranslated, isStale = false }: TranslateButtonProps) {
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
 
@@ -20,18 +21,27 @@ export function TranslateButton({ id, isTranslated }: TranslateButtonProps) {
     })
   }
 
+  const isOutdated = isTranslated && isStale
+
   return (
     <div className="relative">
       <button
         onClick={handleClick}
         disabled={isPending}
-        title={isTranslated ? 'Übersetzung aktualisieren' : 'Ins Englische übersetzen'}
+        title={
+          isPending ? 'Übersetze…'
+          : isOutdated ? 'Übersetzung ist veraltet — neu übersetzen'
+          : isTranslated ? 'Übersetzung aktualisieren'
+          : 'Ins Englische übersetzen'
+        }
         className={`text-xs px-3 py-1.5 border rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
           error
             ? 'border-red-300 dark:border-red-700 text-red-600 dark:text-red-400'
-            : isTranslated
-              ? 'border-movement-300 dark:border-movement-700 text-movement-700 dark:text-movement-400 hover:bg-movement-50 dark:hover:bg-movement-900/20'
-              : 'border-sand-200 dark:border-[#4a4540] text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-[#5a5550] hover:text-[#1a1714] dark:hover:text-[#faf9f7]'
+            : isOutdated
+              ? 'border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20'
+              : isTranslated
+                ? 'border-movement-300 dark:border-movement-700 text-movement-700 dark:text-movement-400 hover:bg-movement-50 dark:hover:bg-movement-900/20'
+                : 'border-sand-200 dark:border-[#4a4540] text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-[#5a5550] hover:text-[#1a1714] dark:hover:text-[#faf9f7]'
         }`}
       >
         {isPending ? (
@@ -48,15 +58,22 @@ export function TranslateButton({ id, isTranslated }: TranslateButtonProps) {
             </svg>
             Fehler
           </span>
-        ) : (
+        ) : isOutdated ? (
           <span className="flex items-center gap-1.5">
-            {isTranslated && (
-              <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M20 6L9 17l-5-5" />
-              </svg>
-            )}
-            {isTranslated ? 'EN ✓' : 'EN übersetzen'}
+            <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+            EN veraltet
           </span>
+        ) : isTranslated ? (
+          <span className="flex items-center gap-1.5">
+            <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M20 6L9 17l-5-5" />
+            </svg>
+            EN ✓
+          </span>
+        ) : (
+          <span>EN übersetzen</span>
         )}
       </button>
 

--- a/src/components/admin/TranslationEditForm.tsx
+++ b/src/components/admin/TranslationEditForm.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useTransition, useState } from 'react'
+import { updateTranslation } from '@/app/admin/translations/actions'
+import { translateEntry } from '@/app/admin/entries/actions'
+
+interface TranslationEditFormProps {
+  entryId: string
+  initialTitle: string
+  initialExcerpt: string
+  initialContent: string
+}
+
+export function TranslationEditForm({
+  entryId,
+  initialTitle,
+  initialExcerpt,
+  initialContent,
+}: TranslationEditFormProps) {
+  const [title, setTitle] = useState(initialTitle)
+  const [excerpt, setExcerpt] = useState(initialExcerpt)
+  const [content, setContent] = useState(initialContent)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveSuccess, setSaveSuccess] = useState(false)
+  const [translateError, setTranslateError] = useState<string | null>(null)
+
+  const [isSaving, startSave] = useTransition()
+  const [isTranslating, startTranslate] = useTransition()
+
+  function handleSave() {
+    setSaveError(null)
+    setSaveSuccess(false)
+    startSave(async () => {
+      const result = await updateTranslation(entryId, { title, excerpt, content })
+      if (result.error) setSaveError(result.error)
+      else setSaveSuccess(true)
+    })
+  }
+
+  function handleRetranslate() {
+    setTranslateError(null)
+    setSaveSuccess(false)
+    startTranslate(async () => {
+      const result = await translateEntry(entryId)
+      if (result.error) {
+        setTranslateError(result.error)
+      } else {
+        // Reload page to show fresh translation
+        window.location.reload()
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-xs font-medium text-sand-500 uppercase tracking-wide mb-1.5">
+          Titel
+        </label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => { setTitle(e.target.value); setSaveSuccess(false) }}
+          className="w-full px-3 py-2 text-sm bg-white dark:bg-[#2d2926] border border-sand-200 dark:border-[#4a4540] rounded-lg text-[#1a1714] dark:text-[#faf9f7] focus:outline-none focus:border-nutrition-500 dark:focus:border-nutrition-400 transition-colors"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-sand-500 uppercase tracking-wide mb-1.5">
+          Excerpt
+        </label>
+        <textarea
+          value={excerpt}
+          onChange={(e) => { setExcerpt(e.target.value); setSaveSuccess(false) }}
+          rows={3}
+          className="w-full px-3 py-2 text-sm bg-white dark:bg-[#2d2926] border border-sand-200 dark:border-[#4a4540] rounded-lg text-[#1a1714] dark:text-[#faf9f7] focus:outline-none focus:border-nutrition-500 dark:focus:border-nutrition-400 transition-colors resize-y"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-sand-500 uppercase tracking-wide mb-1.5">
+          Inhalt (HTML)
+        </label>
+        <textarea
+          value={content}
+          onChange={(e) => { setContent(e.target.value); setSaveSuccess(false) }}
+          rows={14}
+          className="w-full px-3 py-2 text-xs font-mono bg-white dark:bg-[#2d2926] border border-sand-200 dark:border-[#4a4540] rounded-lg text-[#1a1714] dark:text-[#faf9f7] focus:outline-none focus:border-nutrition-500 dark:focus:border-nutrition-400 transition-colors resize-y"
+        />
+      </div>
+
+      {saveError && (
+        <p className="text-sm text-red-600 dark:text-red-400">{saveError}</p>
+      )}
+      {translateError && (
+        <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3">
+          <p className="text-sm text-red-600 dark:text-red-400 leading-snug">{translateError}</p>
+        </div>
+      )}
+      {saveSuccess && (
+        <p className="text-sm text-movement-600 dark:text-movement-400">Gespeichert ✓</p>
+      )}
+
+      <div className="flex items-center gap-3 pt-1">
+        <button
+          onClick={handleSave}
+          disabled={isSaving || isTranslating}
+          className="px-4 py-2 bg-nutrition-600 text-white rounded-xl text-sm font-medium hover:bg-nutrition-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isSaving ? 'Speichere…' : 'Speichern'}
+        </button>
+        <button
+          onClick={handleRetranslate}
+          disabled={isSaving || isTranslating}
+          className="flex items-center gap-2 px-4 py-2 border border-sand-200 dark:border-[#4a4540] rounded-xl text-sm font-medium text-sand-600 dark:text-sand-400 hover:border-sand-300 hover:text-[#1a1714] dark:hover:text-[#faf9f7] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isTranslating ? (
+            <>
+              <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+              </svg>
+              Übersetze…
+            </>
+          ) : (
+            <>
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+              </svg>
+              Neu übersetzen (KI)
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- AdminNav: add "Übersetzungen" nav item
- Staleness detection: compare entry.updatedAt vs translation.updatedAt
- TranslateButton: amber "EN veraltet" state, green "EN ✓", default "EN übersetzen"
- Entries list: pass isStale prop to TranslateButton
- updateEntry: revalidate /de and /en journal pages + /admin/translations
- /admin/translations: overview page with stats (übersetzt/veraltet/fehlt) and per-entry status badges
- /admin/translations/[entryId]: side-by-side DE original vs EN translation, editable title/excerpt/content (HTML textarea), re-translate via Claude, save manual edits
- updateTranslation server action for manual edits

## Beschreibung

<!-- Was ändert dieser PR? Kurze Zusammenfassung. -->

## Verknüpftes Issue

Closes #

## Art der Änderung

- [ ] 🐛 Bug Fix
- [ ] ✨ Neues Feature
- [ ] 🔧 Refactoring
- [ ] 📝 Dokumentation
- [ ] 🎨 Styling
- [ ] ⚡ Performance
- [ ] 🧪 Tests
- [ ] 🔨 Chore (Dependencies, Config, etc.)

## Checkliste

- [ ] Code folgt den Projektkonventionen (CLAUDE.md)
- [ ] TypeScript kompiliert ohne Fehler (`pnpm type-check`)
- [ ] Linting bestanden (`pnpm lint`)
- [ ] Tests geschrieben und bestanden (`pnpm test`)
- [ ] Responsive getestet (Mobile + Desktop)
- [ ] Prisma-Migration erstellt (falls Schema geändert)
- [ ] Umgebungsvariablen dokumentiert (falls neue hinzugefügt)

## Screenshots

<!-- Optional: Vorher/Nachher Screenshots bei UI-Änderungen -->
