### PR TITLE
fix: Docker ARM64 OpenSSL fix for HomeLab deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # --- Stage 1: Dependencies ---
 FROM node:20-alpine AS deps
-RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+RUN apk add --no-cache openssl && corepack enable && corepack prepare pnpm@9.15.0 --activate
 WORKDIR /app
 
 COPY .npmrc package.json pnpm-lock.yaml ./
@@ -13,7 +13,7 @@ RUN pnpm install --frozen-lockfile
 
 # --- Stage 2: Build ---
 FROM node:20-alpine AS builder
-RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+RUN apk add --no-cache openssl && corepack enable && corepack prepare pnpm@9.15.0 --activate
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -34,6 +34,8 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN apk add --no-cache openssl
 
 # Unprivileged user
 RUN addgroup --system --gid 1001 nodejs

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ datasource db {
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x", "linux-musl-arm64-openssl-3.0.x"]
 }
 
 // =============================================


### PR DESCRIPTION
## Summary

- Install `openssl` in all three Dockerfile stages (`deps`, `builder`, `runner`) so Prisma can detect the OpenSSL version at build and runtime
- Add `linux-musl-arm64-openssl-3.0.x` to Prisma `binaryTargets` for ARM64 support (Raspberry Pi 5)

## Problem

On Alpine Linux (ARM64), Prisma cannot detect the OpenSSL version without the `openssl` package installed. It silently falls back to `openssl-1.1.x` — which doesn't exist on Alpine 3.x (OpenSSL 3 only). At startup, `prisma migrate deploy` then tries to download the missing binary and crashes with a permission error.

## Root cause chain

1. `pnpm install` in `deps` stage → downloads `schema-engine-linux-musl-arm64-openssl-1.1.x` (wrong version)
2. `prisma generate` in `builder` stage → generates `libquery_engine-...-openssl-1.1.x` (wrong version)
3. At runtime in `runner` → Prisma can't load `libssl.so.1.1`, tries to re-download, hits permissions wall → crash loop

## Test plan

- [x] Verified on pilab01 (Raspberry Pi 5, Alpine ARM64): `prisma migrate deploy` completes, Next.js starts successfully
- [ ] CI build passes (x86, uses `linux-musl-openssl-3.0.x` — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)