### PR TITLE
fix: await analytics tracking fetch in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,7 +33,7 @@ export async function middleware(req: NextRequest) {
       req.headers.get('x-real-ip') ??
       '0.0.0.0'
     const referrer = req.headers.get('referer') ?? ''
-    void fetch(new URL('/api/internal/track', req.url).toString(), {
+    await fetch(new URL('/api/internal/track', req.url).toString(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-internal-secret': internalSecret },
       body: JSON.stringify({ path: pathname, referrer, ua, ip }),


### PR DESCRIPTION
## Summary
- Change `void fetch(...)` to `await fetch(...)` for the analytics tracking call in Edge Middleware
- In Next.js 14 Edge Runtime, fire-and-forget fetch calls are cancelled when middleware returns the response — so no PageViews were ever written
- Awaiting the call ensures the record is written; latency impact is minimal (fast local loopback)

## Root cause
`void fetch()` in `src/middleware.ts` — the Edge Runtime terminates pending microtasks once the response is dispatched, silently dropping the tracking request.

## Test plan
- [ ] Visit a blog page after deploy
- [ ] Check `/admin/analytics` — views/sessions should now increment

🤖 Generated with [Claude Code](https://claude.com/claude-code)