### PR TITLE
feat: AI-generierte Monats-Zusammenfassungen via Claude API

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -100,6 +100,14 @@
     "minChars": "Mindestens 2 Zeichen eingeben",
     "day": "Tag"
   },
+  "MonthlySummary": {
+    "overviewHeading": "Monats-Zusammenfassungen",
+    "overviewDescription": "AI-generierte Rückblicke auf jeden Monat des Projekts.",
+    "noSummaries": "Noch keine Zusammenfassungen vorhanden.",
+    "generatedOn": "Erstellt am {date}",
+    "summaryLabel": "Monats-Rückblick",
+    "backToOverview": "Alle Zusammenfassungen"
+  },
   "HabitBadges": {
     "movement": {
       "minimal": "Wenig Bewegung",

--- a/messages/en.json
+++ b/messages/en.json
@@ -100,6 +100,14 @@
     "minChars": "Enter at least 2 characters",
     "day": "Day"
   },
+  "MonthlySummary": {
+    "overviewHeading": "Monthly Summaries",
+    "overviewDescription": "AI-generated retrospectives for each month of the project.",
+    "noSummaries": "No summaries yet.",
+    "generatedOn": "Generated on {date}",
+    "summaryLabel": "Monthly Retrospective",
+    "backToOverview": "All summaries"
+  },
   "HabitBadges": {
     "movement": {
       "minimal": "Low activity",

--- a/prisma/migrations/20260406000000_add_month_summary/migration.sql
+++ b/prisma/migrations/20260406000000_add_month_summary/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "MonthSummary" (
+    "id" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "month" INTEGER NOT NULL,
+    "contentDe" TEXT NOT NULL,
+    "contentEn" TEXT,
+    "generatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MonthSummary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MonthSummary_year_month_idx" ON "MonthSummary"("year", "month");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MonthSummary_year_month_key" ON "MonthSummary"("year", "month");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,24 @@ enum ReactionType {
 }
 
 // =============================================
+// MONATS-ZUSAMMENFASSUNGEN — AI-generierte Rückblicke
+// Quelle: Claude API, einmal pro Monat generiert
+// =============================================
+
+model MonthSummary {
+  id          String   @id @default(cuid())
+  year        Int
+  month       Int      // 1–12
+  contentDe   String   @db.Text
+  contentEn   String?  @db.Text
+  generatedAt DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([year, month])
+  @@index([year, month])
+}
+
+// =============================================
 // SEITENAUFRUFE — Privacy-first Analytics
 // Kein Cookie, keine IP-Speicherung
 // sessionHash = SHA-256(IP+UA+Date+Salt), tagesbezogen

--- a/src/app/[locale]/monthly/[month]/page.tsx
+++ b/src/app/[locale]/monthly/[month]/page.tsx
@@ -1,0 +1,107 @@
+export const dynamic = 'force-dynamic'
+
+import { notFound } from 'next/navigation'
+import { getTranslations } from 'next-intl/server'
+import Link from 'next/link'
+import { getMonthSummary } from '@/lib/month-summary'
+import { SITE_NAME, SITE_URL } from '@/lib/site'
+import type { Metadata } from 'next'
+
+const MONTH_NAMES_DE = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
+const MONTH_NAMES_EN = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+
+interface MonthSummaryPageProps {
+  params: { locale: string; month: string }
+}
+
+function parseMonth(slug: string): { year: number; month: number } | null {
+  const match = slug.match(/^(\d{4})-(\d{2})$/)
+  if (!match) return null
+  const year = parseInt(match[1], 10)
+  const month = parseInt(match[2], 10)
+  if (month < 1 || month > 12) return null
+  return { year, month }
+}
+
+export async function generateMetadata({ params }: MonthSummaryPageProps): Promise<Metadata> {
+  const parsed = parseMonth(params.month)
+  if (!parsed) return {}
+
+  const summary = await getMonthSummary(parsed.year, parsed.month)
+  if (!summary) return {}
+
+  const monthNames = params.locale === 'en' ? MONTH_NAMES_EN : MONTH_NAMES_DE
+  const monthName = monthNames[parsed.month - 1]
+  const title = params.locale === 'en'
+    ? `${monthName} ${parsed.year} — Monthly Summary`
+    : `${monthName} ${parsed.year} — Monats-Zusammenfassung`
+
+  const canonicalUrl = `${SITE_URL}/${params.locale}/monthly/${params.month}`
+
+  return {
+    title,
+    alternates: {
+      canonical: canonicalUrl,
+      languages: {
+        de: `${SITE_URL}/de/monthly/${params.month}`,
+        en: `${SITE_URL}/en/monthly/${params.month}`,
+      },
+    },
+    openGraph: {
+      type: 'article',
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      title,
+    },
+  }
+}
+
+export default async function MonthSummaryPage({ params }: MonthSummaryPageProps) {
+  const parsed = parseMonth(params.month)
+  if (!parsed) notFound()
+
+  const { year, month } = parsed
+  const summary = await getMonthSummary(year, month)
+  if (!summary) notFound()
+
+  const t = await getTranslations({ locale: params.locale, namespace: 'MonthlySummary' })
+  const monthNames = params.locale === 'en' ? MONTH_NAMES_EN : MONTH_NAMES_DE
+  const monthName = monthNames[month - 1]
+
+  const isEn = params.locale === 'en'
+  const content = isEn && summary.contentEn ? summary.contentEn : summary.contentDe
+
+  return (
+    <article className="max-w-2xl mx-auto py-12 px-4">
+      {/* Back */}
+      <Link
+        href={`/${params.locale}/monthly`}
+        className="inline-block text-sm text-sand-400 hover:text-[#1a1714] dark:hover:text-[#faf9f7] mb-8 transition-colors"
+      >
+        ← {t('backToOverview')}
+      </Link>
+
+      {/* Header */}
+      <header className="mb-8">
+        <p className="text-xs font-semibold text-nutrition-600 dark:text-nutrition-400 uppercase tracking-wide mb-2">
+          {t('summaryLabel')}
+        </p>
+        <h1 className="font-display text-4xl font-bold text-[#1a1714] dark:text-[#faf9f7]">
+          {monthName} {year}
+        </h1>
+        <p className="text-xs text-sand-400 mt-2">
+          {t('generatedOn', { date: summary.generatedAt.toLocaleDateString(isEn ? 'en-GB' : 'de-CH', { day: 'numeric', month: 'long', year: 'numeric' }) })}
+          {isEn && !summary.contentEn && (
+            <span className="ml-2 italic">(Original auf Deutsch)</span>
+          )}
+        </p>
+      </header>
+
+      {/* Content */}
+      <div
+        className="prose prose-sand dark:prose-invert max-w-none"
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    </article>
+  )
+}

--- a/src/app/[locale]/monthly/page.tsx
+++ b/src/app/[locale]/monthly/page.tsx
@@ -1,0 +1,55 @@
+export const dynamic = 'force-dynamic'
+
+import { getTranslations } from 'next-intl/server'
+import Link from 'next/link'
+import { getAllMonthSummaries } from '@/lib/month-summary'
+
+const MONTH_NAMES_DE = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
+const MONTH_NAMES_EN = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+
+function monthSlug(year: number, month: number): string {
+  return `${year}-${String(month).padStart(2, '0')}`
+}
+
+interface MonthlyOverviewPageProps {
+  params: { locale: string }
+}
+
+export default async function MonthlyOverviewPage({ params }: MonthlyOverviewPageProps) {
+  const t = await getTranslations({ locale: params.locale, namespace: 'MonthlySummary' })
+  const summaries = await getAllMonthSummaries()
+  const monthNames = params.locale === 'en' ? MONTH_NAMES_EN : MONTH_NAMES_DE
+
+  return (
+    <div className="max-w-2xl mx-auto py-12 px-4">
+      <h1 className="font-display text-3xl font-bold text-[#1a1714] dark:text-[#faf9f7] mb-2">
+        {t('overviewHeading')}
+      </h1>
+      <p className="text-sand-500 mb-10">{t('overviewDescription')}</p>
+
+      {summaries.length === 0 ? (
+        <p className="text-sand-400">{t('noSummaries')}</p>
+      ) : (
+        <div className="space-y-3">
+          {summaries.map((s) => (
+            <Link
+              key={s.id}
+              href={`/${params.locale}/monthly/${monthSlug(s.year, s.month)}`}
+              className="flex items-center justify-between bg-white dark:bg-[#2d2926] rounded-xl border border-sand-200 dark:border-[#4a4540] px-6 py-4 hover:border-sand-300 dark:hover:border-[#5a5550] hover:shadow-sm transition-all group"
+            >
+              <div>
+                <p className="font-display font-semibold text-[#1a1714] dark:text-[#faf9f7] group-hover:text-nutrition-700 dark:group-hover:text-nutrition-400 transition-colors">
+                  {monthNames[s.month - 1]} {s.year}
+                </p>
+                <p className="text-xs text-sand-400 mt-0.5">
+                  {t('generatedOn', { date: s.generatedAt.toLocaleDateString(params.locale === 'en' ? 'en-GB' : 'de-CH', { day: 'numeric', month: 'long', year: 'numeric' }) })}
+                </p>
+              </div>
+              <span className="text-sand-400 group-hover:text-nutrition-600 transition-colors">→</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/summaries/[id]/edit/page.tsx
+++ b/src/app/admin/summaries/[id]/edit/page.tsx
@@ -1,0 +1,32 @@
+export const dynamic = 'force-dynamic'
+
+import { notFound } from 'next/navigation'
+import { prisma } from '@/lib/db'
+import { SummaryEditForm } from '@/components/admin/SummaryEditForm'
+
+const MONTH_NAMES = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
+
+interface SummaryEditPageProps {
+  params: { id: string }
+}
+
+export default async function SummaryEditPage({ params }: SummaryEditPageProps) {
+  const summary = await prisma.monthSummary.findUnique({ where: { id: params.id } })
+  if (!summary) notFound()
+
+  const monthLabel = `${MONTH_NAMES[summary.month - 1]} ${summary.year}`
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="font-display text-2xl font-bold text-[#1a1714] dark:text-[#faf9f7]">
+          {monthLabel} — Zusammenfassung bearbeiten
+        </h1>
+        <p className="text-xs text-sand-400 mt-1">
+          Generiert am {summary.generatedAt.toLocaleDateString('de-CH', { day: 'numeric', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
+        </p>
+      </div>
+      <SummaryEditForm summary={summary} />
+    </div>
+  )
+}

--- a/src/app/admin/summaries/actions.ts
+++ b/src/app/admin/summaries/actions.ts
@@ -1,0 +1,31 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/db'
+import { generateAndSaveMonthSummary } from '@/lib/month-summary'
+
+export async function generateSummaryAction(year: number, month: number) {
+  await generateAndSaveMonthSummary(year, month)
+  revalidatePath('/admin/summaries')
+  const summary = await prisma.monthSummary.findUnique({ where: { year_month: { year, month } } })
+  if (summary) {
+    redirect(`/admin/summaries/${summary.id}/edit`)
+  }
+}
+
+export async function updateSummaryAction(id: string, contentDe: string, contentEn: string) {
+  await prisma.monthSummary.update({
+    where: { id },
+    data: { contentDe, contentEn },
+  })
+  revalidatePath('/admin/summaries')
+  revalidatePath(`/de/monthly`)
+  revalidatePath(`/en/monthly`)
+}
+
+export async function deleteSummaryAction(id: string) {
+  await prisma.monthSummary.delete({ where: { id } })
+  revalidatePath('/admin/summaries')
+  redirect('/admin/summaries')
+}

--- a/src/app/admin/summaries/page.tsx
+++ b/src/app/admin/summaries/page.tsx
@@ -1,0 +1,86 @@
+export const dynamic = 'force-dynamic'
+
+import Link from 'next/link'
+import { getAllMonthSummaries } from '@/lib/month-summary'
+import { GenerateSummaryForm } from '@/components/admin/GenerateSummaryForm'
+
+const MONTH_NAMES = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
+
+function formatMonth(year: number, month: number): string {
+  return `${MONTH_NAMES[month - 1]} ${year}`
+}
+
+function monthSlug(year: number, month: number): string {
+  return `${year}-${String(month).padStart(2, '0')}`
+}
+
+export default async function SummariesPage() {
+  const summaries = await getAllMonthSummaries()
+
+  const now = new Date()
+  const currentYear = now.getFullYear()
+  const currentMonth = now.getMonth() + 1
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="font-display text-2xl font-bold text-[#1a1714] dark:text-[#faf9f7]">
+          Monats-Zusammenfassungen
+        </h1>
+      </div>
+
+      {/* Generator */}
+      <div className="bg-white dark:bg-[#2d2926] rounded-xl border border-sand-200 dark:border-[#4a4540] p-5 mb-6">
+        <h2 className="font-display text-sm font-semibold text-[#1a1714] dark:text-[#faf9f7] mb-3">
+          Neue Zusammenfassung generieren
+        </h2>
+        <p className="text-xs text-sand-500 mb-4">
+          Claude analysiert alle Einträge und Metriken des gewählten Monats und erstellt einen Rückblick auf Deutsch und Englisch.
+        </p>
+        <GenerateSummaryForm defaultYear={currentYear} defaultMonth={currentMonth} />
+      </div>
+
+      {/* List */}
+      {summaries.length === 0 ? (
+        <div className="text-center py-16 text-sand-400">
+          <p>Noch keine Zusammenfassungen vorhanden.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {summaries.map((s) => (
+            <div
+              key={s.id}
+              className="bg-white dark:bg-[#2d2926] rounded-xl border border-sand-200 dark:border-[#4a4540] px-5 py-4 flex items-center gap-4 hover:border-sand-300 dark:hover:border-[#5a5550] transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="font-display font-semibold text-[#1a1714] dark:text-[#faf9f7] text-sm">
+                  {formatMonth(s.year, s.month)}
+                </p>
+                <p className="text-xs text-sand-400 mt-0.5">
+                  Generiert: {s.generatedAt.toLocaleDateString('de-CH', { day: 'numeric', month: 'short', year: 'numeric' })}
+                  {' · '}
+                  {s.contentEn ? 'DE + EN' : 'Nur DE'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Link
+                  href={`/de/monthly/${monthSlug(s.year, s.month)}`}
+                  target="_blank"
+                  className="text-xs px-3 py-1.5 border border-sand-200 dark:border-[#4a4540] rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-[#5a5550] hover:text-[#1a1714] dark:hover:text-[#faf9f7] transition-colors"
+                >
+                  Ansehen
+                </Link>
+                <Link
+                  href={`/admin/summaries/${s.id}/edit`}
+                  className="text-xs px-3 py-1.5 bg-sand-100 dark:bg-[#3a3531] border border-sand-200 dark:border-[#4a4540] rounded-lg text-[#1a1714] dark:text-[#faf9f7] hover:border-sand-300 dark:hover:border-[#5a5550] transition-colors"
+                >
+                  Bearbeiten
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { href: '/admin', label: 'Dashboard', exact: true },
   { href: '/admin/entries', label: 'Einträge', exact: false },
   { href: '/admin/translations', label: 'Übersetzungen', exact: false },
+  { href: '/admin/summaries', label: 'Zusammenfassungen', exact: false },
   { href: '/admin/analytics', label: 'Analytics', exact: false },
   { href: '/admin/metrics', label: 'Metriken', exact: false },
   { href: '/admin/fitbit', label: 'Fitbit', exact: false },

--- a/src/components/admin/GenerateSummaryForm.tsx
+++ b/src/components/admin/GenerateSummaryForm.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { generateSummaryAction } from '@/app/admin/summaries/actions'
+
+const MONTH_NAMES = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
+
+interface GenerateSummaryFormProps {
+  defaultYear: number
+  defaultMonth: number
+}
+
+export function GenerateSummaryForm({ defaultYear, defaultMonth }: GenerateSummaryFormProps) {
+  const [year, setYear] = useState(defaultYear)
+  const [month, setMonth] = useState(defaultMonth)
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  const currentYear = new Date().getFullYear()
+  const years = Array.from({ length: 3 }, (_, i) => currentYear - i)
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    startTransition(async () => {
+      try {
+        await generateSummaryAction(year, month)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unbekannter Fehler')
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-3">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-sand-500 font-medium">Monat</label>
+        <select
+          value={month}
+          onChange={(e) => setMonth(Number(e.target.value))}
+          disabled={isPending}
+          className="px-3 py-2 text-sm rounded-lg border border-sand-200 dark:border-[#4a4540] bg-white dark:bg-[#1a1714] text-[#1a1714] dark:text-[#faf9f7] focus:outline-none focus:ring-2 focus:ring-nutrition-400"
+        >
+          {MONTH_NAMES.map((name, i) => (
+            <option key={i + 1} value={i + 1}>{name}</option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-sand-500 font-medium">Jahr</label>
+        <select
+          value={year}
+          onChange={(e) => setYear(Number(e.target.value))}
+          disabled={isPending}
+          className="px-3 py-2 text-sm rounded-lg border border-sand-200 dark:border-[#4a4540] bg-white dark:bg-[#1a1714] text-[#1a1714] dark:text-[#faf9f7] focus:outline-none focus:ring-2 focus:ring-nutrition-400"
+        >
+          {years.map((y) => (
+            <option key={y} value={y}>{y}</option>
+          ))}
+        </select>
+      </div>
+      <button
+        type="submit"
+        disabled={isPending}
+        className="px-4 py-2 text-sm font-medium rounded-lg bg-nutrition-600 text-white hover:bg-nutrition-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {isPending ? 'Generiert…' : 'Zusammenfassung generieren'}
+      </button>
+      {error && (
+        <p className="w-full text-xs text-red-600 dark:text-red-400 mt-1">{error}</p>
+      )}
+    </form>
+  )
+}

--- a/src/components/admin/SummaryEditForm.tsx
+++ b/src/components/admin/SummaryEditForm.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { updateSummaryAction, deleteSummaryAction } from '@/app/admin/summaries/actions'
+
+interface SummaryData {
+  id: string
+  year: number
+  month: number
+  contentDe: string
+  contentEn: string | null
+}
+
+interface SummaryEditFormProps {
+  summary: SummaryData
+}
+
+export function SummaryEditForm({ summary }: SummaryEditFormProps) {
+  const [contentDe, setContentDe] = useState(summary.contentDe)
+  const [contentEn, setContentEn] = useState(summary.contentEn ?? '')
+  const [activeTab, setActiveTab] = useState<'de' | 'en'>('de')
+  const [isPending, startTransition] = useTransition()
+  const [isDeleting, startDeleteTransition] = useTransition()
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setSaved(false)
+    startTransition(async () => {
+      try {
+        await updateSummaryAction(summary.id, contentDe, contentEn)
+        setSaved(true)
+        setTimeout(() => setSaved(false), 3000)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Fehler beim Speichern')
+      }
+    })
+  }
+
+  function handleDelete() {
+    if (!confirm('Zusammenfassung wirklich löschen?')) return
+    startDeleteTransition(async () => {
+      await deleteSummaryAction(summary.id)
+    })
+  }
+
+  const monthSlug = `${summary.year}-${String(summary.month).padStart(2, '0')}`
+
+  return (
+    <form onSubmit={handleSave} className="space-y-4">
+      {/* Tabs */}
+      <div className="flex gap-2 border-b border-sand-200 dark:border-[#4a4540]">
+        {(['de', 'en'] as const).map((lang) => (
+          <button
+            key={lang}
+            type="button"
+            onClick={() => setActiveTab(lang)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              activeTab === lang
+                ? 'border-nutrition-600 text-nutrition-700 dark:text-nutrition-400'
+                : 'border-transparent text-sand-500 hover:text-[#1a1714] dark:hover:text-[#faf9f7]'
+            }`}
+          >
+            {lang === 'de' ? 'Deutsch' : 'English'}
+          </button>
+        ))}
+      </div>
+
+      {/* Editor */}
+      <div>
+        {activeTab === 'de' ? (
+          <textarea
+            value={contentDe}
+            onChange={(e) => setContentDe(e.target.value)}
+            rows={24}
+            className="w-full font-mono text-xs px-4 py-3 rounded-xl border border-sand-200 dark:border-[#4a4540] bg-white dark:bg-[#1a1714] text-[#1a1714] dark:text-[#faf9f7] focus:outline-none focus:ring-2 focus:ring-nutrition-400 resize-none"
+            placeholder="HTML-Content auf Deutsch…"
+          />
+        ) : (
+          <textarea
+            value={contentEn}
+            onChange={(e) => setContentEn(e.target.value)}
+            rows={24}
+            className="w-full font-mono text-xs px-4 py-3 rounded-xl border border-sand-200 dark:border-[#4a4540] bg-white dark:bg-[#1a1714] text-[#1a1714] dark:text-[#faf9f7] focus:outline-none focus:ring-2 focus:ring-nutrition-400 resize-none"
+            placeholder="HTML content in English…"
+          />
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between gap-4">
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="text-xs text-red-500 hover:text-red-700 dark:hover:text-red-400 transition-colors disabled:opacity-50"
+        >
+          {isDeleting ? 'Löschen…' : 'Zusammenfassung löschen'}
+        </button>
+
+        <div className="flex items-center gap-3">
+          <a
+            href={`/de/monthly/${monthSlug}`}
+            target="_blank"
+            className="text-xs px-3 py-2 border border-sand-200 dark:border-[#4a4540] rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 hover:text-[#1a1714] dark:hover:text-[#faf9f7] transition-colors"
+          >
+            Vorschau
+          </a>
+          {saved && (
+            <span className="text-xs text-movement-600 dark:text-movement-400">Gespeichert ✓</span>
+          )}
+          {error && (
+            <span className="text-xs text-red-600 dark:text-red-400">{error}</span>
+          )}
+          <button
+            type="submit"
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-nutrition-600 text-white hover:bg-nutrition-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isPending ? 'Speichern…' : 'Speichern'}
+          </button>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/src/lib/month-summary.ts
+++ b/src/lib/month-summary.ts
@@ -1,0 +1,226 @@
+import Anthropic, { APIError } from '@anthropic-ai/sdk'
+import { prisma } from './db'
+import { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+// =============================================
+// Types
+// =============================================
+
+export interface MonthSummaryData {
+  id: string
+  year: number
+  month: number
+  contentDe: string
+  contentEn: string | null
+  generatedAt: Date
+  updatedAt: Date
+}
+
+// =============================================
+// DB Queries
+// =============================================
+
+export async function getMonthSummary(year: number, month: number): Promise<MonthSummaryData | null> {
+  return prisma.monthSummary.findUnique({ where: { year_month: { year, month } } })
+}
+
+export async function getAllMonthSummaries(): Promise<MonthSummaryData[]> {
+  return prisma.monthSummary.findMany({ orderBy: [{ year: 'desc' }, { month: 'desc' }] })
+}
+
+// =============================================
+// Stats helpers
+// =============================================
+
+function habitRate(values: string[], match: string[]): string {
+  const count = values.filter((v) => match.includes(v)).length
+  return values.length === 0 ? '—' : `${Math.round((count / values.length) * 100)} %`
+}
+
+function avg(nums: (number | null)[]): number | null {
+  const valid = nums.filter((n): n is number => n !== null)
+  return valid.length === 0 ? null : valid.reduce((a, b) => a + b, 0) / valid.length
+}
+
+function fmt(n: number | null, decimals = 1, unit = ''): string {
+  if (n === null) return '—'
+  return `${n.toFixed(decimals)}${unit}`
+}
+
+// =============================================
+// Generate summary via Claude API
+// =============================================
+
+const SYSTEM_PROMPT = `Du bist ein einfühlsamer persönlicher Assistent, der monatliche Rückblicke für ein öffentliches Tagebuch-Projekt schreibt.
+
+"Project 365" ist ein öffentliches 365-Tage-Tagebuch. Der Autor dokumentiert täglich seine drei Gewohnheits-Säulen:
+- Bewegung: MINIMAL | STEPS_ONLY (10'000+ Schritte) | STEPS_TRAINED (10'000+ Schritte + Training)
+- Ernährung: NONE | ONE | TWO | THREE (gesunde Mahlzeiten pro Tag)
+- Rauchstopp: SMOKED | REPLACEMENT (Nikotinersatz) | NONE (rauchfrei)
+
+Schreibe einen motivierenden, ehrlichen Monatsrückblick in der Du-Form. Tone: warm, persönlich, ehrlich — kein klinisches Dashboard.
+
+Strukturiere den Text als HTML mit diesen Abschnitten (verwende <h2> für Überschriften):
+1. Highlights & Meilensteine
+2. Die drei Säulen (mit konkreten Zahlen)
+3. Metriken im Überblick (nur wenn Daten vorhanden, sonst weglassen)
+4. Persönliche Reflexion & Ausblick
+
+Regeln:
+- Nur HTML-Body-Content (kein <!DOCTYPE>, kein <html>/<body>)
+- Verwende <p>, <h2>, <ul>, <li>, <strong> — kein Markdown
+- Sprich den Autor direkt mit "Du" an
+- Sei konkret mit den Zahlen aus den Daten
+- Sei motivierend aber realistisch — auch schlechte Monate verdienen ehrliche Worte`
+
+interface EntryContext {
+  date: string
+  title: string
+  excerpt: string
+  movement: MovementLevel
+  nutrition: NutritionLevel
+  smoking: SmokingStatus
+}
+
+interface MetricsContext {
+  avgWeight: number | null
+  avgSteps: number | null
+  avgSleepH: number | null
+  avgRestingHR: number | null
+}
+
+interface SummaryContext {
+  year: number
+  month: number
+  monthName: string
+  entryCount: number
+  entries: EntryContext[]
+  habitStats: {
+    movementGood: string
+    nutritionGood: string
+    smokingClean: string
+    smokingSmoked: string
+  }
+  metrics: MetricsContext
+}
+
+function buildPrompt(ctx: SummaryContext): string {
+  const entriesText = ctx.entries
+    .map((e) => `- ${e.date} "${e.title}" | Bewegung: ${e.movement} | Ernährung: ${e.nutrition} | Rauchen: ${e.smoking}${e.excerpt ? ` | "${e.excerpt}"` : ''}`)
+    .join('\n')
+
+  return `Monat: ${ctx.monthName} ${ctx.year}
+Einträge: ${ctx.entryCount} von ~${new Date(ctx.year, ctx.month, 0).getDate()} Tagen
+
+HABITS-STATISTIK:
+- Bewegung gut (STEPS_ONLY oder STEPS_TRAINED): ${ctx.habitStats.movementGood}
+- Ernährung gut (mind. 2 Mahlzeiten): ${ctx.habitStats.nutritionGood}
+- Rauchfrei (NONE): ${ctx.habitStats.smokingClean}
+- Geraucht (SMOKED): ${ctx.habitStats.smokingSmoked}
+
+METRIKEN (Monatsdurchschnitt):
+- Gewicht: ${fmt(ctx.metrics.avgWeight, 1, ' kg')}
+- Schritte: ${ctx.metrics.avgSteps !== null ? Math.round(ctx.metrics.avgSteps).toLocaleString('de-CH') : '—'}
+- Schlaf: ${ctx.metrics.avgSleepH !== null ? fmt(ctx.metrics.avgSleepH, 1, ' h') : '—'}
+- Ruheherzfrequenz: ${ctx.metrics.avgRestingHR !== null ? Math.round(ctx.metrics.avgRestingHR) + ' bpm' : '—'}
+
+EINTRÄGE DES MONATS:
+${entriesText}
+
+Bitte schreibe den Monatsrückblick auf Deutsch.`
+}
+
+async function translateSummaryToEnglish(deSummary: string): Promise<string> {
+  const message = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 4096,
+    system: `You are a professional German-to-English translator specializing in personal blog content.
+Translate the HTML content from German to English.
+Preserve ALL HTML tags exactly. Only translate the visible text.
+Keep "Du" → "you" (informal, direct address).
+Return ONLY the translated HTML — no extra text, no code fences.`,
+    messages: [{ role: 'user', content: deSummary }],
+  })
+
+  const raw = message.content[0]
+  if (raw.type !== 'text') throw new Error('Unexpected Claude response type')
+  return raw.text.trim()
+}
+
+export async function generateAndSaveMonthSummary(year: number, month: number): Promise<MonthSummaryData> {
+  const start = new Date(year, month - 1, 1)
+  const end = new Date(year, month, 0, 23, 59, 59)
+
+  const [entries, metricsRows] = await Promise.all([
+    prisma.journalEntry.findMany({
+      where: { date: { gte: start, lte: end }, published: true },
+      orderBy: { date: 'asc' },
+      select: { date: true, title: true, excerpt: true, movement: true, nutrition: true, smoking: true },
+    }),
+    prisma.dailyMetrics.findMany({
+      where: { date: { gte: start, lte: end } },
+      select: { weight: true, steps: true, sleepDuration: true, restingHR: true },
+    }),
+  ])
+
+  const movements = entries.map((e) => e.movement)
+  const nutritions = entries.map((e) => e.nutrition)
+  const smokings = entries.map((e) => e.smoking)
+
+  const monthNames = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
+
+  const ctx: SummaryContext = {
+    year,
+    month,
+    monthName: monthNames[month - 1],
+    entryCount: entries.length,
+    entries: entries.map((e) => ({
+      date: e.date.toISOString().slice(0, 10),
+      title: e.title,
+      excerpt: e.excerpt ?? '',
+      movement: e.movement,
+      nutrition: e.nutrition,
+      smoking: e.smoking,
+    })),
+    habitStats: {
+      movementGood: habitRate(movements, [MovementLevel.STEPS_ONLY, MovementLevel.STEPS_TRAINED]),
+      nutritionGood: habitRate(nutritions, [NutritionLevel.TWO, NutritionLevel.THREE]),
+      smokingClean: habitRate(smokings, [SmokingStatus.NONE]),
+      smokingSmoked: habitRate(smokings, [SmokingStatus.SMOKED]),
+    },
+    metrics: {
+      avgWeight: avg(metricsRows.map((m) => m.weight)),
+      avgSteps: avg(metricsRows.map((m) => m.steps)),
+      avgSleepH: avg(metricsRows.map((m) => (m.sleepDuration !== null ? m.sleepDuration / 60 : null))),
+      avgRestingHR: avg(metricsRows.map((m) => m.restingHR)),
+    },
+  }
+
+  try {
+    const deMessage = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: buildPrompt(ctx) }],
+    })
+
+    const raw = deMessage.content[0]
+    if (raw.type !== 'text') throw new Error('Unexpected Claude response type')
+    const contentDe = raw.text.trim()
+
+    const contentEn = await translateSummaryToEnglish(contentDe)
+
+    const saved = await prisma.monthSummary.upsert({
+      where: { year_month: { year, month } },
+      create: { year, month, contentDe, contentEn, generatedAt: new Date() },
+      update: { contentDe, contentEn, generatedAt: new Date() },
+    })
+
+    return saved
+  } catch (e) {
+    if (e instanceof APIError) throw new Error(e.message)
+    throw e
+  }
+}


### PR DESCRIPTION
## Summary

- **`MonthSummary` DB-Model**: year, month, contentDe, contentEn, generatedAt
- **`lib/month-summary.ts`**: lädt alle Einträge + Metriken des Monats, berechnet Habit-Statistiken, ruft Claude API für DE-Zusammenfassung + EN-Übersetzung auf, upsert in DB
- **Admin `/admin/summaries`**: Übersicht aller Zusammenfassungen + Generier-Formular (Monat/Jahr Dropdown)
- **Admin `/admin/summaries/[id]/edit`**: Tab-Editor für DE/EN HTML, Vorschau-Link, Löschen
- **Öffentlich `/[locale]/monthly`**: Übersicht aller publizierten Zusammenfassungen
- **Öffentlich `/[locale]/monthly/2026-03`**: Einzelne Zusammenfassung, Locale-aware (DE/EN)
- **AdminNav**: "Zusammenfassungen" hinzugefügt
- **i18n**: `MonthlySummary`-Namespace in `de.json` + `en.json`

## Test plan

- [ ] Admin → Zusammenfassungen → Monat/Jahr wählen → "Generieren" klicken
- [ ] Redirect auf Edit-Seite nach Generierung prüfen
- [ ] DE und EN Tabs in Edit-Seite prüfen
- [ ] Speichern und Vorschau unter `/de/monthly/2026-03` prüfen
- [ ] `/en/monthly/2026-03` → EN-Content angezeigt
- [ ] Übersichtsseite `/de/monthly` listet alle Zusammenfassungen
- [ ] Löschen funktioniert + Redirect zurück zur Übersicht
- [ ] CI: `prisma migrate deploy` mit neuem Migration-File testen

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)