### PR TITLE
feat: AI-generated banner images for journal entries

### DIFF
--- a/src/app/api/admin/generate-banner/route.ts
+++ b/src/app/api/admin/generate-banner/route.ts
@@ -1,0 +1,41 @@
+import { writeFile, mkdir } from 'fs/promises'
+import path from 'path'
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { generateBannerSvg } from '@/lib/banner-generate'
+
+export async function POST(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) {
+    return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 })
+  }
+
+  let body: { title?: string; excerpt?: string; slug?: string }
+  try {
+    body = (await request.json()) as { title?: string; excerpt?: string; slug?: string }
+  } catch {
+    return NextResponse.json({ error: 'Ungültige Anfrage' }, { status: 400 })
+  }
+
+  const { title, excerpt, slug } = body
+
+  if (!title?.trim()) {
+    return NextResponse.json({ error: 'Titel fehlt — bitte zuerst einen Titel eingeben' }, { status: 400 })
+  }
+
+  try {
+    const svg = await generateBannerSvg(title.trim(), excerpt?.trim() ?? '')
+
+    const rawSlug = (slug ?? '').replace(/[^a-z0-9_-]/gi, '-').slice(0, 100)
+    const filename = `${rawSlug || Date.now()}-ai.svg`
+
+    const uploadDir = path.join(process.cwd(), 'public', 'images', 'journal')
+    await mkdir(uploadDir, { recursive: true })
+    await writeFile(path.join(uploadDir, filename), svg, 'utf-8')
+
+    return NextResponse.json({ url: `/images/journal/${filename}` })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Unbekannter Fehler'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/components/admin/BannerUpload.tsx
+++ b/src/components/admin/BannerUpload.tsx
@@ -6,12 +6,17 @@ interface BannerUploadProps {
   value: string | undefined
   onChange: (url: string | undefined) => void
   slug: string
+  title?: string
+  excerpt?: string
 }
 
-export function BannerUpload({ value, onChange, slug }: BannerUploadProps) {
+export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
+  const [generating, setGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  const busy = uploading || generating
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
@@ -42,8 +47,33 @@ export function BannerUpload({ value, onChange, slug }: BannerUploadProps) {
       setError('Upload fehlgeschlagen')
     } finally {
       setUploading(false)
-      // Input zurücksetzen damit dasselbe Bild nochmal hochgeladen werden kann
       if (inputRef.current) inputRef.current.value = ''
+    }
+  }
+
+  async function handleGenerate() {
+    setError(null)
+    setGenerating(true)
+
+    try {
+      const res = await fetch('/api/admin/generate-banner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, excerpt, slug }),
+      })
+
+      const data = (await res.json()) as { url?: string; error?: string }
+
+      if (!res.ok || !data.url) {
+        setError(data.error ?? 'Generierung fehlgeschlagen')
+        return
+      }
+
+      onChange(data.url)
+    } catch {
+      setError('Generierung fehlgeschlagen')
+    } finally {
+      setGenerating(false)
     }
   }
 
@@ -67,8 +97,16 @@ export function BannerUpload({ value, onChange, slug }: BannerUploadProps) {
           <div className="absolute bottom-3 right-3 flex gap-2">
             <button
               type="button"
+              onClick={handleGenerate}
+              disabled={busy}
+              className="px-3 py-1.5 bg-white/90 dark:bg-ctp-base/90 backdrop-blur-sm border border-ctp-surface1 rounded-lg text-xs font-medium text-ctp-mauve hover:bg-white dark:hover:bg-ctp-base transition-colors shadow-sm disabled:opacity-50"
+            >
+              {generating ? 'Generiert...' : 'AI neu'}
+            </button>
+            <button
+              type="button"
               onClick={() => inputRef.current?.click()}
-              disabled={uploading}
+              disabled={busy}
               className="px-3 py-1.5 bg-white/90 dark:bg-ctp-base/90 backdrop-blur-sm border border-ctp-surface1 rounded-lg text-xs font-medium text-ctp-text hover:bg-white dark:hover:bg-ctp-base transition-colors shadow-sm disabled:opacity-50"
             >
               {uploading ? 'Lädt...' : 'Ersetzen'}
@@ -76,42 +114,85 @@ export function BannerUpload({ value, onChange, slug }: BannerUploadProps) {
             <button
               type="button"
               onClick={() => onChange(undefined)}
-              className="px-3 py-1.5 bg-white/90 dark:bg-ctp-base/90 backdrop-blur-sm border border-red-200 dark:border-red-800/40 rounded-lg text-xs font-medium text-red-600 dark:text-red-400 hover:bg-white dark:hover:bg-ctp-base transition-colors shadow-sm"
+              disabled={busy}
+              className="px-3 py-1.5 bg-white/90 dark:bg-ctp-base/90 backdrop-blur-sm border border-red-200 dark:border-red-800/40 rounded-lg text-xs font-medium text-red-600 dark:text-red-400 hover:bg-white dark:hover:bg-ctp-base transition-colors shadow-sm disabled:opacity-50"
             >
               Entfernen
             </button>
           </div>
         </div>
       ) : (
-        /* Upload-Zone */
-        <button
-          type="button"
-          onClick={() => inputRef.current?.click()}
-          disabled={uploading}
-          className="w-full flex flex-col items-center justify-center gap-2 border-2 border-dashed border-ctp-surface1 rounded-xl bg-ctp-base hover:bg-sand-100 dark:hover:bg-ctp-surface0 hover:border-sand-300 dark:hover:border-ctp-overlay2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          style={{ aspectRatio: '16/7' }}
-        >
-          {uploading ? (
-            <span className="text-sm text-sand-400">Hochladen...</span>
-          ) : (
-            <>
-              <svg
-                className="w-8 h-8 text-sand-300"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={1.5}
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-                />
-              </svg>
-              <span className="text-sm text-sand-400 font-medium">Bild auswählen</span>
-            </>
-          )}
-        </button>
+        /* Upload-Zone + AI-Generierung */
+        <div className="flex gap-3" style={{ aspectRatio: '16/7' }}>
+          {/* Manueller Upload */}
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            disabled={busy}
+            className="flex-1 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-ctp-surface1 rounded-xl bg-ctp-base hover:bg-sand-100 dark:hover:bg-ctp-surface0 hover:border-sand-300 dark:hover:border-ctp-overlay2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {uploading ? (
+              <span className="text-sm text-sand-400">Hochladen...</span>
+            ) : (
+              <>
+                <svg
+                  className="w-8 h-8 text-sand-300"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                  />
+                </svg>
+                <span className="text-sm text-sand-400 font-medium">Bild hochladen</span>
+              </>
+            )}
+          </button>
+
+          {/* AI-Generierung */}
+          <button
+            type="button"
+            onClick={handleGenerate}
+            disabled={busy}
+            className="flex-1 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-ctp-mauve/40 rounded-xl bg-ctp-base hover:bg-ctp-mauve/5 hover:border-ctp-mauve/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {generating ? (
+              <>
+                <svg
+                  className="w-8 h-8 text-ctp-mauve animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                <span className="text-sm text-ctp-mauve font-medium">Wird generiert...</span>
+              </>
+            ) : (
+              <>
+                <svg
+                  className="w-8 h-8 text-ctp-mauve/60"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+                  />
+                </svg>
+                <span className="text-sm text-ctp-mauve/80 font-medium">AI generieren</span>
+                <span className="text-xs text-sand-400">aus Titel &amp; Inhalt</span>
+              </>
+            )}
+          </button>
+        </div>
       )}
 
       {error && (

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -226,7 +226,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
       </div>
 
       {/* Banner-Bild */}
-      <BannerUpload value={bannerUrl} onChange={setBannerUrl} slug={slug} />
+      <BannerUpload value={bannerUrl} onChange={setBannerUrl} slug={slug} title={title} excerpt={excerpt} />
 
       {/* Tiptap Editor */}
       <div>

--- a/src/lib/banner-generate.ts
+++ b/src/lib/banner-generate.ts
@@ -1,0 +1,60 @@
+import Anthropic, { APIError } from '@anthropic-ai/sdk'
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+const SYSTEM_PROMPT = `You are a creative SVG designer specializing in abstract, minimalist banner artwork for a personal journal website.
+
+Your task: Generate a beautiful abstract SVG banner (1200×420px viewBox) based on the given journal entry.
+
+STYLE RULES (follow strictly for visual consistency across all banners):
+- Abstract geometric composition: overlapping circles, ellipses, flowing curves, soft polygons
+- Catppuccin Mocha color palette only:
+  Background: #1e1e2e
+  Accent colors: #cba6f7 (mauve), #89b4fa (blue), #a6e3a1 (green), #f38ba8 (red), #fab387 (peach), #f9e2af (yellow), #94e2d5 (teal), #89dceb (sky)
+  Surface colors: #313244, #45475a, #585b70
+- Use 4–7 overlapping shapes with opacity between 0.15 and 0.55
+- Always include a subtle radial or linear gradient overlay on the background
+- Use <defs> with gradients and optionally a blur filter (feGaussianBlur, stdDeviation 20–60)
+- No text, no icons, no recognizable real-world objects — purely abstract
+
+CONTENT MAPPING:
+- Movement/sport/exercise/training → green (#a6e3a1), teal (#94e2d5), angular or dynamic shapes
+- Nutrition/food/eating → peach (#fab387), yellow (#f9e2af), rounded organic shapes
+- Reflection/introspection/calm → mauve (#cba6f7), blue (#89b4fa), smooth large circles
+- Challenges/difficulty/struggle → red (#f38ba8), sharp contrasts, fragmented shapes
+- Nature/outdoors → green + teal, flowing curves
+- Default → mauve + blue, balanced composition
+
+OUTPUT: Return ONLY valid SVG markup. Start with <svg and end with </svg>. No other text, no markdown, no code fences.`
+
+export async function generateBannerSvg(title: string, excerpt: string): Promise<string> {
+  const userMessage = `Generate an abstract banner SVG for this journal entry:
+
+Title: ${title}
+Excerpt: ${excerpt || '(none)'}
+
+Return only the SVG markup.`
+
+  try {
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userMessage }],
+    })
+
+    const raw = message.content[0]
+    if (raw.type !== 'text') throw new Error('Unerwarteter Antworttyp von Claude')
+
+    const svg = raw.text.replace(/^```(?:svg)?\n?/, '').replace(/\n?```$/, '').trim()
+
+    if (!svg.startsWith('<svg') || !svg.includes('</svg>')) {
+      throw new Error('Claude hat kein gültiges SVG zurückgegeben')
+    }
+
+    return svg
+  } catch (e) {
+    if (e instanceof APIError) throw new Error(e.message)
+    throw e
+  }
+}


### PR DESCRIPTION
Closes #123

## Summary

- Neuer Button „AI generieren" im Admin-Editor neben dem manuellen Banner-Upload
- Claude API analysiert Titel und Kurzbeschreibung des Eintrags und generiert ein abstraktes SVG-Banner
- Konsistenter visueller Stil durch fixen System-Prompt mit Catppuccin Mocha-Farbpalette und geometrisch-abstrakten Formen
- Generiertes SVG wird unter `public/images/journal/<slug>-ai.svg` gespeichert und sofort als Vorschau gesetzt
- Bei bestehendem Banner: zusätzlicher „AI neu"-Button neben Ersetzen/Entfernen

## Änderungen

| Datei | Art |
|---|---|
| `src/lib/banner-generate.ts` | Neu — Claude API Logik für SVG-Generierung |
| `src/app/api/admin/generate-banner/route.ts` | Neu — Admin-geschützter API-Endpoint |
| `src/components/admin/BannerUpload.tsx` | Geändert — Zweispalten-Leerstate + AI-Button im Preview |
| `src/components/admin/EntryForm.tsx` | Geändert — `title`/`excerpt` Props weitergegeben |

## Test plan

- [ ] Admin-Editor öffnen, Titel eingeben, „AI generieren" klicken → Loading-Animation erscheint
- [ ] Nach Generierung: SVG-Banner wird als Vorschau angezeigt (16:7 Verhältnis)
- [ ] Eintrag speichern → `bannerUrl` zeigt auf `/images/journal/<slug>-ai.svg`
- [ ] Banner erscheint im Frontend korrekt
- [ ] „AI neu" klicken bei bestehendem Banner → neues SVG ersetzt das alte
- [ ] „Entfernen" → Banner wird geleert
- [ ] Ohne Titel auf „AI generieren" → Fehlermeldung „Titel fehlt"
- [ ] API-Fehler wird korrekt in der UI angezeigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)