### PR TITLE
feat: dark-only Kinetic Lab color system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 - PostgreSQL + Prisma ORM
 - NextAuth.js (Google OAuth, Single-Admin)
 - Tiptap Rich-Text Editor
-- next-intl (i18n: DE, EN — Phase 5c erweitert um PT, FR, IT, ES)
+- next-intl (i18n: DE, EN, PT, FR, IT, ES)
 - Docker Compose (Production)
 - Recharts (Visualisierungen)
 - Claude API (AI-Übersetzungen, Monats-Zusammenfassungen)
@@ -42,7 +42,7 @@ Journal-Einträge werden in PostgreSQL gespeichert (JournalEntry Model), nicht a
 
 - `MINIMAL` — Unter 10k Schritte, kein Training ❌
 - `STEPS_ONLY` — 10k+ Schritte, kein Training ✅
-- `TRAINED_ONLY` — Training absolviert, unter 10k Schritte ✅ _(NEU in Phase 5a)_
+- `TRAINED_ONLY` — Training absolviert, unter 10k Schritte ✅
 - `STEPS_TRAINED` — 10k+ Schritte + Training ✅
 
 **Ernährung** (NutritionLevel Enum):
@@ -58,12 +58,57 @@ Journal-Einträge werden in PostgreSQL gespeichert (JournalEntry Model), nicht a
 - `NICOTINE_REPLACEMENT` — Nikotinersatz ✅ (Minimum für Zielerfüllung)
 - `SMOKE_FREE` — Rauchfrei ohne Hilfsmittel ✅
 
-### Design-System: Catppuccin (ab Phase 5b)
+### Design-System: "Kinetic Lab" (ab Phase 6)
 
-- Light Mode: Catppuccin **Latte**
-- Dark Mode: Catppuccin **Mocha**
-- Referenz: https://catppuccin.com/palette
-- npm: @catppuccin/palette
+**Nur Dark Mode** — kein Light/Dark Toggle.
+
+#### Farbpalette
+
+- Background: `#0e0e0e`
+- Surface-Container-Lowest: `#000000`
+- Surface-Container-Low: `#131313`
+- Surface-Container: `#1a1919`
+- Surface-Container-High: `#201f1f`
+- Surface-Container-Highest: `#262626`
+- Surface-Variant: `#262626`
+- Surface-Bright: `#2c2c2c`
+- Primary: `#ff8f70` (warmes Orange)
+- Primary-Container: `#ff7852`
+- Primary-Dim: `#ff734c`
+- Secondary: `#fc7c7c`
+- Tertiary: `#eaa5ff`
+- Error: `#ff716c`
+- On-Surface: `#ffffff`
+- On-Surface-Variant: `#adaaaa`
+- Outline: `#767575`
+- Outline-Variant: `#484847`
+
+#### Typografie
+
+- Headline Font: **Space Grotesk** (300–700) — `font-headline`
+- Body/Label Font: **Manrope** (300–800) — `font-body`, `font-label`
+- Headlines: `font-headline font-bold tracking-tighter`
+- Body: `font-body leading-relaxed`
+- Labels/Badges: `font-label font-bold tracking-widest uppercase`
+
+#### Icons
+
+- **Google Material Symbols** (Outlined, variable)
+- Variable Font Settings: `font-variation-settings: 'FILL' 0|1`
+
+#### Border-Radius
+
+- Default: `0.125rem` (2px)
+- lg: `0.25rem` (4px)
+- xl: `0.5rem` (8px)
+- full: `0.75rem` (12px)
+
+#### Glassmorphism
+
+- Backdrop-Blur: `backdrop-blur-xl`
+- Semi-transparente Hintergründe: `bg-surface-variant/40`
+- Subtile Borders: `border border-outline-variant/15`
+- Card-Hover: `hover:bg-surface-variant/60 transition-colors`
 
 ## Schema-Details (wichtig!)
 
@@ -105,7 +150,7 @@ project365blog/
 │   ├── journal/           → Feed & Posts
 │   └── reactions/         → Emoji-Reactions
 ├── src/lib/               → Business-Logik
-├── messages/              → i18n Message Files (de.json, en.json)
+├── messages/              → i18n Message Files (de.json, en.json, ...)
 ├── content/journal/       → Legacy MDX (nicht mehr aktiv genutzt)
 ├── public/images/journal/ → Banner-Bilder
 ├── scripts/               → Utility Scripts
@@ -142,13 +187,13 @@ project365blog/
 - iOS App (Lifetime), POSTing an `/api/health-import`
 - Bearer Token Auth funktioniert (200 OK)
 - ⚠️ `daysProcessed: 0` — Parser `parseHealthPayload()` matcht nicht mit v2 Export-Format
-- Fix blockiert durch ausstehendes HomeLab Deployment
+- Fix ausstehend
 
 ### Infrastruktur
 
 - Nginx Proxy Manager: Container `nginxproxy`, DNS fix applied (`dns: 192.168.1.11`)
 - App Container: `app-web-1`, Compose Dir: `/container/project365blog/app`
-- ⚠️ HomeLab Deployment noch ausstehend
+- HomeLab Deployment: ✅ abgeschlossen
 
 ## Abgeschlossene Phasen
 
@@ -172,40 +217,55 @@ next-intl Setup (/de, /en), UI-Übersetzungen, Sprachumschalter, AI-Übersetzung
 
 i18n-Lücken geschlossen, statische Werte (Grösse/Ziele), GitHub-style Contribution Grid, Live-Vorschau im Editor, PostgreSQL Backup-Strategie, Admin-Analytics (Privacy-first), AI-Monats-Zusammenfassungen
 
-## Aktuelle Phase: Phase 5
+### Phase 5 — Bugfixing, Aufräumen & HomeLab Deployment ✅
 
-### Phase 5a — Bugfixing & Aufräumen
+Phase 5a: Bugfixing (Banner-Bild, HTML-Tag, Drop-Cap, Säulen-Logik mit TRAINED_ONLY, Security Review, Deploy-Webhook, Admin-Link, Excerpt-Feld, Favicon)
+Phase 5b: UI/UX Redesign (Catppuccin → wird in Phase 6 durch Kinetic Lab ersetzt)
+Phase 5c: Neue Funktionen (Starttag-Einstellung, Emoji-Reactions im Feed, zusätzliche Sprachen PT/FR/IT/ES)
+HomeLab Deployment abgeschlossen
 
-1. Banner-Bild wird im Feed nicht angezeigt (Bug)
-2. HTML-Tag `<br/>` im Startseiten-Titel (Bug)
-3. Drop-Cap (übergrosse Anfangsbuchstaben) entfernen (Bug)
-4. Säulen-Logik für Zielerfüllung anpassen (neue Stufe `TRAINED_ONLY`, Schwellen ändern)
-5. Security Review + Massnahmen
-6. Deploy-Webhook in GitHub Actions
-7. Admin → Startseite Link
-8. Excerpt-Feld klären/dokumentieren
-9. Favicon mit AI generieren
+## Aktuelle Phase: Phase 6 — "Kinetic Lab" Redesign
 
-### Phase 5b — UI/UX Redesign (Catppuccin)
+Komplettes visuelles Redesign: Dark-Only, warmes Orange, Space Grotesk + Manrope, Material Symbols, Bento-Grid Dashboard, Glassmorphism-Effekte.
 
-1. Catppuccin Design-System als Tailwind-Theme (Latte/Mocha)
-2. Public-Bereich Startseite neu strukturieren (Hero + Tabs/Sections)
-3. Admin-Bereich Navigation überarbeiten (Sidebar statt überladene Top-Nav)
-4. Projektbeschreibung auf Startseite für Besucher
+### Phase 6a — Design Foundation
 
-### Phase 5c — Neue Funktionen
+| #   | Issue                                             | Status  |
+| --- | ------------------------------------------------- | ------- |
+| 125 | Dark-Only Farbsystem und Tailwind-Theme umstellen | ⬜ Open |
+| 126 | Typografie-System (Space Grotesk + Manrope)       | ⬜ Open |
+| 127 | Material Symbols als Icon-Set integrieren         | ⬜ Open |
+| 128 | Border-Radius und Glassmorphism Design-Tokens     | ⬜ Open |
 
-1. Starttag in Admin-Einstellungen definierbar
-2. Emoji-Reactions in Journal-Übersichtsseite (Feed)
-3. Zusätzliche Sprachen (PT, FR, IT, ES) — UI + AI-Übersetzung, Admin bleibt DE
+### Phase 6b — Seitenstruktur & Komponenten
 
-## Backlog (Phase 6+)
+| #   | Issue                                                 | Status  |
+| --- | ----------------------------------------------------- | ------- |
+| 129 | Navigation im Kinetic-Stil redesignen                 | ⬜ Open |
+| 130 | Hero-Section mit Hintergrundbild und CTA              | ⬜ Open |
+| 131 | Live Status Section — Habits & Metriken im Bento-Grid | ⬜ Open |
+| 132 | Daily Journals Section auf Startseite redesignen      | ⬜ Open |
+| 133 | Footer im neuen Design-Stil                           | ⬜ Open |
 
-- Vierte Säule / Spenden-Indikator (Betterplace)
-- Social Media Strategie
+### Phase 6c — Neue Seiten & Inhalte
+
+| #   | Issue                                                       | Status  |
+| --- | ----------------------------------------------------------- | ------- |
+| 134 | "Über das Projekt" Seite (21-Tage-Wanderung, Spendenaktion) | ⬜ Open |
+| 135 | Journal-Einzelansicht im neuen Stil                         | ⬜ Open |
+| 136 | Journal-Übersichtsseite im neuen Stil                       | ⬜ Open |
+
+### Empfohlene Reihenfolge
+
+1. #125 Farbsystem → 2. #126 Typografie → 3. #127 Icons + #128 Glassmorphism → 4. #129 Navigation → 5. #130 Hero → 6. #131 Live Status → 7. #132 Journals → 8. #133 Footer → 9. #135 Einzelansicht → 10. #136 Übersicht → 11. #134 Über-Seite
+
+## Backlog (Phase 7+)
+
+- AI-generierte Banner-Bilder für Journal-Einträge (konsistenter Stil, angepasst an Inhalt)
 - Live Location Map (OwnTracks)
+- Betterplace Spendensäule / Widget
 - Komoot Routen-Anzeige
-- Apple Health Parser Fix (nach HomeLab Deployment)
+- Apple Health Parser Fix (`parseHealthPayload()` v2 Format)
 
 ## Bekannte Bugs (nicht in Issues)
 

--- a/scripts/migrate-colors.mjs
+++ b/scripts/migrate-colors.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Kinetic Lab color migration script
+ * Replaces Catppuccin ctp-* and sand-* tokens with new Kinetic Lab tokens.
+ * Also strips dark: prefixes (keeping the dark-variant value).
+ */
+
+import { readFileSync, writeFileSync } from 'fs'
+import { globSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+
+// Files to process
+const files = [
+  ...globSync('src/**/*.{tsx,ts,css}', { cwd: ROOT }),
+].filter(f =>
+  !f.includes('node_modules') &&
+  !f.includes('migrate-colors') &&
+  f !== 'src/styles/globals.css' &&          // already done
+  f !== 'src/app/layout.tsx' &&              // already done
+  f !== 'src/components/providers/ThemeProvider.tsx' // already done
+)
+
+// ─────────────────────────────────────────────────────────────────
+// Token replacement map (ordered — longest first to avoid partial matches)
+// ─────────────────────────────────────────────────────────────────
+const TOKEN_MAP = [
+  // ctp-surface hierarchy (order matters: surface2 before surface1 before surface0)
+  ['ctp-surface2',      'surface-container-highest'],
+  ['ctp-surface1',      'surface-container-high'],
+  ['ctp-surface0',      'surface-container'],
+  // ctp backgrounds
+  ['ctp-crust',         'surface-container-lowest'],
+  ['ctp-mantle',        'surface-container-low'],
+  ['ctp-base',          'surface-container'],
+  // ctp text / subtext / overlay
+  ['ctp-subtext1',      'on-surface-variant'],
+  ['ctp-subtext0',      'on-surface-variant'],
+  ['ctp-overlay2',      'on-surface-variant'],
+  ['ctp-overlay1',      'on-surface-variant'],
+  ['ctp-overlay0',      'on-surface-variant'],
+  ['ctp-text',          'on-surface'],
+  // ctp accent colors
+  ['ctp-rosewater',     'primary'],
+  ['ctp-flamingo',      'secondary'],
+  ['ctp-pink',          'tertiary'],
+  ['ctp-mauve',         'tertiary'],
+  ['ctp-red',           'error'],
+  ['ctp-maroon',        'secondary'],
+  ['ctp-peach',         'primary'],
+  ['ctp-yellow',        'primary'],
+  ['ctp-green',         'on-surface'],
+  ['ctp-teal',          'tertiary'],
+  ['ctp-sky',           'tertiary'],
+  ['ctp-sapphire',      'secondary'],
+  ['ctp-blue',          'secondary'],
+  ['ctp-lavender',      'tertiary'],
+  // sand scale
+  ['sand-50',           'background'],
+  ['sand-100',          'surface-container'],
+  ['sand-200',          'surface-container-high'],
+  ['sand-300',          'outline'],
+  ['sand-400',          'on-surface-variant'],
+  ['sand-500',          'on-surface-variant'],
+  ['sand-600',          'on-surface-variant'],
+]
+
+// Nutrition/Smoking/Movement dark: adjustments
+// dark:bg-movement-600/10 → bg-movement-600/10
+// dark:text-movement-400  → text-movement-400
+// We handle these via the dark: stripping pass below.
+
+function migrateContent(content) {
+  let out = content
+
+  // ── Step 1: Handle "X dark:Y" pairs → keep only Y (without dark:) ──
+  // Pattern: a Tailwind class followed by space and dark: variant of same utility type
+  // e.g. "bg-sand-50/95 dark:bg-ctp-mantle/95" → "bg-ctp-mantle/95" (then token-replaced later)
+  // e.g. "text-nutrition-600 dark:text-nutrition-500" → "text-nutrition-500"
+  // e.g. "hover:text-nutrition-700 dark:hover:text-nutrition-400" → "hover:text-nutrition-400"
+  //
+  // Strategy: strip the light variant when a dark: variant follows it
+  out = out.replace(
+    /(?:hover:|focus:|group-hover:|disabled:)?[\w-]+(?:\/[\d.]+)?\s+dark:(?:(hover:|focus:|group-hover:|disabled:)?[\w-]+(?:\/[\d.]+)?)/g,
+    (match) => {
+      // Extract dark: part and remove the "dark:" prefix
+      const darkIdx = match.indexOf(' dark:')
+      if (darkIdx === -1) return match
+      return match.slice(darkIdx + 6) // " dark:X" → "X"
+    }
+  )
+
+  // ── Step 2: Remove remaining standalone dark: prefixes ──
+  out = out.replace(/\bdark:/g, '')
+
+  // ── Step 3: Token name replacements ──
+  for (const [from, to] of TOKEN_MAP) {
+    // Replace as part of Tailwind class token (after bg-, text-, border-, etc.)
+    // Using word boundary awareness via negative lookbehind/lookahead
+    out = out.split(from).join(to)
+  }
+
+  return out
+}
+
+let changed = 0
+for (const rel of files) {
+  const abs = path.join(ROOT, rel)
+  let original
+  try {
+    original = readFileSync(abs, 'utf8')
+  } catch {
+    continue
+  }
+  const migrated = migrateContent(original)
+  if (migrated !== original) {
+    writeFileSync(abs, migrated, 'utf8')
+    console.log(`  ✓ ${rel}`)
+    changed++
+  }
+}
+
+console.log(`\nDone — ${changed} files updated.`)

--- a/scripts/migrate-colors.py
+++ b/scripts/migrate-colors.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Kinetic Lab color migration script v2.
+Safe approach:
+  1. Remove dark: prefix from all Tailwind utility classes (promotes dark variants)
+  2. Replace ctp-* and sand-* token names with new Kinetic Lab tokens
+
+Does NOT try to remove "light-mode duplicates" — that would require parsing JSX.
+Both old and new-promoted class may co-exist on elements; CSS cascade resolves order.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SKIP_FILES = {
+    'src/styles/globals.css',
+    'src/app/layout.tsx',
+    'src/components/providers/ThemeProvider.tsx',
+    'src/components/layout/Navigation.tsx',
+    'src/components/layout/ThemeToggle.tsx',
+    'scripts/migrate-colors.py',
+    'scripts/migrate-colors.mjs',
+    'tailwind.config.ts',
+}
+
+def find_files():
+    result = []
+    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, 'src')):
+        dirnames[:] = [d for d in dirnames if d not in ('node_modules', '.next', '__pycache__')]
+        for f in filenames:
+            if f.endswith(('.tsx', '.ts', '.css')):
+                rel = os.path.relpath(os.path.join(dirpath, f), ROOT)
+                if rel not in SKIP_FILES:
+                    result.append(rel)
+    return result
+
+# Token replacement map (most specific first to avoid partial substring matches)
+TOKEN_MAP = [
+    # ctp-surface hierarchy (longest first)
+    ('ctp-surface2',    'surface-container-highest'),
+    ('ctp-surface1',    'surface-container-high'),
+    ('ctp-surface0',    'surface-container'),
+    # ctp backgrounds
+    ('ctp-crust',       'surface-container-lowest'),
+    ('ctp-mantle',      'surface-container-low'),
+    ('ctp-base',        'surface-container'),
+    # ctp text / subtext / overlay (all → on-surface-variant except text)
+    ('ctp-subtext1',    'on-surface-variant'),
+    ('ctp-subtext0',    'on-surface-variant'),
+    ('ctp-overlay2',    'on-surface-variant'),
+    ('ctp-overlay1',    'on-surface-variant'),
+    ('ctp-overlay0',    'on-surface-variant'),
+    ('ctp-text',        'on-surface'),
+    # ctp accent colors
+    ('ctp-rosewater',   'primary'),
+    ('ctp-flamingo',    'secondary'),
+    ('ctp-pink',        'tertiary'),
+    ('ctp-mauve',       'tertiary'),
+    ('ctp-red',         'error'),
+    ('ctp-maroon',      'secondary'),
+    ('ctp-peach',       'primary'),
+    ('ctp-yellow',      'primary'),
+    ('ctp-green',       'on-surface'),
+    ('ctp-teal',        'tertiary'),
+    ('ctp-sky',         'tertiary'),
+    ('ctp-sapphire',    'secondary'),
+    ('ctp-blue',        'secondary'),
+    ('ctp-lavender',    'tertiary'),
+    # sand scale (longest first to avoid sand-50 matching sand-500)
+    ('sand-600',        'on-surface-variant'),
+    ('sand-500',        'on-surface-variant'),
+    ('sand-400',        'on-surface-variant'),
+    ('sand-300',        'outline'),
+    ('sand-200',        'surface-container-high'),
+    ('sand-100',        'surface-container'),
+    ('sand-50',         'background'),
+]
+
+# Remove "dark:" prefix (keeps the class value, promotes it to unconditional)
+# Safe: only matches the literal string "dark:" not inside strings
+DARK_RE = re.compile(r'\bdark:')
+
+def migrate(content):
+    # Step 1: Strip dark: prefix everywhere (safe simple replacement)
+    content = DARK_RE.sub('', content)
+
+    # Step 2: Replace token names (simple string replacement, most-specific first)
+    for old, new in TOKEN_MAP:
+        content = content.replace(old, new)
+
+    return content
+
+def main():
+    files = find_files()
+    changed = 0
+    for rel in sorted(files):
+        abs_path = os.path.join(ROOT, rel)
+        try:
+            with open(abs_path, 'r', encoding='utf-8') as f:
+                original = f.read()
+        except Exception as e:
+            print(f'  ! Could not read {rel}: {e}', file=sys.stderr)
+            continue
+
+        migrated = migrate(original)
+        if migrated != original:
+            with open(abs_path, 'w', encoding='utf-8') as f:
+                f.write(migrated)
+            print(f'  ✓ {rel}')
+            changed += 1
+
+    print(f'\nDone — {changed} files updated.')
+
+if __name__ == '__main__':
+    main()

--- a/src/app/[locale]/journal/[slug]/loading.tsx
+++ b/src/app/[locale]/journal/[slug]/loading.tsx
@@ -27,7 +27,7 @@ export default function Loading() {
           <Skeleton key={i} className="h-4" style={{ width: `${w}%` }} />
         ))}
       </div>
-      <div className="mt-12 pt-8 border-t border-ctp-surface0 space-y-3">
+      <div className="mt-12 pt-8 border-t border-surface-container space-y-3">
         <Skeleton className="h-3 w-20" />
         <div className="flex gap-2">
           {[0, 1, 2, 3, 4].map((i) => (

--- a/src/app/[locale]/loading.tsx
+++ b/src/app/[locale]/loading.tsx
@@ -13,9 +13,9 @@ export default function Loading() {
           {[0, 1, 2].map((i) => (
             <div
               key={i}
-              className="rounded-2xl border border-ctp-surface1 overflow-hidden"
+              className="rounded-2xl border border-surface-container-high overflow-hidden"
             >
-              <div className="h-1 bg-ctp-surface0" />
+              <div className="h-1 bg-surface-container" />
               <div className="p-5 space-y-5">
                 <Skeleton className="h-4 w-24" />
                 <div className="space-y-2">
@@ -40,14 +40,14 @@ export default function Loading() {
       <section>
         <Skeleton className="h-6 w-24 mb-5" />
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <div className="sm:col-span-2 rounded-2xl border border-ctp-surface1 p-5">
+          <div className="sm:col-span-2 rounded-2xl border border-surface-container-high p-5">
             <div className="flex justify-between mb-4">
               <Skeleton className="h-4 w-16" />
               <Skeleton className="h-7 w-20" />
             </div>
             <Skeleton className="h-44 w-full rounded-xl" />
           </div>
-          <div className="rounded-2xl border border-ctp-surface1 p-5">
+          <div className="rounded-2xl border border-surface-container-high p-5">
             <div className="flex justify-between mb-4">
               <Skeleton className="h-4 w-16" />
               <Skeleton className="h-7 w-16" />
@@ -64,7 +64,7 @@ export default function Loading() {
           {[0, 1, 2].map((i) => (
             <div
               key={i}
-              className="rounded-2xl border border-ctp-surface1 overflow-hidden"
+              className="rounded-2xl border border-surface-container-high overflow-hidden"
             >
               <Skeleton className="h-36 w-full rounded-none" />
               <div className="p-6 space-y-3">

--- a/src/app/[locale]/monthly/[month]/page.tsx
+++ b/src/app/[locale]/monthly/[month]/page.tsx
@@ -76,20 +76,20 @@ export default async function MonthSummaryPage({ params }: MonthSummaryPageProps
       {/* Back */}
       <Link
         href={`/${params.locale}/monthly`}
-        className="inline-block text-sm text-sand-400 hover:text-ctp-text mb-8 transition-colors"
+        className="inline-block text-sm text-on-surface-variant hover:text-on-surface mb-8 transition-colors"
       >
         ← {t('backToOverview')}
       </Link>
 
       {/* Header */}
       <header className="mb-8">
-        <p className="text-xs font-semibold text-nutrition-600 dark:text-nutrition-400 uppercase tracking-wide mb-2">
+        <p className="text-xs font-semibold text-nutrition-600 text-nutrition-400 uppercase tracking-wide mb-2">
           {t('summaryLabel')}
         </p>
-        <h1 className="font-display text-4xl font-bold text-ctp-text">
+        <h1 className="font-display text-4xl font-bold text-on-surface">
           {monthName} {year}
         </h1>
-        <p className="text-xs text-sand-400 mt-2">
+        <p className="text-xs text-on-surface-variant mt-2">
           {t('generatedOn', { date: summary.generatedAt.toLocaleDateString(isEn ? 'en-GB' : 'de-CH', { day: 'numeric', month: 'long', year: 'numeric' }) })}
           {isEn && !summary.contentEn && (
             <span className="ml-2 italic">(Original auf Deutsch)</span>
@@ -99,7 +99,7 @@ export default async function MonthSummaryPage({ params }: MonthSummaryPageProps
 
       {/* Content */}
       <div
-        className="prose prose-sand dark:prose-invert max-w-none"
+        className="prose prose-sand prose-invert max-w-none"
         dangerouslySetInnerHTML={{ __html: content }}
       />
     </article>

--- a/src/app/[locale]/monthly/page.tsx
+++ b/src/app/[locale]/monthly/page.tsx
@@ -22,30 +22,30 @@ export default async function MonthlyOverviewPage({ params }: MonthlyOverviewPag
 
   return (
     <div className="max-w-2xl mx-auto py-12 px-4">
-      <h1 className="font-display text-3xl font-bold text-ctp-text mb-2">
+      <h1 className="font-display text-3xl font-bold text-on-surface mb-2">
         {t('overviewHeading')}
       </h1>
-      <p className="text-sand-500 mb-10">{t('overviewDescription')}</p>
+      <p className="text-on-surface-variant mb-10">{t('overviewDescription')}</p>
 
       {summaries.length === 0 ? (
-        <p className="text-sand-400">{t('noSummaries')}</p>
+        <p className="text-on-surface-variant">{t('noSummaries')}</p>
       ) : (
         <div className="space-y-3">
           {summaries.map((s) => (
             <Link
               key={s.id}
               href={`/${params.locale}/monthly/${monthSlug(s.year, s.month)}`}
-              className="flex items-center justify-between bg-ctp-base rounded-xl border border-ctp-surface1 px-6 py-4 hover:border-sand-300 dark:hover:border-ctp-overlay2 hover:shadow-sm transition-all group"
+              className="flex items-center justify-between bg-surface-container rounded-xl border border-surface-container-high px-6 py-4 hover:border-outline hover:border-on-surface-variant hover:shadow-sm transition-all group"
             >
               <div>
-                <p className="font-display font-semibold text-ctp-text group-hover:text-nutrition-700 dark:group-hover:text-nutrition-400 transition-colors">
+                <p className="font-display font-semibold text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-400 transition-colors">
                   {monthNames[s.month - 1]} {s.year}
                 </p>
-                <p className="text-xs text-sand-400 mt-0.5">
+                <p className="text-xs text-on-surface-variant mt-0.5">
                   {t('generatedOn', { date: s.generatedAt.toLocaleDateString(params.locale === 'en' ? 'en-GB' : 'de-CH', { day: 'numeric', month: 'long', year: 'numeric' }) })}
                 </p>
               </div>
-              <span className="text-sand-400 group-hover:text-nutrition-600 transition-colors">→</span>
+              <span className="text-on-surface-variant group-hover:text-nutrition-600 transition-colors">→</span>
             </Link>
           ))}
         </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -88,26 +88,26 @@ export default async function HomePage({ params }: HomePageProps) {
 
       {/* ── Hero ───────────────────────────────────── */}
       <header className="mb-10">
-        <p className="text-xs font-medium tracking-widest uppercase text-sand-500 mb-3">
+        <p className="text-xs font-medium tracking-widest uppercase text-on-surface-variant mb-3">
           {t('tagline')}
         </p>
 
-        <h1 className="font-display text-4xl sm:text-5xl font-bold leading-tight text-ctp-text mb-4">
+        <h1 className="font-display text-4xl sm:text-5xl font-bold leading-tight text-on-surface mb-4">
           <span className="block">{t('headline_1')}</span>
           <span className="block">{t('headline_2')}</span>
         </h1>
 
-        <p className="text-lg text-sand-500 max-w-xl leading-relaxed mb-6">
+        <p className="text-lg text-on-surface-variant max-w-xl leading-relaxed mb-6">
           {t('description')}
         </p>
 
         {/* Day counter + streaks */}
-        <div className="p-4 rounded-xl bg-ctp-surface0 border border-ctp-surface1">
+        <div className="p-4 rounded-xl bg-surface-container border border-surface-container-high">
           <div className="flex items-baseline gap-3 mb-3">
-            <p className="font-display text-3xl font-bold text-ctp-peach leading-none">
+            <p className="font-display text-3xl font-bold text-primary leading-none">
               {currentDay}
             </p>
-            <p className="text-xs text-sand-500">
+            <p className="text-xs text-on-surface-variant">
               {t('dayCounter', { day: currentDay })}
             </p>
           </div>
@@ -116,18 +116,18 @@ export default async function HomePage({ params }: HomePageProps) {
           <div className="flex gap-4">
             <div className="flex items-center gap-1.5" title={t('streakMovement')}>
               <span className="text-base leading-none">🏃</span>
-              <span className="text-sm font-semibold text-ctp-text tabular-nums">{movementStreak.current}</span>
-              <span className="text-xs text-sand-400">{t('streakDays')}</span>
+              <span className="text-sm font-semibold text-on-surface tabular-nums">{movementStreak.current}</span>
+              <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
             </div>
             <div className="flex items-center gap-1.5" title={t('streakNutrition')}>
               <span className="text-base leading-none">🥗</span>
-              <span className="text-sm font-semibold text-ctp-text tabular-nums">{nutritionStreak.current}</span>
-              <span className="text-xs text-sand-400">{t('streakDays')}</span>
+              <span className="text-sm font-semibold text-on-surface tabular-nums">{nutritionStreak.current}</span>
+              <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
             </div>
             <div className="flex items-center gap-1.5" title={t('streakSmoking')}>
               <span className="text-base leading-none">🚭</span>
-              <span className="text-sm font-semibold text-ctp-text tabular-nums">{smokingStreak.current}</span>
-              <span className="text-xs text-sand-400">{t('streakDays')}</span>
+              <span className="text-sm font-semibold text-on-surface tabular-nums">{smokingStreak.current}</span>
+              <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
             </div>
           </div>
         </div>
@@ -148,9 +148,9 @@ export default async function HomePage({ params }: HomePageProps) {
               ))}
             </div>
             {hasMore && (
-              <div className="mt-6 pt-5 border-t border-sand-200 dark:border-ctp-surface0">
+              <div className="mt-6 pt-5 border-t border-surface-container-high border-surface-container">
                 <details className="group">
-                  <summary className="cursor-pointer text-sm font-medium text-sand-500 hover:text-ctp-peach transition-colors list-none flex items-center gap-2">
+                  <summary className="cursor-pointer text-sm font-medium text-on-surface-variant hover:text-primary transition-colors list-none flex items-center gap-2">
                     <span className="group-open:hidden">{t('allEntries', { count: entries.length })}</span>
                     <span className="hidden group-open:inline">Weniger anzeigen</span>
                   </summary>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -12,10 +12,10 @@ interface StatCardProps {
 
 function StatCard({ value, label, sub }: StatCardProps) {
   return (
-    <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-4 text-center">
-      <p className="font-display text-2xl font-bold text-ctp-text">{value}</p>
-      <p className="text-xs font-medium text-sand-500 mt-1">{label}</p>
-      {sub && <p className="text-xs text-sand-400 mt-0.5">{sub}</p>}
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high p-4 text-center">
+      <p className="font-display text-2xl font-bold text-on-surface">{value}</p>
+      <p className="text-xs font-medium text-on-surface-variant mt-1">{label}</p>
+      {sub && <p className="text-xs text-on-surface-variant mt-0.5">{sub}</p>}
     </div>
   )
 }
@@ -45,13 +45,13 @@ export default async function AnalyticsPage({
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-display text-2xl font-bold text-ctp-text mb-1">Analytics</h1>
-        <p className="text-sand-500 text-sm">Privacy-first · Kein Cookie · Keine IP-Speicherung</p>
+        <h1 className="font-display text-2xl font-bold text-on-surface mb-1">Analytics</h1>
+        <p className="text-on-surface-variant text-sm">Privacy-first · Kein Cookie · Keine IP-Speicherung</p>
       </div>
 
       {/* Summary Cards */}
       <section>
-        <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide mb-3">Übersicht</h2>
+        <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Übersicht</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <StatCard value={summary.viewsToday.toLocaleString('de-CH')} label="Aufrufe heute" sub={`${summary.sessionsToday} Besucher`} />
           <StatCard value={summary.viewsLast7d.toLocaleString('de-CH')} label="Aufrufe 7 Tage" sub={`${summary.sessionsLast7d} Besucher`} />
@@ -63,7 +63,7 @@ export default async function AnalyticsPage({
       {/* Chart */}
       <section>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide">Verlauf</h2>
+          <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">Verlauf</h2>
           <div className="flex gap-1">
             {PERIODS.map(({ label, value }) => (
               <Link
@@ -71,8 +71,8 @@ export default async function AnalyticsPage({
                 href={`/admin/analytics?period=${value}`}
                 className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors ${
                   String(period) === value
-                    ? 'bg-ctp-surface0 text-ctp-text'
-                    : 'text-sand-500 hover:text-ctp-text hover:bg-sand-50 dark:hover:bg-ctp-base'
+                    ? 'bg-surface-container text-on-surface'
+                    : 'text-on-surface-variant hover:text-on-surface hover:bg-background hover:bg-surface-container'
                 }`}
               >
                 {label}
@@ -80,7 +80,7 @@ export default async function AnalyticsPage({
             ))}
           </div>
         </div>
-        <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
+        <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
           <ViewsChart data={viewsPerDay} />
         </div>
       </section>
@@ -88,24 +88,24 @@ export default async function AnalyticsPage({
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Top Pages */}
         <section>
-          <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide mb-3">
+          <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">
             Top Seiten <span className="normal-case font-normal">({period} Tage)</span>
           </h2>
-          <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 divide-y divide-sand-100 dark:divide-ctp-surface0">
+          <div className="bg-surface-container rounded-2xl border border-surface-container-high divide-y divide-surface-container divide-surface-container">
             {topPages.length === 0 ? (
-              <p className="px-5 py-4 text-sm text-sand-400">Noch keine Daten</p>
+              <p className="px-5 py-4 text-sm text-on-surface-variant">Noch keine Daten</p>
             ) : (
               topPages.map(({ path, views, sessions }) => (
                 <div key={path} className="px-4 py-3">
                   <div className="flex items-center justify-between mb-1.5">
-                    <span className="text-xs font-mono text-ctp-text truncate max-w-[60%]">
+                    <span className="text-xs font-mono text-on-surface truncate max-w-[60%]">
                       {path}
                     </span>
-                    <span className="text-xs text-sand-500 shrink-0 ml-2">
+                    <span className="text-xs text-on-surface-variant shrink-0 ml-2">
                       {views} · {sessions} Bes.
                     </span>
                   </div>
-                  <div className="h-1 bg-ctp-surface0 rounded-full overflow-hidden">
+                  <div className="h-1 bg-surface-container rounded-full overflow-hidden">
                     <div
                       className="h-full bg-blue-500 rounded-full"
                       style={{ width: `${(views / maxPageViews) * 100}%` }}
@@ -119,19 +119,19 @@ export default async function AnalyticsPage({
 
         {/* Referrers */}
         <section>
-          <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide mb-3">
+          <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">
             Referrer <span className="normal-case font-normal">({period} Tage)</span>
           </h2>
-          <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 divide-y divide-sand-100 dark:divide-ctp-surface0">
+          <div className="bg-surface-container rounded-2xl border border-surface-container-high divide-y divide-surface-container divide-surface-container">
             {topReferrers.length === 0 ? (
-              <p className="px-5 py-4 text-sm text-sand-400">Noch keine Referrer-Daten</p>
+              <p className="px-5 py-4 text-sm text-on-surface-variant">Noch keine Referrer-Daten</p>
             ) : (
               topReferrers.map(({ referrer, count }) => (
                 <div key={referrer} className="px-4 py-3 flex items-center justify-between">
-                  <span className="text-xs font-mono text-ctp-text truncate">
+                  <span className="text-xs font-mono text-on-surface truncate">
                     {referrer}
                   </span>
-                  <span className="text-xs text-sand-500 shrink-0 ml-2">{count}</span>
+                  <span className="text-xs text-on-surface-variant shrink-0 ml-2">{count}</span>
                 </div>
               ))
             )}

--- a/src/app/admin/entries/[id]/edit/page.tsx
+++ b/src/app/admin/entries/[id]/edit/page.tsx
@@ -27,7 +27,7 @@ export default async function EditEntryPage({ params }: EditEntryPageProps) {
 
   return (
     <div className="max-w-3xl">
-      <h1 className="font-display text-2xl font-bold text-ctp-text mb-8">Eintrag bearbeiten</h1>
+      <h1 className="font-display text-2xl font-bold text-on-surface mb-8">Eintrag bearbeiten</h1>
       <EntryForm mode="edit" entryId={entry.id} initial={initial} />
     </div>
   )

--- a/src/app/admin/entries/new/page.tsx
+++ b/src/app/admin/entries/new/page.tsx
@@ -3,7 +3,7 @@ import { EntryForm } from '@/components/admin/EntryForm'
 export default function NewEntryPage() {
   return (
     <div className="max-w-3xl">
-      <h1 className="font-display text-2xl font-bold text-ctp-text mb-8">Neuer Eintrag</h1>
+      <h1 className="font-display text-2xl font-bold text-on-surface mb-8">Neuer Eintrag</h1>
       <EntryForm mode="create" />
     </div>
   )

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -39,7 +39,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="font-display text-2xl font-bold text-ctp-text">Einträge</h1>
+        <h1 className="font-display text-2xl font-bold text-on-surface">Einträge</h1>
         <Link
           href="/admin/entries/new"
           className="flex items-center gap-2 px-4 py-2 bg-nutrition-600 text-white rounded-xl text-sm font-medium hover:bg-nutrition-700 transition-colors"
@@ -56,7 +56,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
       )}
 
       {entries.length === 0 ? (
-        <div className="text-center py-16 text-sand-400">
+        <div className="text-center py-16 text-on-surface-variant">
           <p className="text-lg mb-2">Noch keine Einträge</p>
           <Link href="/admin/entries/new" className="text-sm text-nutrition-600 hover:text-nutrition-700">
             Ersten Eintrag erstellen →
@@ -72,24 +72,24 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
             return (
               <div
                 key={entry.id}
-                className="bg-ctp-base rounded-xl border border-ctp-surface1 px-5 py-4 flex items-center gap-4 hover:border-sand-300 dark:hover:border-ctp-overlay2 transition-colors"
+                className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4 flex items-center gap-4 hover:border-outline hover:border-on-surface-variant transition-colors"
               >
-                <span className="text-xs font-mono text-sand-400 shrink-0 w-8 text-right">
+                <span className="text-xs font-mono text-on-surface-variant shrink-0 w-8 text-right">
                   {getDayNumber(dateStr, startDate)}
                 </span>
 
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-0.5">
-                    <span className="font-display font-semibold text-ctp-text truncate">
+                    <span className="font-display font-semibold text-on-surface truncate">
                       {entry.title}
                     </span>
                     {!entry.published && (
-                      <span className="text-xs px-1.5 py-0.5 bg-ctp-surface0 text-sand-500 rounded shrink-0">
+                      <span className="text-xs px-1.5 py-0.5 bg-surface-container text-on-surface-variant rounded shrink-0">
                         Entwurf
                       </span>
                     )}
                   </div>
-                  <time className="text-xs text-sand-400">{formatDate(entry.date)}</time>
+                  <time className="text-xs text-on-surface-variant">{formatDate(entry.date)}</time>
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0">
@@ -97,13 +97,13 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
                   <Link
                     href={`/journal/${entry.slug}`}
                     target="_blank"
-                    className="text-xs text-sand-400 hover:text-ctp-text transition-colors"
+                    className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
                   >
                     Ansehen ↗
                   </Link>
                   <Link
                     href={`/admin/entries/${entry.id}/edit`}
-                    className="text-xs px-3 py-1.5 border border-ctp-surface1 rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-ctp-overlay2 hover:text-ctp-text transition-colors"
+                    className="text-xs px-3 py-1.5 border border-surface-container-high rounded-lg text-on-surface-variant text-on-surface-variant hover:border-outline hover:border-on-surface-variant hover:text-on-surface transition-colors"
                   >
                     Bearbeiten
                   </Link>

--- a/src/app/admin/fitbit/page.tsx
+++ b/src/app/admin/fitbit/page.tsx
@@ -12,8 +12,8 @@ function ConfigBadge({ ok, label }: { ok: boolean; label: string }) {
       <span
         className={`w-2 h-2 rounded-full flex-none ${ok ? 'bg-movement-500' : 'bg-red-400'}`}
       />
-      <span className="text-sm text-ctp-text">{label}</span>
-      <span className={`text-xs font-medium ${ok ? 'text-movement-600 dark:text-movement-400' : 'text-red-600 dark:text-red-400'}`}>
+      <span className="text-sm text-on-surface">{label}</span>
+      <span className={`text-xs font-medium ${ok ? 'text-movement-600 text-movement-400' : 'text-red-600 text-red-400'}`}>
         {ok ? 'Konfiguriert' : 'Fehlt'}
       </span>
     </div>
@@ -61,64 +61,64 @@ export default async function FitbitPage({
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-display text-2xl font-bold text-ctp-text mb-1">Fitbit Sync</h1>
-        <p className="text-ctp-subtext1 text-sm">
+        <h1 className="font-display text-2xl font-bold text-on-surface mb-1">Fitbit Sync</h1>
+        <p className="text-on-surface-variant text-sm">
           Metriken manuell synchronisieren oder historische Daten nachfüllen.
         </p>
       </div>
 
       {searchParams.authorized === '1' && (
-        <div className="bg-movement-100 dark:bg-movement-900/20 border border-movement-200 dark:border-movement-800 rounded-xl px-4 py-3 text-sm text-movement-700 dark:text-movement-400">
+        <div className="bg-movement-100 bg-movement-900/20 border border-movement-200 border-movement-800 rounded-xl px-4 py-3 text-sm text-movement-700 text-movement-400">
           Fitbit erfolgreich autorisiert. Tokens wurden in der Datenbank gespeichert.
         </div>
       )}
 
       {searchParams.error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl px-4 py-3 text-sm text-red-700 dark:text-red-400">
+        <div className="bg-red-50 bg-red-900/20 border border-red-200 border-red-800 rounded-xl px-4 py-3 text-sm text-red-700 text-red-400">
           Autorisierung fehlgeschlagen: <code>{searchParams.error}</code>
         </div>
       )}
 
       <section>
-        <h2 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wide mb-3">Konfiguration</h2>
-        <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5 space-y-3">
+        <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Konfiguration</h2>
+        <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 space-y-3">
           <ConfigBadge ok={hasClientId} label="FITBIT_CLIENT_ID" />
           <ConfigBadge ok={hasClientSecret} label="FITBIT_CLIENT_SECRET" />
           <div className="flex items-center gap-2">
             <span className={`w-2 h-2 rounded-full flex-none ${(hasDbTokens || hasEnvTokens) ? 'bg-movement-500' : 'bg-red-400'}`} />
-            <span className="text-sm text-ctp-text">OAuth Tokens</span>
-            <span className={`text-xs font-medium ${(hasDbTokens || hasEnvTokens) ? 'text-movement-600 dark:text-movement-400' : 'text-red-600 dark:text-red-400'}`}>
+            <span className="text-sm text-on-surface">OAuth Tokens</span>
+            <span className={`text-xs font-medium ${(hasDbTokens || hasEnvTokens) ? 'text-movement-600 text-movement-400' : 'text-red-600 text-red-400'}`}>
               {hasDbTokens ? 'In DB gespeichert' : hasEnvTokens ? 'Aus .env (noch nicht persistiert)' : 'Fehlen'}
             </span>
           </div>
-          <div className="border-t border-ctp-surface0 pt-3">
+          <div className="border-t border-surface-container pt-3">
             <Link
               href={fitbitAuthUrl}
-              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-ctp-surface0 hover:bg-ctp-surface1 text-ctp-text text-xs font-medium transition-colors"
+              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-surface-container hover:bg-surface-container-high text-on-surface text-xs font-medium transition-colors"
             >
               {isConfigured ? '↺ Re-Authorize' : '+ Fitbit autorisieren'}
             </Link>
-            <p className="mt-2 text-xs text-ctp-overlay1">
+            <p className="mt-2 text-xs text-on-surface-variant">
               Öffnet Fitbit OAuth — nach Bestätigung werden Tokens automatisch in der DB gespeichert.
-              Die Redirect-URL <code className="text-ctp-subtext1">{baseUrl}/api/fitbit/callback</code> muss in der Fitbit App registriert sein.
+              Die Redirect-URL <code className="text-on-surface-variant">{baseUrl}/api/fitbit/callback</code> muss in der Fitbit App registriert sein.
             </p>
           </div>
         </div>
       </section>
 
       <section>
-        <h2 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wide mb-3">Manueller Sync</h2>
+        <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Manueller Sync</h2>
         <FitbitSyncPanel />
       </section>
 
       {recentFitbitMetrics.length > 0 && (
         <section>
-          <h2 className="text-xs font-semibold text-ctp-subtext0 uppercase tracking-wide mb-3">Letzte Fitbit-Daten</h2>
-          <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 overflow-hidden">
+          <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Letzte Fitbit-Daten</h2>
+          <div className="bg-surface-container rounded-2xl border border-surface-container-high overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-xs">
                 <thead>
-                  <tr className="border-b border-ctp-surface0 text-ctp-subtext1 text-left">
+                  <tr className="border-b border-surface-container text-on-surface-variant text-left">
                     <th className="px-4 py-3 font-medium">Datum</th>
                     <th className="px-4 py-3 font-medium">Gewicht</th>
                     <th className="px-4 py-3 font-medium">Körperfett</th>
@@ -132,15 +132,15 @@ export default async function FitbitPage({
                   {recentFitbitMetrics.map((row) => (
                     <tr
                       key={row.id}
-                      className="border-b border-ctp-surface0 last:border-0 hover:bg-ctp-surface0 transition-colors"
+                      className="border-b border-surface-container last:border-0 hover:bg-surface-container transition-colors"
                     >
-                      <td className="px-4 py-3 font-mono text-ctp-subtext1">{formatDate(row.date)}</td>
-                      <td className="px-4 py-3 text-ctp-text">{row.weight != null ? `${row.weight} kg` : '—'}</td>
-                      <td className="px-4 py-3 text-ctp-text">{row.bodyFat != null ? `${row.bodyFat}%` : '—'}</td>
-                      <td className="px-4 py-3 text-ctp-text">{row.steps != null ? row.steps.toLocaleString('de-CH') : '—'}</td>
-                      <td className="px-4 py-3 text-ctp-text">{row.activeMinutes != null ? `${row.activeMinutes} min` : '—'}</td>
-                      <td className="px-4 py-3 text-ctp-text">{row.restingHR != null ? `${row.restingHR} bpm` : '—'}</td>
-                      <td className="px-4 py-3 text-ctp-text">{row.distance != null ? `${row.distance} km` : '—'}</td>
+                      <td className="px-4 py-3 font-mono text-on-surface-variant">{formatDate(row.date)}</td>
+                      <td className="px-4 py-3 text-on-surface">{row.weight != null ? `${row.weight} kg` : '—'}</td>
+                      <td className="px-4 py-3 text-on-surface">{row.bodyFat != null ? `${row.bodyFat}%` : '—'}</td>
+                      <td className="px-4 py-3 text-on-surface">{row.steps != null ? row.steps.toLocaleString('de-CH') : '—'}</td>
+                      <td className="px-4 py-3 text-on-surface">{row.activeMinutes != null ? `${row.activeMinutes} min` : '—'}</td>
+                      <td className="px-4 py-3 text-on-surface">{row.restingHR != null ? `${row.restingHR} bpm` : '—'}</td>
+                      <td className="px-4 py-3 text-on-surface">{row.distance != null ? `${row.distance} km` : '—'}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -15,15 +15,15 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
   }
 
   return (
-    <div className="min-h-screen bg-ctp-mantle">
+    <div className="min-h-screen bg-surface-container-low">
 
       {/* ── Top bar ───────────────────────────────── */}
-      <header className="sticky top-0 z-10 bg-ctp-base border-b border-ctp-surface0">
+      <header className="sticky top-0 z-10 bg-surface-container border-b border-surface-container">
         <div className="flex items-center justify-between px-4 sm:px-6 h-12">
           {/* Logo */}
-          <Link href="/admin" className="font-display text-sm font-bold text-ctp-text">
-            Project <span className="text-ctp-peach">365</span>{' '}
-            <span className="text-ctp-overlay1 font-normal">Admin</span>
+          <Link href="/admin" className="font-display text-sm font-bold text-on-surface">
+            Project <span className="text-primary">365</span>{' '}
+            <span className="text-on-surface-variant font-normal">Admin</span>
           </Link>
 
           {/* Right actions */}
@@ -32,7 +32,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
               href="/de"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs text-ctp-subtext1 hover:text-ctp-text transition-colors"
+              className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
               title="Zur öffentlichen Seite"
             >
               ↗ Zur Seite
@@ -47,7 +47,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
             )}
             <Link
               href="/api/auth/signout"
-              className="text-xs text-ctp-subtext1 hover:text-ctp-text transition-colors"
+              className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
             >
               Abmelden
             </Link>
@@ -55,7 +55,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
         </div>
 
         {/* Mobile nav — horizontal scroll below top bar */}
-        <div className="md:hidden border-t border-ctp-surface0">
+        <div className="md:hidden border-t border-surface-container">
           <AdminNavMobile />
         </div>
       </header>
@@ -64,7 +64,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
       <div className="flex">
 
         {/* Sidebar — desktop only */}
-        <aside className="hidden md:block w-44 shrink-0 sticky top-12 h-[calc(100vh-3rem)] overflow-y-auto border-r border-ctp-surface0 bg-ctp-base">
+        <aside className="hidden md:block w-44 shrink-0 sticky top-12 h-[calc(100vh-3rem)] overflow-y-auto border-r border-surface-container bg-surface-container">
           <AdminSidebar />
         </aside>
 

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -10,16 +10,16 @@ function LoginContent() {
   const callbackUrl = searchParams.get('callbackUrl') ?? '/admin'
 
   return (
-    <div className="min-h-screen bg-sand-50 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
       <div className="max-w-sm w-full">
         <div className="text-center mb-8">
-          <h1 className="font-display text-3xl font-bold text-ctp-text mb-2">
+          <h1 className="font-display text-3xl font-bold text-on-surface mb-2">
             Project <span className="text-nutrition-600">365</span>
           </h1>
-          <p className="text-sand-500 text-sm">Admin-Bereich</p>
+          <p className="text-on-surface-variant text-sm">Admin-Bereich</p>
         </div>
 
-        <div className="bg-white rounded-2xl shadow-sm border border-sand-200 p-8">
+        <div className="bg-white rounded-2xl shadow-sm border border-surface-container-high p-8">
           {error === 'AccessDenied' && (
             <div className="mb-6 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
               Zugriff verweigert. Nur der Admin-Account hat Zugang.
@@ -28,7 +28,7 @@ function LoginContent() {
 
           <button
             onClick={() => signIn('google', { callbackUrl })}
-            className="w-full flex items-center justify-center gap-3 px-4 py-3 bg-white border border-sand-300 rounded-xl text-sm font-medium text-ctp-text hover:bg-sand-50 hover:border-sand-400 transition-colors shadow-sm"
+            className="w-full flex items-center justify-center gap-3 px-4 py-3 bg-white border border-outline rounded-xl text-sm font-medium text-on-surface hover:bg-background hover:border-on-surface-variant transition-colors shadow-sm"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
               <path

--- a/src/app/admin/metrics/page.tsx
+++ b/src/app/admin/metrics/page.tsx
@@ -52,8 +52,8 @@ export default async function MetricsPage({ searchParams }: PageProps) {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="font-display text-2xl font-bold text-ctp-text">Metriken erfassen</h1>
-        <p className="text-sand-500 text-sm mt-1">Manuell erfasste Werte überschreiben automatische Importe.</p>
+        <h1 className="font-display text-2xl font-bold text-on-surface">Metriken erfassen</h1>
+        <p className="text-on-surface-variant text-sm mt-1">Manuell erfasste Werte überschreiben automatische Importe.</p>
       </div>
 
       <MetricsForm date={date} initial={initial} />
@@ -61,12 +61,12 @@ export default async function MetricsPage({ searchParams }: PageProps) {
       {/* Recent entries table */}
       {recent.length > 0 && (
         <div className="mt-10">
-          <h2 className="font-display text-base font-semibold text-ctp-text mb-3">Letzte Einträge</h2>
-          <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 overflow-hidden">
+          <h2 className="font-display text-base font-semibold text-on-surface mb-3">Letzte Einträge</h2>
+          <div className="bg-surface-container rounded-2xl border border-surface-container-high overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-xs">
                 <thead>
-                  <tr className="border-b border-ctp-surface0 text-sand-500 text-left">
+                  <tr className="border-b border-surface-container text-on-surface-variant text-left">
                     <th className="px-4 py-3 font-medium">Datum</th>
                     <th className="px-4 py-3 font-medium">Gewicht</th>
                     <th className="px-4 py-3 font-medium">Körperfett</th>
@@ -80,28 +80,28 @@ export default async function MetricsPage({ searchParams }: PageProps) {
                   {recent.map((row) => (
                     <tr
                       key={row.id}
-                      className="border-b border-ctp-surface0 last:border-0 hover:bg-sand-50 dark:hover:bg-ctp-surface0 transition-colors"
+                      className="border-b border-surface-container last:border-0 hover:bg-background hover:bg-surface-container transition-colors"
                     >
-                      <td className="px-4 py-3 font-mono text-sand-500">
+                      <td className="px-4 py-3 font-mono text-on-surface-variant">
                         {formatDate(row.date)}
                       </td>
-                      <td className="px-4 py-3 text-ctp-text">
+                      <td className="px-4 py-3 text-on-surface">
                         {row.weight != null ? `${row.weight} kg` : '—'}
                       </td>
-                      <td className="px-4 py-3 text-ctp-text">
+                      <td className="px-4 py-3 text-on-surface">
                         {row.bodyFat != null ? `${row.bodyFat}%` : '—'}
                       </td>
-                      <td className="px-4 py-3 text-ctp-text">
+                      <td className="px-4 py-3 text-on-surface">
                         {row.steps != null ? row.steps.toLocaleString('de-CH') : '—'}
                       </td>
-                      <td className="px-4 py-3 text-ctp-text">
+                      <td className="px-4 py-3 text-on-surface">
                         {formatSleep(row.sleepDuration)}
                       </td>
-                      <td className="px-4 py-3 text-ctp-text">
+                      <td className="px-4 py-3 text-on-surface">
                         {row.restingHR != null ? `${row.restingHR} bpm` : '—'}
                       </td>
                       <td className="px-4 py-3">
-                        <span className="px-1.5 py-0.5 bg-ctp-surface0 text-sand-500 rounded text-xs">
+                        <span className="px-1.5 py-0.5 bg-surface-container text-on-surface-variant rounded text-xs">
                           {row.source}
                         </span>
                       </td>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -38,27 +38,27 @@ function StatusCard({ label, ok, okLabel, missingLabel, href }: StatusCardProps)
     <div
       className={`rounded-2xl border p-4 flex items-start gap-3 ${
         ok
-          ? 'bg-movement-100 dark:bg-movement-600/10 border-movement-200 dark:border-movement-600/20'
-          : 'bg-ctp-base border-ctp-surface1'
+          ? 'bg-movement-100 bg-movement-600/10 border-movement-200 border-movement-600/20'
+          : 'bg-surface-container border-surface-container-high'
       }`}
     >
       <span
         className={`mt-0.5 flex-none w-5 h-5 rounded-full flex items-center justify-center text-xs ${
-          ok ? 'bg-movement-500 text-white' : 'bg-ctp-surface1 text-white'
+          ok ? 'bg-movement-500 text-white' : 'bg-surface-container-high text-white'
         }`}
       >
         {ok ? '✓' : '·'}
       </span>
       <div className="flex-1 min-w-0">
-        <p className="text-xs font-medium text-sand-500">{label}</p>
-        <p className={`text-sm font-semibold mt-0.5 ${ok ? 'text-movement-700 dark:text-movement-400' : 'text-sand-400'}`}>
+        <p className="text-xs font-medium text-on-surface-variant">{label}</p>
+        <p className={`text-sm font-semibold mt-0.5 ${ok ? 'text-movement-700 text-movement-400' : 'text-on-surface-variant'}`}>
           {ok ? okLabel : missingLabel}
         </p>
       </div>
       {!ok && (
         <Link
           href={href}
-          className="shrink-0 text-xs px-2.5 py-1 bg-ctp-surface0 border border-ctp-surface1 rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 hover:text-ctp-text transition-colors"
+          className="shrink-0 text-xs px-2.5 py-1 bg-surface-container border border-surface-container-high rounded-lg text-on-surface-variant text-on-surface-variant hover:border-outline hover:text-on-surface transition-colors"
         >
           Erfassen
         </Link>
@@ -79,10 +79,10 @@ interface StatCardProps {
 
 function StatCard({ value, label, sub }: StatCardProps) {
   return (
-    <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-4 text-center">
-      <p className="font-display text-3xl font-bold text-ctp-text">{value}</p>
-      <p className="text-xs font-medium text-sand-500 mt-1">{label}</p>
-      {sub && <p className="text-xs text-sand-400 mt-0.5">{sub}</p>}
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high p-4 text-center">
+      <p className="font-display text-3xl font-bold text-on-surface">{value}</p>
+      <p className="text-xs font-medium text-on-surface-variant mt-1">{label}</p>
+      {sub && <p className="text-xs text-on-surface-variant mt-0.5">{sub}</p>}
     </div>
   )
 }
@@ -121,14 +121,14 @@ export default async function AdminPage() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-display text-2xl font-bold text-ctp-text mb-1">
+        <h1 className="font-display text-2xl font-bold text-on-surface mb-1">
           Hallo, {session?.user?.name?.split(' ')[0]}
         </h1>
-        <p className="text-sand-500 text-sm">{formatDate(new Date(today))}</p>
+        <p className="text-on-surface-variant text-sm">{formatDate(new Date(today))}</p>
       </div>
 
       <section>
-        <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide mb-3">Heute</h2>
+        <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Heute</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <StatusCard
             label="Journal-Eintrag"
@@ -148,7 +148,7 @@ export default async function AdminPage() {
       </section>
 
       <section>
-        <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide mb-3">Übersicht</h2>
+        <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Übersicht</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <StatCard value={publishedCount} label="Einträge" sub="veröffentlicht" />
           <StatCard value={draftCount} label="Entwürfe" />
@@ -161,34 +161,34 @@ export default async function AdminPage() {
       </section>
 
       <section>
-        <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide mb-3">Aktionen</h2>
+        <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Aktionen</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <Link
             href="/admin/entries/new"
-            className="group bg-ctp-base rounded-2xl border border-ctp-surface1 p-5 flex items-center gap-4 hover:border-nutrition-300 hover:shadow-sm transition-all"
+            className="group bg-surface-container rounded-2xl border border-surface-container-high p-5 flex items-center gap-4 hover:border-nutrition-300 hover:shadow-sm transition-all"
           >
-            <div className="flex-none w-10 h-10 bg-nutrition-100 dark:bg-nutrition-600/10 rounded-xl flex items-center justify-center group-hover:bg-nutrition-200 dark:group-hover:bg-nutrition-600/20 transition-colors">
-              <svg className="w-5 h-5 text-nutrition-700 dark:text-nutrition-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <div className="flex-none w-10 h-10 bg-nutrition-100 bg-nutrition-600/10 rounded-xl flex items-center justify-center group-hover:bg-nutrition-200 group-hover:bg-nutrition-600/20 transition-colors">
+              <svg className="w-5 h-5 text-nutrition-700 text-nutrition-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
               </svg>
             </div>
             <div>
-              <p className="font-display text-sm font-semibold text-ctp-text">Neuer Eintrag</p>
-              <p className="text-xs text-sand-500 mt-0.5">Journal-Eintrag mit Habits erfassen</p>
+              <p className="font-display text-sm font-semibold text-on-surface">Neuer Eintrag</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">Journal-Eintrag mit Habits erfassen</p>
             </div>
           </Link>
           <Link
             href={`/admin/metrics?date=${today}`}
-            className="group bg-ctp-base rounded-2xl border border-ctp-surface1 p-5 flex items-center gap-4 hover:border-movement-300 hover:shadow-sm transition-all"
+            className="group bg-surface-container rounded-2xl border border-surface-container-high p-5 flex items-center gap-4 hover:border-movement-300 hover:shadow-sm transition-all"
           >
-            <div className="flex-none w-10 h-10 bg-movement-100 dark:bg-movement-600/10 rounded-xl flex items-center justify-center group-hover:bg-movement-200 dark:group-hover:bg-movement-600/20 transition-colors">
-              <svg className="w-5 h-5 text-movement-700 dark:text-movement-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <div className="flex-none w-10 h-10 bg-movement-100 bg-movement-600/10 rounded-xl flex items-center justify-center group-hover:bg-movement-200 group-hover:bg-movement-600/20 transition-colors">
+              <svg className="w-5 h-5 text-movement-700 text-movement-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
               </svg>
             </div>
             <div>
-              <p className="font-display text-sm font-semibold text-ctp-text">Metriken erfassen</p>
-              <p className="text-xs text-sand-500 mt-0.5">Gewicht, Schritte und weitere Werte</p>
+              <p className="font-display text-sm font-semibold text-on-surface">Metriken erfassen</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">Gewicht, Schritte und weitere Werte</p>
             </div>
           </Link>
         </div>
@@ -197,32 +197,32 @@ export default async function AdminPage() {
       {recentEntries.length > 0 && (
         <section>
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide">Letzte Einträge</h2>
-            <Link href="/admin/entries" className="text-xs text-sand-500 hover:text-ctp-text transition-colors">
+            <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">Letzte Einträge</h2>
+            <Link href="/admin/entries" className="text-xs text-on-surface-variant hover:text-on-surface transition-colors">
               Alle anzeigen →
             </Link>
           </div>
-          <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 divide-y divide-sand-100 dark:divide-ctp-surface0">
+          <div className="bg-surface-container rounded-2xl border border-surface-container-high divide-y divide-surface-container divide-surface-container">
             {recentEntries.map((entry) => {
               const dateStr = entry.date.toISOString().slice(0, 10)
               return (
                 <div key={entry.id} className="px-5 py-3 flex items-center gap-4">
-                  <span className="text-xs font-mono text-sand-400 shrink-0 w-8 text-right">
+                  <span className="text-xs font-mono text-on-surface-variant shrink-0 w-8 text-right">
                     {getDayNumber(dateStr, startDate)}
                   </span>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-ctp-text truncate">{entry.title}</p>
-                    <p className="text-xs text-sand-400">{formatDateShort(entry.date)}</p>
+                    <p className="text-sm font-medium text-on-surface truncate">{entry.title}</p>
+                    <p className="text-xs text-on-surface-variant">{formatDateShort(entry.date)}</p>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     {!entry.published && (
-                      <span className="text-xs px-1.5 py-0.5 bg-ctp-surface0 text-sand-500 rounded">
+                      <span className="text-xs px-1.5 py-0.5 bg-surface-container text-on-surface-variant rounded">
                         Entwurf
                       </span>
                     )}
                     <Link
                       href={`/admin/entries/${entry.id}/edit`}
-                      className="text-xs text-sand-400 hover:text-ctp-text transition-colors"
+                      className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
                     >
                       Bearbeiten
                     </Link>
@@ -237,38 +237,38 @@ export default async function AdminPage() {
       {latestMetrics && (
         <section>
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-xs font-semibold text-sand-400 uppercase tracking-wide">Letzte Metriken</h2>
-            <Link href="/admin/metrics" className="text-xs text-sand-500 hover:text-ctp-text transition-colors">
+            <h2 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide">Letzte Metriken</h2>
+            <Link href="/admin/metrics" className="text-xs text-on-surface-variant hover:text-on-surface transition-colors">
               Alle anzeigen →
             </Link>
           </div>
-          <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-            <p className="text-xs text-sand-400 mb-3">{formatDate(latestMetrics.date)}</p>
+          <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+            <p className="text-xs text-on-surface-variant mb-3">{formatDate(latestMetrics.date)}</p>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
               {latestMetrics.weight != null && (
                 <div>
-                  <p className="text-xs text-sand-500">Gewicht</p>
-                  <p className="text-base font-semibold text-ctp-text mt-0.5">{latestMetrics.weight} kg</p>
+                  <p className="text-xs text-on-surface-variant">Gewicht</p>
+                  <p className="text-base font-semibold text-on-surface mt-0.5">{latestMetrics.weight} kg</p>
                 </div>
               )}
               {latestMetrics.bodyFat != null && (
                 <div>
-                  <p className="text-xs text-sand-500">Körperfett</p>
-                  <p className="text-base font-semibold text-ctp-text mt-0.5">{latestMetrics.bodyFat}%</p>
+                  <p className="text-xs text-on-surface-variant">Körperfett</p>
+                  <p className="text-base font-semibold text-on-surface mt-0.5">{latestMetrics.bodyFat}%</p>
                 </div>
               )}
               {latestMetrics.steps != null && (
                 <div>
-                  <p className="text-xs text-sand-500">Schritte</p>
-                  <p className="text-base font-semibold text-ctp-text mt-0.5">
+                  <p className="text-xs text-on-surface-variant">Schritte</p>
+                  <p className="text-base font-semibold text-on-surface mt-0.5">
                     {latestMetrics.steps.toLocaleString('de-CH')}
                   </p>
                 </div>
               )}
               {latestMetrics.restingHR != null && (
                 <div>
-                  <p className="text-xs text-sand-500">Ruheherzfrequenz</p>
-                  <p className="text-base font-semibold text-ctp-text mt-0.5">{latestMetrics.restingHR} bpm</p>
+                  <p className="text-xs text-on-surface-variant">Ruheherzfrequenz</p>
+                  <p className="text-base font-semibold text-on-surface mt-0.5">{latestMetrics.restingHR} bpm</p>
                 </div>
               )}
             </div>

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -14,8 +14,8 @@ export default async function SettingsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="font-display text-2xl font-bold text-ctp-text">Einstellungen</h1>
-        <p className="text-sand-500 text-sm mt-1">Statische Werte und persönliche Ziele.</p>
+        <h1 className="font-display text-2xl font-bold text-on-surface">Einstellungen</h1>
+        <p className="text-on-surface-variant text-sm mt-1">Statische Werte und persönliche Ziele.</p>
       </div>
 
       <SettingsForm initial={initial} />

--- a/src/app/admin/summaries/[id]/edit/page.tsx
+++ b/src/app/admin/summaries/[id]/edit/page.tsx
@@ -19,10 +19,10 @@ export default async function SummaryEditPage({ params }: SummaryEditPageProps) 
   return (
     <div>
       <div className="mb-6">
-        <h1 className="font-display text-2xl font-bold text-ctp-text">
+        <h1 className="font-display text-2xl font-bold text-on-surface">
           {monthLabel} — Zusammenfassung bearbeiten
         </h1>
-        <p className="text-xs text-sand-400 mt-1">
+        <p className="text-xs text-on-surface-variant mt-1">
           Generiert am {summary.generatedAt.toLocaleDateString('de-CH', { day: 'numeric', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
         </p>
       </div>

--- a/src/app/admin/summaries/page.tsx
+++ b/src/app/admin/summaries/page.tsx
@@ -24,17 +24,17 @@ export default async function SummariesPage() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="font-display text-2xl font-bold text-ctp-text">
+        <h1 className="font-display text-2xl font-bold text-on-surface">
           Monats-Zusammenfassungen
         </h1>
       </div>
 
       {/* Generator */}
-      <div className="bg-ctp-base rounded-xl border border-ctp-surface1 p-5 mb-6">
-        <h2 className="font-display text-sm font-semibold text-ctp-text mb-3">
+      <div className="bg-surface-container rounded-xl border border-surface-container-high p-5 mb-6">
+        <h2 className="font-display text-sm font-semibold text-on-surface mb-3">
           Neue Zusammenfassung generieren
         </h2>
-        <p className="text-xs text-sand-500 mb-4">
+        <p className="text-xs text-on-surface-variant mb-4">
           Claude analysiert alle Einträge und Metriken des gewählten Monats und erstellt einen Rückblick auf Deutsch und Englisch.
         </p>
         <GenerateSummaryForm defaultYear={currentYear} defaultMonth={currentMonth} />
@@ -42,7 +42,7 @@ export default async function SummariesPage() {
 
       {/* List */}
       {summaries.length === 0 ? (
-        <div className="text-center py-16 text-sand-400">
+        <div className="text-center py-16 text-on-surface-variant">
           <p>Noch keine Zusammenfassungen vorhanden.</p>
         </div>
       ) : (
@@ -50,13 +50,13 @@ export default async function SummariesPage() {
           {summaries.map((s) => (
             <div
               key={s.id}
-              className="bg-ctp-base rounded-xl border border-ctp-surface1 px-5 py-4 flex items-center gap-4 hover:border-sand-300 dark:hover:border-ctp-overlay2 transition-colors"
+              className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4 flex items-center gap-4 hover:border-outline hover:border-on-surface-variant transition-colors"
             >
               <div className="flex-1 min-w-0">
-                <p className="font-display font-semibold text-ctp-text text-sm">
+                <p className="font-display font-semibold text-on-surface text-sm">
                   {formatMonth(s.year, s.month)}
                 </p>
-                <p className="text-xs text-sand-400 mt-0.5">
+                <p className="text-xs text-on-surface-variant mt-0.5">
                   Generiert: {s.generatedAt.toLocaleDateString('de-CH', { day: 'numeric', month: 'short', year: 'numeric' })}
                   {' · '}
                   {s.contentEn ? 'DE + EN' : 'Nur DE'}
@@ -66,13 +66,13 @@ export default async function SummariesPage() {
                 <Link
                   href={`/de/monthly/${monthSlug(s.year, s.month)}`}
                   target="_blank"
-                  className="text-xs px-3 py-1.5 border border-ctp-surface1 rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-ctp-overlay2 hover:text-ctp-text transition-colors"
+                  className="text-xs px-3 py-1.5 border border-surface-container-high rounded-lg text-on-surface-variant text-on-surface-variant hover:border-outline hover:border-on-surface-variant hover:text-on-surface transition-colors"
                 >
                   Ansehen
                 </Link>
                 <Link
                   href={`/admin/summaries/${s.id}/edit`}
-                  className="text-xs px-3 py-1.5 bg-ctp-surface0 border border-ctp-surface1 rounded-lg text-ctp-text hover:border-sand-300 dark:hover:border-ctp-overlay2 transition-colors"
+                  className="text-xs px-3 py-1.5 bg-surface-container border border-surface-container-high rounded-lg text-on-surface hover:border-outline hover:border-on-surface-variant transition-colors"
                 >
                   Bearbeiten
                 </Link>

--- a/src/app/admin/translations/[entryId]/page.tsx
+++ b/src/app/admin/translations/[entryId]/page.tsx
@@ -38,17 +38,17 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
           <div className="flex items-center gap-2 mb-1">
             <Link
               href="/admin/translations"
-              className="text-sm text-sand-400 hover:text-ctp-text transition-colors"
+              className="text-sm text-on-surface-variant hover:text-on-surface transition-colors"
             >
               ← Übersetzungen
             </Link>
           </div>
-          <h1 className="font-display text-2xl font-bold text-ctp-text">
+          <h1 className="font-display text-2xl font-bold text-on-surface">
             {entry.title}
           </h1>
           <div className="flex items-center gap-3 mt-1">
-            <span className="text-xs font-mono text-sand-400">Tag {getDayNumber(dateStr, startDate)}</span>
-            <span className="text-xs text-sand-400">{formatDate(entry.date)}</span>
+            <span className="text-xs font-mono text-on-surface-variant">Tag {getDayNumber(dateStr, startDate)}</span>
+            <span className="text-xs text-on-surface-variant">{formatDate(entry.date)}</span>
           </div>
         </div>
         <div className="flex items-center gap-3 shrink-0">
@@ -56,7 +56,7 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
             <Link
               href={`/en/journal/${entry.slug}`}
               target="_blank"
-              className="text-xs text-sand-400 hover:text-ctp-text transition-colors"
+              className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
             >
               EN ↗
             </Link>
@@ -65,7 +65,7 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
             <Link
               href={`/pt/journal/${entry.slug}`}
               target="_blank"
-              className="text-xs text-sand-400 hover:text-ctp-text transition-colors"
+              className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
             >
               PT ↗
             </Link>
@@ -77,25 +77,25 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* DE original (read-only) */}
         <div className="space-y-4">
-          <h2 className="text-sm font-semibold text-sand-500 uppercase tracking-wide flex items-center gap-2">
-            <span className="text-xs px-1.5 py-0.5 bg-ctp-surface0 text-sand-600 dark:text-sand-400 rounded font-mono">DE</span>
+          <h2 className="text-sm font-semibold text-on-surface-variant uppercase tracking-wide flex items-center gap-2">
+            <span className="text-xs px-1.5 py-0.5 bg-surface-container text-on-surface-variant text-on-surface-variant rounded font-mono">DE</span>
             Original
           </h2>
 
-          <div className="rounded-xl border border-ctp-surface1 bg-ctp-base p-4 space-y-4">
+          <div className="rounded-xl border border-surface-container-high bg-surface-container p-4 space-y-4">
             <div>
-              <p className="text-xs font-medium text-sand-400 uppercase tracking-wide mb-1">Titel</p>
-              <p className="text-sm font-semibold text-ctp-text">{entry.title}</p>
+              <p className="text-xs font-medium text-on-surface-variant uppercase tracking-wide mb-1">Titel</p>
+              <p className="text-sm font-semibold text-on-surface">{entry.title}</p>
             </div>
             {entry.excerpt && (
               <div>
-                <p className="text-xs font-medium text-sand-400 uppercase tracking-wide mb-1">Excerpt</p>
-                <p className="text-sm text-sand-600 dark:text-sand-400">{entry.excerpt}</p>
+                <p className="text-xs font-medium text-on-surface-variant uppercase tracking-wide mb-1">Excerpt</p>
+                <p className="text-sm text-on-surface-variant text-on-surface-variant">{entry.excerpt}</p>
               </div>
             )}
             <div>
-              <p className="text-xs font-medium text-sand-400 uppercase tracking-wide mb-1">Inhalt (HTML)</p>
-              <div className="text-xs font-mono text-sand-500 dark:text-sand-400 bg-ctp-mantle rounded-lg p-3 max-h-64 overflow-y-auto whitespace-pre-wrap break-all">
+              <p className="text-xs font-medium text-on-surface-variant uppercase tracking-wide mb-1">Inhalt (HTML)</p>
+              <div className="text-xs font-mono text-on-surface-variant text-on-surface-variant bg-surface-container-low rounded-lg p-3 max-h-64 overflow-y-auto whitespace-pre-wrap break-all">
                 {entry.content}
               </div>
             </div>
@@ -104,12 +104,12 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
 
         {/* EN translation (editable) */}
         <div className="space-y-4">
-          <h2 className="text-sm font-semibold text-sand-500 uppercase tracking-wide flex items-center gap-2">
-            <span className="text-xs px-1.5 py-0.5 bg-nutrition-100 dark:bg-nutrition-900/30 text-nutrition-700 dark:text-nutrition-400 rounded font-mono">EN</span>
+          <h2 className="text-sm font-semibold text-on-surface-variant uppercase tracking-wide flex items-center gap-2">
+            <span className="text-xs px-1.5 py-0.5 bg-nutrition-100 bg-nutrition-900/30 text-nutrition-700 text-nutrition-400 rounded font-mono">EN</span>
             Englisch
           </h2>
 
-          <div className="rounded-xl border border-ctp-surface1 bg-ctp-base p-4">
+          <div className="rounded-xl border border-surface-container-high bg-surface-container p-4">
             {enTranslation ? (
               <TranslationEditForm
                 entryId={entry.id}
@@ -120,7 +120,7 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
               />
             ) : (
               <div className="space-y-3 py-4">
-                <p className="text-sm text-sand-400 text-center">Noch keine EN-Übersetzung.</p>
+                <p className="text-sm text-on-surface-variant text-center">Noch keine EN-Übersetzung.</p>
                 <TranslationEditForm
                   entryId={entry.id}
                   locale="en"
@@ -135,12 +135,12 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
 
         {/* PT translation (editable) */}
         <div className="space-y-4">
-          <h2 className="text-sm font-semibold text-sand-500 uppercase tracking-wide flex items-center gap-2">
-            <span className="text-xs px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded font-mono">PT</span>
+          <h2 className="text-sm font-semibold text-on-surface-variant uppercase tracking-wide flex items-center gap-2">
+            <span className="text-xs px-1.5 py-0.5 bg-blue-100 bg-blue-900/30 text-blue-700 text-blue-400 rounded font-mono">PT</span>
             Portugiesisch (BR)
           </h2>
 
-          <div className="rounded-xl border border-ctp-surface1 bg-ctp-base p-4">
+          <div className="rounded-xl border border-surface-container-high bg-surface-container p-4">
             {ptTranslation ? (
               <TranslationEditForm
                 entryId={entry.id}
@@ -151,7 +151,7 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
               />
             ) : (
               <div className="space-y-3 py-4">
-                <p className="text-sm text-sand-400 text-center">Noch keine PT-Übersetzung.</p>
+                <p className="text-sm text-on-surface-variant text-center">Noch keine PT-Übersetzung.</p>
                 <TranslationEditForm
                   entryId={entry.id}
                   locale="pt"

--- a/src/app/admin/translations/page.tsx
+++ b/src/app/admin/translations/page.tsx
@@ -19,7 +19,7 @@ function getStatus(
 function StatusBadge({ status }: { status: TranslationStatus }) {
   if (status === 'current') {
     return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-movement-100 dark:bg-movement-900/30 text-movement-700 dark:text-movement-400 rounded-full">
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-movement-100 bg-movement-900/30 text-movement-700 text-movement-400 rounded-full">
         <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M20 6L9 17l-5-5" />
         </svg>
@@ -29,7 +29,7 @@ function StatusBadge({ status }: { status: TranslationStatus }) {
   }
   if (status === 'stale') {
     return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-full">
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-amber-100 bg-amber-900/30 text-amber-700 text-amber-400 rounded-full">
         <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
         </svg>
@@ -38,7 +38,7 @@ function StatusBadge({ status }: { status: TranslationStatus }) {
     )
   }
   return (
-    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-ctp-surface0 text-sand-500 rounded-full">
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-surface-container text-on-surface-variant rounded-full">
       <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
         <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
       </svg>
@@ -75,29 +75,29 @@ export default async function TranslationsPage() {
 
   return (
     <div>
-      <h1 className="font-display text-2xl font-bold text-ctp-text mb-6">
+      <h1 className="font-display text-2xl font-bold text-on-surface mb-6">
         Übersetzungen
       </h1>
 
       {/* Stats */}
       <div className="grid grid-cols-3 gap-3 mb-6">
-        <div className="bg-ctp-base rounded-xl border border-ctp-surface1 px-5 py-4">
-          <p className="text-2xl font-bold font-display text-movement-600 dark:text-movement-400">{countCurrent}</p>
-          <p className="text-xs text-sand-400 mt-0.5">Übersetzt</p>
+        <div className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4">
+          <p className="text-2xl font-bold font-display text-movement-600 text-movement-400">{countCurrent}</p>
+          <p className="text-xs text-on-surface-variant mt-0.5">Übersetzt</p>
         </div>
-        <div className="bg-ctp-base rounded-xl border border-ctp-surface1 px-5 py-4">
-          <p className="text-2xl font-bold font-display text-amber-600 dark:text-amber-400">{countStale}</p>
-          <p className="text-xs text-sand-400 mt-0.5">Veraltet</p>
+        <div className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4">
+          <p className="text-2xl font-bold font-display text-amber-600 text-amber-400">{countStale}</p>
+          <p className="text-xs text-on-surface-variant mt-0.5">Veraltet</p>
         </div>
-        <div className="bg-ctp-base rounded-xl border border-ctp-surface1 px-5 py-4">
-          <p className="text-2xl font-bold font-display text-sand-500">{countMissing}</p>
-          <p className="text-xs text-sand-400 mt-0.5">Fehlen</p>
+        <div className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4">
+          <p className="text-2xl font-bold font-display text-on-surface-variant">{countMissing}</p>
+          <p className="text-xs text-on-surface-variant mt-0.5">Fehlen</p>
         </div>
       </div>
 
       {/* Entry list */}
       {entries.length === 0 ? (
-        <div className="text-center py-16 text-sand-400">
+        <div className="text-center py-16 text-on-surface-variant">
           <p>Noch keine Einträge vorhanden.</p>
         </div>
       ) : (
@@ -109,23 +109,23 @@ export default async function TranslationsPage() {
             return (
               <div
                 key={entry.id}
-                className="bg-ctp-base rounded-xl border border-ctp-surface1 px-5 py-4 flex items-center gap-4 hover:border-sand-300 dark:hover:border-ctp-overlay2 transition-colors"
+                className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4 flex items-center gap-4 hover:border-outline hover:border-on-surface-variant transition-colors"
               >
-                <span className="text-xs font-mono text-sand-400 shrink-0 w-8 text-right">
+                <span className="text-xs font-mono text-on-surface-variant shrink-0 w-8 text-right">
                   {getDayNumber(dateStr, startDate)}
                 </span>
 
                 <div className="flex-1 min-w-0">
-                  <p className="font-display font-semibold text-ctp-text truncate text-sm">
+                  <p className="font-display font-semibold text-on-surface truncate text-sm">
                     {entry.title}
                   </p>
-                  <time className="text-xs text-sand-400">{formatDate(entry.date)}</time>
+                  <time className="text-xs text-on-surface-variant">{formatDate(entry.date)}</time>
                 </div>
 
                 <div className="flex items-center gap-1.5 shrink-0">
-                  <span className="text-xs font-mono text-sand-400">EN</span>
+                  <span className="text-xs font-mono text-on-surface-variant">EN</span>
                   <StatusBadge status={enStatus} />
-                  <span className="text-xs font-mono text-sand-400 ml-2">PT</span>
+                  <span className="text-xs font-mono text-on-surface-variant ml-2">PT</span>
                   <StatusBadge status={ptStatus} />
                 </div>
 
@@ -137,7 +137,7 @@ export default async function TranslationsPage() {
                   />
                   <Link
                     href={`/admin/translations/${entry.id}`}
-                    className="text-xs px-3 py-1.5 border border-ctp-surface1 rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-ctp-overlay2 hover:text-ctp-text transition-colors"
+                    className="text-xs px-3 py-1.5 border border-surface-container-high rounded-lg text-on-surface-variant text-on-surface-variant hover:border-outline hover:border-on-surface-variant hover:text-on-surface transition-colors"
                   >
                     Bearbeiten
                   </Link>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,8 +58,8 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   const [locale, headersList] = await Promise.all([getLocale(), headers()])
   const nonce = headersList.get('x-nonce') ?? undefined
   return (
-    <html lang={locale} className={`${playfair.variable} ${lora.variable}`} suppressHydrationWarning>
-      <body className="bg-ctp-mantle text-ctp-text font-body antialiased">
+    <html lang={locale} className={`${playfair.variable} ${lora.variable}`}>
+      <body className="bg-background text-on-surface font-body antialiased">
         <ThemeProvider nonce={nonce}>
           <AuthSessionProvider>
             {children}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -46,8 +46,8 @@ function NavLink({ href, label, exact }: { href: string; label: string; exact: b
       className={clsx(
         'block px-3 py-1.5 rounded-lg text-sm transition-colors',
         isActive
-          ? 'bg-ctp-surface0 text-ctp-text font-medium'
-          : 'text-ctp-subtext1 hover:text-ctp-text hover:bg-ctp-surface0'
+          ? 'bg-surface-container text-on-surface font-medium'
+          : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container'
       )}
     >
       {label}
@@ -62,7 +62,7 @@ export function AdminSidebar() {
       {NAV_GROUPS.map((group, i) => (
         <div key={i}>
           {group.label && (
-            <p className="px-3 mb-1 text-[10px] font-semibold tracking-widest uppercase text-ctp-overlay1">
+            <p className="px-3 mb-1 text-[10px] font-semibold tracking-widest uppercase text-on-surface-variant">
               {group.label}
             </p>
           )}
@@ -92,8 +92,8 @@ export function AdminNavMobile() {
             className={clsx(
               'flex-none px-3 py-1.5 rounded-lg text-sm whitespace-nowrap transition-colors',
               isActive
-                ? 'bg-ctp-surface0 text-ctp-text font-medium'
-                : 'text-ctp-subtext1 hover:text-ctp-text hover:bg-ctp-surface0'
+                ? 'bg-surface-container text-on-surface font-medium'
+                : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container'
             )}
           >
             {label}

--- a/src/components/admin/BannerUpload.tsx
+++ b/src/components/admin/BannerUpload.tsx
@@ -79,14 +79,14 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
 
   return (
     <div>
-      <label className="block text-xs font-medium text-sand-500 mb-1">
+      <label className="block text-xs font-medium text-on-surface-variant mb-1">
         Banner-Bild{' '}
-        <span className="text-sand-400 font-normal">(optional · 16:7 · max 5 MB · JPEG/PNG/WebP)</span>
+        <span className="text-on-surface-variant font-normal">(optional · 16:7 · max 5 MB · JPEG/PNG/WebP)</span>
       </label>
 
       {value ? (
         /* Vorschau mit Aktionen */
-        <div className="relative rounded-xl overflow-hidden bg-ctp-surface0 border border-ctp-surface1">
+        <div className="relative rounded-xl overflow-hidden bg-surface-container border border-surface-container-high">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={value}
@@ -99,7 +99,7 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
               type="button"
               onClick={handleGenerate}
               disabled={busy}
-              className="px-3 py-1.5 bg-white/90 dark:bg-ctp-base/90 backdrop-blur-sm border border-ctp-surface1 rounded-lg text-xs font-medium text-ctp-mauve hover:bg-white dark:hover:bg-ctp-base transition-colors shadow-sm disabled:opacity-50"
+              className="px-3 py-1.5 bg-white/90 bg-surface-container/90 backdrop-blur-sm border border-surface-container-high rounded-lg text-xs font-medium text-tertiary hover:bg-white hover:bg-surface-container transition-colors shadow-sm disabled:opacity-50"
             >
               {generating ? 'Generiert...' : 'AI neu'}
             </button>
@@ -107,7 +107,7 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
               type="button"
               onClick={() => inputRef.current?.click()}
               disabled={busy}
-              className="px-3 py-1.5 bg-white/90 dark:bg-ctp-base/90 backdrop-blur-sm border border-ctp-surface1 rounded-lg text-xs font-medium text-ctp-text hover:bg-white dark:hover:bg-ctp-base transition-colors shadow-sm disabled:opacity-50"
+              className="px-3 py-1.5 bg-white/90 bg-surface-container/90 backdrop-blur-sm border border-surface-container-high rounded-lg text-xs font-medium text-on-surface hover:bg-white hover:bg-surface-container transition-colors shadow-sm disabled:opacity-50"
             >
               {uploading ? 'Lädt...' : 'Ersetzen'}
             </button>
@@ -115,7 +115,7 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
               type="button"
               onClick={() => onChange(undefined)}
               disabled={busy}
-              className="px-3 py-1.5 bg-white/90 dark:bg-ctp-base/90 backdrop-blur-sm border border-red-200 dark:border-red-800/40 rounded-lg text-xs font-medium text-red-600 dark:text-red-400 hover:bg-white dark:hover:bg-ctp-base transition-colors shadow-sm disabled:opacity-50"
+              className="px-3 py-1.5 bg-white/90 bg-surface-container/90 backdrop-blur-sm border border-red-200 border-red-800/40 rounded-lg text-xs font-medium text-red-600 text-red-400 hover:bg-white hover:bg-surface-container transition-colors shadow-sm disabled:opacity-50"
             >
               Entfernen
             </button>
@@ -129,14 +129,14 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
             type="button"
             onClick={() => inputRef.current?.click()}
             disabled={busy}
-            className="flex-1 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-ctp-surface1 rounded-xl bg-ctp-base hover:bg-sand-100 dark:hover:bg-ctp-surface0 hover:border-sand-300 dark:hover:border-ctp-overlay2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-surface-container-high rounded-xl bg-surface-container hover:bg-surface-container hover:bg-surface-container hover:border-outline hover:border-on-surface-variant transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {uploading ? (
-              <span className="text-sm text-sand-400">Hochladen...</span>
+              <span className="text-sm text-on-surface-variant">Hochladen...</span>
             ) : (
               <>
                 <svg
-                  className="w-8 h-8 text-sand-300"
+                  className="w-8 h-8 text-outline"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth={1.5}
@@ -148,7 +148,7 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
                     d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
                   />
                 </svg>
-                <span className="text-sm text-sand-400 font-medium">Bild hochladen</span>
+                <span className="text-sm text-on-surface-variant font-medium">Bild hochladen</span>
               </>
             )}
           </button>
@@ -158,24 +158,24 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
             type="button"
             onClick={handleGenerate}
             disabled={busy}
-            className="flex-1 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-ctp-mauve/40 rounded-xl bg-ctp-base hover:bg-ctp-mauve/5 hover:border-ctp-mauve/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-tertiary/40 rounded-xl bg-surface-container hover:bg-tertiary/5 hover:border-tertiary/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {generating ? (
               <>
                 <svg
-                  className="w-8 h-8 text-ctp-mauve animate-spin"
+                  className="w-8 h-8 text-tertiary animate-spin"
                   fill="none"
                   viewBox="0 0 24 24"
                 >
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>
-                <span className="text-sm text-ctp-mauve font-medium">Wird generiert...</span>
+                <span className="text-sm text-tertiary font-medium">Wird generiert...</span>
               </>
             ) : (
               <>
                 <svg
-                  className="w-8 h-8 text-ctp-mauve/60"
+                  className="w-8 h-8 text-tertiary/60"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth={1.5}
@@ -187,8 +187,8 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
                     d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
                   />
                 </svg>
-                <span className="text-sm text-ctp-mauve/80 font-medium">AI generieren</span>
-                <span className="text-xs text-sand-400">aus Titel &amp; Inhalt</span>
+                <span className="text-sm text-tertiary/80 font-medium">AI generieren</span>
+                <span className="text-xs text-on-surface-variant">aus Titel &amp; Inhalt</span>
               </>
             )}
           </button>

--- a/src/components/admin/DeleteEntryButton.tsx
+++ b/src/components/admin/DeleteEntryButton.tsx
@@ -31,7 +31,7 @@ export function DeleteEntryButton({ id, title }: DeleteEntryButtonProps) {
     <>
       <button
         onClick={() => { setError(null); setShowConfirm(true) }}
-        className="text-xs px-3 py-1.5 border border-red-200 dark:border-red-900/50 rounded-lg text-red-500 dark:text-red-400 hover:border-red-300 dark:hover:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 hover:text-red-700 dark:hover:text-red-300 transition-colors"
+        className="text-xs px-3 py-1.5 border border-red-200 border-red-900/50 rounded-lg text-red-500 text-red-400 hover:border-red-300 hover:border-red-800 hover:bg-red-50 hover:bg-red-950/30 hover:text-red-700 hover:text-red-300 transition-colors"
       >
         Löschen
       </button>
@@ -54,18 +54,18 @@ export function DeleteEntryButton({ id, title }: DeleteEntryButtonProps) {
           />
 
           {/* Dialog */}
-          <div className="relative bg-ctp-base rounded-2xl border border-ctp-surface1 shadow-xl p-6 max-w-sm w-full space-y-4">
+          <div className="relative bg-surface-container rounded-2xl border border-surface-container-high shadow-xl p-6 max-w-sm w-full space-y-4">
             <div className="flex items-start gap-3">
               <span className="text-2xl leading-none mt-0.5" aria-hidden="true">🗑️</span>
               <div>
                 <h2
                   id="delete-dialog-title"
-                  className="font-display font-bold text-lg text-ctp-text leading-tight"
+                  className="font-display font-bold text-lg text-on-surface leading-tight"
                 >
                   Eintrag löschen?
                 </h2>
-                <p className="text-sm text-sand-500 dark:text-sand-400 mt-1">
-                  <span className="font-medium text-ctp-text">&bdquo;{title}&ldquo;</span>{' '}
+                <p className="text-sm text-on-surface-variant text-on-surface-variant mt-1">
+                  <span className="font-medium text-on-surface">&bdquo;{title}&ldquo;</span>{' '}
                   wird dauerhaft gelöscht &mdash; inklusive aller Reaktionen.
                 </p>
               </div>
@@ -75,7 +75,7 @@ export function DeleteEntryButton({ id, title }: DeleteEntryButtonProps) {
               <button
                 onClick={() => setShowConfirm(false)}
                 disabled={isPending}
-                className="px-4 py-2 text-sm border border-ctp-surface1 rounded-xl text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-ctp-overlay2 hover:text-ctp-text transition-colors disabled:opacity-50"
+                className="px-4 py-2 text-sm border border-surface-container-high rounded-xl text-on-surface-variant text-on-surface-variant hover:border-outline hover:border-on-surface-variant hover:text-on-surface transition-colors disabled:opacity-50"
               >
                 Abbrechen
               </button>

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -98,15 +98,15 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
   return (
     <div className="space-y-4">
       {/* Editor / Vorschau Toggle */}
-      <div className="flex items-center gap-1 bg-ctp-mantle rounded-lg p-1 w-fit">
+      <div className="flex items-center gap-1 bg-surface-container-low rounded-lg p-1 w-fit">
         <button
           type="button"
           onClick={() => setIsPreview(false)}
           className={clsx(
             'px-3 py-1 rounded-md text-sm font-medium transition-colors',
             !isPreview
-              ? 'bg-ctp-surface0 text-ctp-text shadow-sm'
-              : 'text-sand-500 hover:text-ctp-text'
+              ? 'bg-surface-container text-on-surface shadow-sm'
+              : 'text-on-surface-variant hover:text-on-surface'
           )}
         >
           Bearbeiten
@@ -117,8 +117,8 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
           className={clsx(
             'px-3 py-1 rounded-md text-sm font-medium transition-colors',
             isPreview
-              ? 'bg-ctp-surface0 text-ctp-text shadow-sm'
-              : 'text-sand-500 hover:text-ctp-text'
+              ? 'bg-surface-container text-on-surface shadow-sm'
+              : 'text-on-surface-variant hover:text-on-surface'
           )}
         >
           Vorschau
@@ -139,7 +139,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
       ) : (
     <form onSubmit={handleSubmit} className="space-y-6">
       {error && (
-        <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40 rounded-lg text-sm text-red-700 dark:text-red-400">
+        <div className="p-3 bg-red-50 bg-red-900/20 border border-red-200 border-red-800/40 rounded-lg text-sm text-red-700 text-red-400">
           {error}
         </div>
       )}
@@ -152,28 +152,28 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Titel des Eintrags"
           required
-          className="w-full font-display text-2xl font-bold bg-transparent border-0 border-b-2 border-ctp-surface1 focus:border-nutrition-500 focus:outline-none pb-2 text-ctp-text placeholder:text-sand-300 transition-colors"
+          className="w-full font-display text-2xl font-bold bg-transparent border-0 border-b-2 border-surface-container-high focus:border-nutrition-500 focus:outline-none pb-2 text-on-surface placeholder:text-outline transition-colors"
         />
       </div>
 
       {/* Datum + Slug + Veröffentlicht */}
       <div className="flex flex-wrap items-end gap-4">
         <div className="flex-none">
-          <label className="block text-xs font-medium text-sand-500 mb-1">Datum</label>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">Datum</label>
           <input
             type="date"
             value={date}
             onChange={(e) => handleDateChange(e.target.value)}
             required
-            className="border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+            className="border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
           />
         </div>
 
         <div className="flex-1 min-w-[180px]">
-          <label className="block text-xs font-medium text-sand-500 mb-1">
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">
             Slug{' '}
             {mode === 'edit' && (
-              <span className="text-sand-400 font-normal">(nicht änderbar)</span>
+              <span className="text-on-surface-variant font-normal">(nicht änderbar)</span>
             )}
           </label>
           <input
@@ -183,10 +183,10 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
             readOnly={mode === 'edit'}
             required
             className={clsx(
-              'w-full border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm font-mono focus:outline-none bg-ctp-surface0',
+              'w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm font-mono focus:outline-none bg-surface-container',
               mode === 'edit'
-                ? 'text-sand-400 cursor-default'
-                : 'text-ctp-text focus:border-sand-400'
+                ? 'text-on-surface-variant cursor-default'
+                : 'text-on-surface focus:border-on-surface-variant'
             )}
           />
         </div>
@@ -197,7 +197,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
             onClick={() => setPublished((p) => !p)}
             className={clsx(
               'relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none',
-              published ? 'bg-movement-500' : 'bg-sand-300'
+              published ? 'bg-movement-500' : 'bg-outline'
             )}
           >
             <span
@@ -207,21 +207,21 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
               )}
             />
           </button>
-          <span className="text-sm text-sand-500">{published ? 'Veröffentlicht' : 'Entwurf'}</span>
+          <span className="text-sm text-on-surface-variant">{published ? 'Veröffentlicht' : 'Entwurf'}</span>
         </div>
       </div>
 
       {/* Tags */}
       <div>
-        <label className="block text-xs font-medium text-sand-500 mb-1">
-          Tags <span className="text-sand-400 font-normal">(kommagetrennt, optional)</span>
+        <label className="block text-xs font-medium text-on-surface-variant mb-1">
+          Tags <span className="text-on-surface-variant font-normal">(kommagetrennt, optional)</span>
         </label>
         <input
           type="text"
           value={tags}
           onChange={(e) => setTags(e.target.value)}
           placeholder="motivation, training, ernährung"
-          className="w-full border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+          className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
         />
       </div>
 
@@ -230,7 +230,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
 
       {/* Tiptap Editor */}
       <div>
-        <label className="block text-xs font-medium text-sand-500 mb-1">Inhalt</label>
+        <label className="block text-xs font-medium text-on-surface-variant mb-1">Inhalt</label>
         <TiptapEditor
           content={content}
           onChange={setContent}
@@ -240,16 +240,16 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
 
       {/* Excerpt */}
       <div>
-        <label className="block text-xs font-medium text-sand-500 mb-1">
+        <label className="block text-xs font-medium text-on-surface-variant mb-1">
           Kurzbeschreibung{' '}
-          <span className="text-sand-400 font-normal">(optional — für SEO, RSS, Suche &amp; Feed-Vorschau; wird sonst automatisch generiert)</span>
+          <span className="text-on-surface-variant font-normal">(optional — für SEO, RSS, Suche &amp; Feed-Vorschau; wird sonst automatisch generiert)</span>
         </label>
         <textarea
           value={excerpt}
           onChange={(e) => setExcerpt(e.target.value)}
           rows={2}
           placeholder="1–2 Sätze, die den Eintrag zusammenfassen..."
-          className="w-full border border-ctp-surface1 rounded-lg px-3 py-2 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0 resize-none"
+          className="w-full border border-surface-container-high rounded-lg px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container resize-none"
         />
       </div>
 
@@ -268,7 +268,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
         <button
           type="button"
           onClick={() => router.back()}
-          className="text-sm text-sand-500 hover:text-ctp-text transition-colors"
+          className="text-sm text-on-surface-variant hover:text-on-surface transition-colors"
         >
           ← Abbrechen
         </button>

--- a/src/components/admin/EntryPreview.tsx
+++ b/src/components/admin/EntryPreview.tsx
@@ -50,7 +50,7 @@ function HabitBadge({ label, fulfilled, colorClass }: HabitBadgeProps) {
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-        fulfilled ? colorClass : 'bg-ctp-surface0 text-sand-500'
+        fulfilled ? colorClass : 'bg-surface-container text-on-surface-variant'
       }`}
     >
       <span className={`w-1.5 h-1.5 rounded-full bg-current ${fulfilled ? '' : 'opacity-30'}`} />
@@ -105,21 +105,21 @@ export function EntryPreview({
     .filter(Boolean)
 
   return (
-    <div className="bg-ctp-base rounded-xl border border-ctp-surface1 overflow-hidden">
+    <div className="bg-surface-container rounded-xl border border-surface-container-high overflow-hidden">
       {/* Preview label */}
-      <div className="flex items-center gap-2 px-4 py-2 bg-ctp-surface0 border-b border-ctp-surface1">
-        <svg className="w-3.5 h-3.5 text-sand-400" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
+      <div className="flex items-center gap-2 px-4 py-2 bg-surface-container border-b border-surface-container-high">
+        <svg className="w-3.5 h-3.5 text-on-surface-variant" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.964-7.178Z" />
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
         </svg>
-        <span className="text-xs font-medium text-sand-500">Vorschau</span>
-        <span className="text-xs text-sand-400">— so sieht der Eintrag nach der Veröffentlichung aus</span>
+        <span className="text-xs font-medium text-on-surface-variant">Vorschau</span>
+        <span className="text-xs text-on-surface-variant">— so sieht der Eintrag nach der Veröffentlichung aus</span>
       </div>
 
       <article className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
         {/* Banner */}
         {bannerUrl && (
-          <div className="relative w-full aspect-[16/7] rounded-2xl overflow-hidden mb-10 bg-ctp-surface0">
+          <div className="relative w-full aspect-[16/7] rounded-2xl overflow-hidden mb-10 bg-surface-container">
             <Image
               src={bannerUrl}
               alt={title}
@@ -133,19 +133,19 @@ export function EntryPreview({
         {/* Header */}
         <header className="mb-10">
           <div className="flex items-center gap-3 mb-4">
-            <span className="font-display font-bold text-xs tracking-widest uppercase text-sand-400 border border-ctp-surface1 rounded px-2 py-0.5">
+            <span className="font-display font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-2 py-0.5">
               Tag {dayNumber}
             </span>
             {formattedDate && (
               <>
-                <span className="text-sand-300 dark:text-ctp-surface1 select-none" aria-hidden="true">·</span>
-                <time className="text-sm text-sand-400">{formattedDate}</time>
+                <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
+                <time className="text-sm text-on-surface-variant">{formattedDate}</time>
               </>
             )}
           </div>
 
-          <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight text-ctp-text mb-5">
-            {title || <span className="text-sand-300 font-normal italic">Titel…</span>}
+          <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight text-on-surface mb-5">
+            {title || <span className="text-outline font-normal italic">Titel…</span>}
           </h1>
 
           {/* Habit badges */}
@@ -153,17 +153,17 @@ export function EntryPreview({
             <HabitBadge
               label={MOVEMENT_LABELS[movement]}
               fulfilled={isMovementOk(movement)}
-              colorClass="bg-movement-100 dark:bg-movement-600/20 text-movement-700 dark:text-movement-400"
+              colorClass="bg-movement-100 bg-movement-600/20 text-movement-700 text-movement-400"
             />
             <HabitBadge
               label={NUTRITION_LABELS[nutrition]}
               fulfilled={isNutritionOk(nutrition)}
-              colorClass="bg-nutrition-100 dark:bg-nutrition-600/20 text-nutrition-700 dark:text-nutrition-400"
+              colorClass="bg-nutrition-100 bg-nutrition-600/20 text-nutrition-700 text-nutrition-400"
             />
             <HabitBadge
               label={SMOKING_LABELS[smoking]}
               fulfilled={isSmokingOk(smoking)}
-              colorClass="bg-smoking-100 dark:bg-smoking-600/20 text-smoking-700 dark:text-smoking-400"
+              colorClass="bg-smoking-100 bg-smoking-600/20 text-smoking-700 text-smoking-400"
             />
           </div>
 
@@ -173,7 +173,7 @@ export function EntryPreview({
               {tagList.map((tag) => (
                 <li
                   key={tag}
-                  className="text-xs px-2.5 py-1 bg-ctp-surface0 text-sand-500 rounded-full"
+                  className="text-xs px-2.5 py-1 bg-surface-container text-on-surface-variant rounded-full"
                 >
                   #{tag}
                 </li>
@@ -182,16 +182,16 @@ export function EntryPreview({
           )}
         </header>
 
-        <hr className="border-ctp-surface1 mb-10" />
+        <hr className="border-surface-container-high mb-10" />
 
         {/* Content */}
         {content ? (
           <div
-            className="prose prose-stone prose-lg max-w-none dark:prose-invert"
+            className="prose prose-stone prose-lg max-w-none prose-invert"
             dangerouslySetInnerHTML={{ __html: content }}
           />
         ) : (
-          <p className="text-sand-300 dark:text-ctp-surface1 italic text-sm">Noch kein Inhalt…</p>
+          <p className="text-outline text-surface-container-high italic text-sm">Noch kein Inhalt…</p>
         )}
       </article>
     </div>

--- a/src/components/admin/FitbitSyncPanel.tsx
+++ b/src/components/admin/FitbitSyncPanel.tsx
@@ -10,14 +10,14 @@ import type { FitbitSyncResult } from '@/lib/fitbit'
 
 function ResultRow({ r }: { r: FitbitSyncResult }) {
   return (
-    <tr className="border-b border-ctp-surface0 last:border-0 text-xs">
-      <td className="px-4 py-2.5 font-mono text-sand-500">{r.date}</td>
-      <td className="px-4 py-2.5 text-ctp-text">{r.weight != null ? `${r.weight} kg` : '—'}</td>
-      <td className="px-4 py-2.5 text-ctp-text">{r.bodyFat != null ? `${r.bodyFat}%` : '—'}</td>
-      <td className="px-4 py-2.5 text-ctp-text">
+    <tr className="border-b border-surface-container last:border-0 text-xs">
+      <td className="px-4 py-2.5 font-mono text-on-surface-variant">{r.date}</td>
+      <td className="px-4 py-2.5 text-on-surface">{r.weight != null ? `${r.weight} kg` : '—'}</td>
+      <td className="px-4 py-2.5 text-on-surface">{r.bodyFat != null ? `${r.bodyFat}%` : '—'}</td>
+      <td className="px-4 py-2.5 text-on-surface">
         {r.activeMinutes != null ? `${r.activeMinutes} min` : '—'}
       </td>
-      <td className="px-4 py-2.5 text-ctp-text">
+      <td className="px-4 py-2.5 text-on-surface">
         {r.restingHR != null ? `${r.restingHR} bpm` : '—'}
       </td>
     </tr>
@@ -28,7 +28,7 @@ function SyncResultDisplay({ outcome }: { outcome: SyncActionResult }) {
   return (
     <div className="mt-4 space-y-3">
       {outcome.error && (
-        <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40 rounded-lg text-sm text-red-700 dark:text-red-400">
+        <div className="p-3 bg-red-50 bg-red-900/20 border border-red-200 border-red-800/40 rounded-lg text-sm text-red-700 text-red-400">
           {outcome.error}
           {outcome.rateLimitSeconds != null && (
             <span className="ml-1 text-red-500">
@@ -38,22 +38,22 @@ function SyncResultDisplay({ outcome }: { outcome: SyncActionResult }) {
         </div>
       )}
       {outcome.tokensRefreshed && (
-        <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40 rounded-lg text-sm text-amber-700 dark:text-amber-400">
+        <div className="p-3 bg-amber-50 bg-amber-900/20 border border-amber-200 border-amber-800/40 rounded-lg text-sm text-amber-700 text-amber-400">
           Tokens wurden erneuert — bitte <code>FITBIT_ACCESS_TOKEN</code> und{' '}
           <code>FITBIT_REFRESH_TOKEN</code> im Server-Log ablesen und in <code>.env</code>{' '}
           aktualisieren.
         </div>
       )}
       {outcome.results && outcome.results.length > 0 && !outcome.error && (
-        <div className="p-3 bg-movement-100 dark:bg-movement-600/10 border border-movement-200 dark:border-movement-600/20 rounded-lg text-sm text-movement-700 dark:text-movement-400">
+        <div className="p-3 bg-movement-100 bg-movement-600/10 border border-movement-200 border-movement-600/20 rounded-lg text-sm text-movement-700 text-movement-400">
           {outcome.results.length === 1 ? 'Sync erfolgreich.' : `${outcome.results.length} Tage synchronisiert.`}
         </div>
       )}
       {outcome.results && outcome.results.length > 0 && (
-        <div className="bg-ctp-base rounded-xl border border-ctp-surface1 overflow-x-auto">
+        <div className="bg-surface-container rounded-xl border border-surface-container-high overflow-x-auto">
           <table className="w-full text-xs">
             <thead>
-              <tr className="border-b border-ctp-surface0 text-sand-500 text-left">
+              <tr className="border-b border-surface-container text-on-surface-variant text-left">
                 <th className="px-4 py-2.5 font-medium">Datum</th>
                 <th className="px-4 py-2.5 font-medium">Gewicht</th>
                 <th className="px-4 py-2.5 font-medium">Körperfett</th>
@@ -115,19 +115,19 @@ export function FitbitSyncPanel() {
   return (
     <div className="space-y-6">
       {/* Single day */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-4">
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">
           Einzelnen Tag synchronisieren
         </h3>
         <div className="flex flex-wrap items-end gap-3">
           <div>
-            <label className="block text-xs font-medium text-sand-500 mb-1">Datum</label>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Datum</label>
             <input
               type="date"
               value={singleDate}
               max={todayString()}
               onChange={(e) => setSingleDate(e.target.value)}
-              className="border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+              className="border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
             />
           </div>
           <button
@@ -143,30 +143,30 @@ export function FitbitSyncPanel() {
       </div>
 
       {/* Date range backfill */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-1">
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">
           Zeitraum nachfüllen (Backfill)
         </h3>
-        <p className="text-xs text-sand-400 mb-4">Maximal 30 Tage auf einmal.</p>
+        <p className="text-xs text-on-surface-variant mb-4">Maximal 30 Tage auf einmal.</p>
         <div className="flex flex-wrap items-end gap-3">
           <div>
-            <label className="block text-xs font-medium text-sand-500 mb-1">Von</label>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Von</label>
             <input
               type="date"
               value={startDate}
               max={todayString()}
               onChange={(e) => setStartDate(e.target.value)}
-              className="border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+              className="border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
             />
           </div>
           <div>
-            <label className="block text-xs font-medium text-sand-500 mb-1">Bis</label>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Bis</label>
             <input
               type="date"
               value={endDate}
               max={todayString()}
               onChange={(e) => setEndDate(e.target.value)}
-              className="border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+              className="border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
             />
           </div>
           <button

--- a/src/components/admin/FlashMessage.tsx
+++ b/src/components/admin/FlashMessage.tsx
@@ -31,8 +31,8 @@ export function FlashMessage({ message, type = 'success' }: FlashMessageProps) {
 
   const styles =
     type === 'success'
-      ? 'bg-movement-100 dark:bg-movement-600/10 border-movement-200 dark:border-movement-600/20 text-movement-800 dark:text-movement-300'
-      : 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900/50 text-red-700 dark:text-red-400'
+      ? 'bg-movement-100 bg-movement-600/10 border-movement-200 border-movement-600/20 text-movement-800 text-movement-300'
+      : 'bg-red-50 bg-red-950/30 border-red-200 border-red-900/50 text-red-700 text-red-400'
 
   const icon = type === 'success' ? '✓' : '✕'
 

--- a/src/components/admin/GenerateSummaryForm.tsx
+++ b/src/components/admin/GenerateSummaryForm.tsx
@@ -34,12 +34,12 @@ export function GenerateSummaryForm({ defaultYear, defaultMonth }: GenerateSumma
   return (
     <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-3">
       <div className="flex flex-col gap-1">
-        <label className="text-xs text-sand-500 font-medium">Monat</label>
+        <label className="text-xs text-on-surface-variant font-medium">Monat</label>
         <select
           value={month}
           onChange={(e) => setMonth(Number(e.target.value))}
           disabled={isPending}
-          className="px-3 py-2 text-sm rounded-lg border border-ctp-surface1 bg-ctp-mantle text-ctp-text focus:outline-none focus:ring-2 focus:ring-nutrition-400"
+          className="px-3 py-2 text-sm rounded-lg border border-surface-container-high bg-surface-container-low text-on-surface focus:outline-none focus:ring-2 focus:ring-nutrition-400"
         >
           {MONTH_NAMES.map((name, i) => (
             <option key={i + 1} value={i + 1}>{name}</option>
@@ -47,12 +47,12 @@ export function GenerateSummaryForm({ defaultYear, defaultMonth }: GenerateSumma
         </select>
       </div>
       <div className="flex flex-col gap-1">
-        <label className="text-xs text-sand-500 font-medium">Jahr</label>
+        <label className="text-xs text-on-surface-variant font-medium">Jahr</label>
         <select
           value={year}
           onChange={(e) => setYear(Number(e.target.value))}
           disabled={isPending}
-          className="px-3 py-2 text-sm rounded-lg border border-ctp-surface1 bg-ctp-mantle text-ctp-text focus:outline-none focus:ring-2 focus:ring-nutrition-400"
+          className="px-3 py-2 text-sm rounded-lg border border-surface-container-high bg-surface-container-low text-on-surface focus:outline-none focus:ring-2 focus:ring-nutrition-400"
         >
           {years.map((y) => (
             <option key={y} value={y}>{y}</option>
@@ -67,7 +67,7 @@ export function GenerateSummaryForm({ defaultYear, defaultMonth }: GenerateSumma
         {isPending ? 'Generiert…' : 'Zusammenfassung generieren'}
       </button>
       {error && (
-        <p className="w-full text-xs text-red-600 dark:text-red-400 mt-1">{error}</p>
+        <p className="w-full text-xs text-red-600 text-red-400 mt-1">{error}</p>
       )}
     </form>
   )

--- a/src/components/admin/HabitSelector.tsx
+++ b/src/components/admin/HabitSelector.tsx
@@ -157,10 +157,10 @@ function FulfillmentDot({
   }
   if (fulfillment === 'partial') {
     return (
-      <span className="flex-none w-2 h-2 rounded-full bg-sand-300 ring-1 ring-sand-400 ring-offset-0" />
+      <span className="flex-none w-2 h-2 rounded-full bg-outline ring-1 ring-on-surface-variant ring-offset-0" />
     )
   }
-  return <span className="flex-none w-2 h-2 rounded-full bg-sand-200" />
+  return <span className="flex-none w-2 h-2 rounded-full bg-surface-container-high" />
 }
 
 // =============================================
@@ -207,7 +207,7 @@ export function HabitSelector<T extends HabitValue>({
                 'group flex items-center gap-3 w-full text-left px-3.5 py-2.5 rounded-xl border transition-all duration-150',
                 isSelected
                   ? [cfg.accentBg, cfg.accentBorder, cfg.accentText, 'shadow-sm']
-                  : 'bg-white border-sand-200 text-ctp-text hover:border-sand-300 hover:bg-sand-50'
+                  : 'bg-white border-surface-container-high text-on-surface hover:border-outline hover:bg-background'
               )}
             >
               {/* Fulfillment-Indikator */}
@@ -218,7 +218,7 @@ export function HabitSelector<T extends HabitValue>({
                 <span
                   className={clsx(
                     'block text-xs font-semibold leading-tight',
-                    isSelected ? cfg.accentText : 'text-ctp-text'
+                    isSelected ? cfg.accentText : 'text-on-surface'
                   )}
                 >
                   {opt.label}
@@ -226,7 +226,7 @@ export function HabitSelector<T extends HabitValue>({
                 <span
                   className={clsx(
                     'block text-xs leading-tight mt-0.5',
-                    isSelected ? 'opacity-75' : 'text-sand-400'
+                    isSelected ? 'opacity-75' : 'text-on-surface-variant'
                   )}
                 >
                   {opt.description}

--- a/src/components/admin/HabitsPicker.tsx
+++ b/src/components/admin/HabitsPicker.tsx
@@ -38,7 +38,7 @@ function PreviewBadge({ label, fulfilled, colorClass }: PreviewBadgeProps) {
     <span
       className={clsx(
         'inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full',
-        fulfilled ? colorClass : 'bg-ctp-surface1 text-sand-500'
+        fulfilled ? colorClass : 'bg-surface-container-high text-on-surface-variant'
       )}
     >
       <span
@@ -88,17 +88,17 @@ export function HabitsPicker({
   ].filter(Boolean).length
 
   return (
-    <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 overflow-hidden">
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-ctp-surface0">
-        <h3 className="font-display text-sm font-semibold text-ctp-text">Die drei Säulen</h3>
+      <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-surface-container">
+        <h3 className="font-display text-sm font-semibold text-on-surface">Die drei Säulen</h3>
         <span
           className={clsx(
             'text-xs font-medium px-2 py-0.5 rounded-full',
             fulfilledCount === 3
               ? 'bg-movement-100 text-movement-700'
               : fulfilledCount === 0
-              ? 'bg-sand-100 text-sand-500'
+              ? 'bg-surface-container text-on-surface-variant'
               : 'bg-nutrition-100 text-nutrition-700'
           )}
         >
@@ -129,8 +129,8 @@ export function HabitsPicker({
       </div>
 
       {/* Live-Vorschau */}
-      <div className="flex items-center gap-3 px-5 py-3 bg-ctp-surface0 border-t border-ctp-surface1">
-        <span className="text-xs text-sand-400 shrink-0">Vorschau:</span>
+      <div className="flex items-center gap-3 px-5 py-3 bg-surface-container border-t border-surface-container-high">
+        <span className="text-xs text-on-surface-variant shrink-0">Vorschau:</span>
         <div className="flex flex-wrap gap-1.5">
           <PreviewBadge
             label={movementLabel}

--- a/src/components/admin/MetricsForm.tsx
+++ b/src/components/admin/MetricsForm.tsx
@@ -22,8 +22,8 @@ interface FieldProps {
 function MetricField({ label, unit, value, onChange, placeholder = '—', step = 'any', inputMode = 'decimal' }: FieldProps) {
   return (
     <div>
-      <label className="block text-xs font-medium text-sand-500 mb-1">
-        {label} <span className="font-normal text-sand-400">({unit})</span>
+      <label className="block text-xs font-medium text-on-surface-variant mb-1">
+        {label} <span className="font-normal text-on-surface-variant">({unit})</span>
       </label>
       <input
         type="number"
@@ -33,7 +33,7 @@ function MetricField({ label, unit, value, onChange, placeholder = '—', step =
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+        className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
       />
     </div>
   )
@@ -98,7 +98,7 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
         <button
           type="button"
           onClick={prevDay}
-          className="p-1.5 rounded-lg border border-ctp-surface1 text-sand-500 hover:text-ctp-text hover:border-sand-300 transition-colors"
+          className="p-1.5 rounded-lg border border-surface-container-high text-on-surface-variant hover:text-on-surface hover:border-outline transition-colors"
           aria-label="Vorheriger Tag"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
@@ -109,12 +109,12 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
           type="date"
           value={date}
           onChange={(e) => handleDateChange(e.target.value)}
-          className="border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+          className="border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
         />
         <button
           type="button"
           onClick={nextDay}
-          className="p-1.5 rounded-lg border border-ctp-surface1 text-sand-500 hover:text-ctp-text hover:border-sand-300 transition-colors"
+          className="p-1.5 rounded-lg border border-surface-container-high text-on-surface-variant hover:text-on-surface hover:border-outline transition-colors"
           aria-label="Nächster Tag"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
@@ -124,8 +124,8 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
       </div>
 
       {/* Körperwerte */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-4">Körperwerte</h3>
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">Körperwerte</h3>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <MetricField label="Gewicht" unit="kg" value={weight} onChange={setWeight} step="0.1" />
           <MetricField label="Körperfett" unit="%" value={bodyFat} onChange={setBodyFat} step="0.1" />
@@ -134,8 +134,8 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
       </div>
 
       {/* Aktivität */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-4">Aktivität</h3>
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">Aktivität</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <MetricField label="Schritte" unit="Schritte" value={steps} onChange={setSteps} step="1" inputMode="numeric" />
           <MetricField label="Aktive Minuten" unit="min" value={activeMinutes} onChange={setActiveMinutes} step="1" inputMode="numeric" />
@@ -145,8 +145,8 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
       </div>
 
       {/* Vitalwerte */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-4">Vitalwerte</h3>
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">Vitalwerte</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <MetricField label="Ruheherzfrequenz" unit="bpm" value={restingHR} onChange={setRestingHR} step="1" inputMode="numeric" />
           <MetricField label="Schlafdauer" unit="min" value={sleepDuration} onChange={setSleepDuration} step="1" inputMode="numeric" />
@@ -155,12 +155,12 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
 
       {/* Feedback */}
       {error && (
-        <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40 rounded-lg text-sm text-red-700 dark:text-red-400">
+        <div className="p-3 bg-red-50 bg-red-900/20 border border-red-200 border-red-800/40 rounded-lg text-sm text-red-700 text-red-400">
           {error}
         </div>
       )}
       {success && (
-        <div className="p-3 bg-movement-50 dark:bg-movement-600/10 border border-movement-200 dark:border-movement-600/20 rounded-lg text-sm text-movement-700 dark:text-movement-400">
+        <div className="p-3 bg-movement-50 bg-movement-600/10 border border-movement-200 border-movement-600/20 rounded-lg text-sm text-movement-700 text-movement-400">
           Metriken gespeichert.
         </div>
       )}

--- a/src/components/admin/SettingsForm.tsx
+++ b/src/components/admin/SettingsForm.tsx
@@ -21,10 +21,10 @@ interface FieldProps {
 function SettingField({ label, unit, hint, value, onChange, placeholder = '—', step = 'any', inputMode = 'decimal' }: FieldProps) {
   return (
     <div>
-      <label className="block text-xs font-medium text-sand-500 mb-1">
-        {label} <span className="font-normal text-sand-400">({unit})</span>
+      <label className="block text-xs font-medium text-on-surface-variant mb-1">
+        {label} <span className="font-normal text-on-surface-variant">({unit})</span>
       </label>
-      {hint && <p className="text-xs text-sand-400 mb-1.5">{hint}</p>}
+      {hint && <p className="text-xs text-on-surface-variant mb-1.5">{hint}</p>}
       <input
         type="number"
         inputMode={inputMode}
@@ -33,7 +33,7 @@ function SettingField({ label, unit, hint, value, onChange, placeholder = '—',
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+        className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
       />
     </div>
   )
@@ -67,9 +67,9 @@ export function SettingsForm({ initial }: SettingsFormProps) {
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {/* Körperprofil */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-1">Körperprofil</h3>
-        <p className="text-xs text-sand-400 mb-4">Wird für die automatische BMI-Berechnung verwendet.</p>
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">Körperprofil</h3>
+        <p className="text-xs text-on-surface-variant mb-4">Wird für die automatische BMI-Berechnung verwendet.</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <SettingField
             label="Körpergrösse"
@@ -83,9 +83,9 @@ export function SettingsForm({ initial }: SettingsFormProps) {
       </div>
 
       {/* Ziele */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-1">Ziele</h3>
-        <p className="text-xs text-sand-400 mb-4">Persönliche Zielwerte für die Metriken-Darstellung.</p>
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">Ziele</h3>
+        <p className="text-xs text-on-surface-variant mb-4">Persönliche Zielwerte für die Metriken-Darstellung.</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <SettingField
             label="Zielgewicht"
@@ -108,12 +108,12 @@ export function SettingsForm({ initial }: SettingsFormProps) {
       </div>
 
       {/* Projekt */}
-      <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-        <h3 className="font-display text-sm font-semibold text-ctp-text mb-1">Projekt</h3>
-        <p className="text-xs text-sand-400 mb-4">Bestimmt den Projekttag für alle Anzeigen (Tag 1 = Startdatum).</p>
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">Projekt</h3>
+        <p className="text-xs text-on-surface-variant mb-4">Bestimmt den Projekttag für alle Anzeigen (Tag 1 = Startdatum).</p>
         <div className="max-w-xs">
-          <label className="block text-xs font-medium text-sand-500 mb-1">
-            Startdatum <span className="font-normal text-sand-400">(YYYY-MM-DD)</span>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">
+            Startdatum <span className="font-normal text-on-surface-variant">(YYYY-MM-DD)</span>
           </label>
           <input
             type="date"
@@ -121,20 +121,20 @@ export function SettingsForm({ initial }: SettingsFormProps) {
             onChange={(e) => setProjectStartDate(e.target.value)}
             max={new Date().toISOString().slice(0, 10)}
             placeholder="2026-03-26"
-            className="w-full border border-ctp-surface1 rounded-lg px-3 py-1.5 text-sm text-ctp-text focus:outline-none focus:border-sand-400 bg-ctp-surface0"
+            className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
           />
-          <p className="text-xs text-sand-400 mt-1">Default: 2026-03-26 (falls nicht gesetzt)</p>
+          <p className="text-xs text-on-surface-variant mt-1">Default: 2026-03-26 (falls nicht gesetzt)</p>
         </div>
       </div>
 
       {/* Feedback */}
       {error && (
-        <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40 rounded-lg text-sm text-red-700 dark:text-red-400">
+        <div className="p-3 bg-red-50 bg-red-900/20 border border-red-200 border-red-800/40 rounded-lg text-sm text-red-700 text-red-400">
           {error}
         </div>
       )}
       {success && (
-        <div className="p-3 bg-movement-50 dark:bg-movement-600/10 border border-movement-200 dark:border-movement-600/20 rounded-lg text-sm text-movement-700 dark:text-movement-400">
+        <div className="p-3 bg-movement-50 bg-movement-600/10 border border-movement-200 border-movement-600/20 rounded-lg text-sm text-movement-700 text-movement-400">
           Einstellungen gespeichert.
         </div>
       )}

--- a/src/components/admin/SummaryEditForm.tsx
+++ b/src/components/admin/SummaryEditForm.tsx
@@ -51,7 +51,7 @@ export function SummaryEditForm({ summary }: SummaryEditFormProps) {
   return (
     <form onSubmit={handleSave} className="space-y-4">
       {/* Tabs */}
-      <div className="flex gap-2 border-b border-ctp-surface1">
+      <div className="flex gap-2 border-b border-surface-container-high">
         {(['de', 'en'] as const).map((lang) => (
           <button
             key={lang}
@@ -59,8 +59,8 @@ export function SummaryEditForm({ summary }: SummaryEditFormProps) {
             onClick={() => setActiveTab(lang)}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
               activeTab === lang
-                ? 'border-nutrition-600 text-nutrition-700 dark:text-nutrition-400'
-                : 'border-transparent text-sand-500 hover:text-ctp-text'
+                ? 'border-nutrition-600 text-nutrition-700 text-nutrition-400'
+                : 'border-transparent text-on-surface-variant hover:text-on-surface'
             }`}
           >
             {lang === 'de' ? 'Deutsch' : 'English'}
@@ -75,7 +75,7 @@ export function SummaryEditForm({ summary }: SummaryEditFormProps) {
             value={contentDe}
             onChange={(e) => setContentDe(e.target.value)}
             rows={24}
-            className="w-full font-mono text-xs px-4 py-3 rounded-xl border border-ctp-surface1 bg-ctp-mantle text-ctp-text focus:outline-none focus:ring-2 focus:ring-nutrition-400 resize-none"
+            className="w-full font-mono text-xs px-4 py-3 rounded-xl border border-surface-container-high bg-surface-container-low text-on-surface focus:outline-none focus:ring-2 focus:ring-nutrition-400 resize-none"
             placeholder="HTML-Content auf Deutsch…"
           />
         ) : (
@@ -83,7 +83,7 @@ export function SummaryEditForm({ summary }: SummaryEditFormProps) {
             value={contentEn}
             onChange={(e) => setContentEn(e.target.value)}
             rows={24}
-            className="w-full font-mono text-xs px-4 py-3 rounded-xl border border-ctp-surface1 bg-ctp-mantle text-ctp-text focus:outline-none focus:ring-2 focus:ring-nutrition-400 resize-none"
+            className="w-full font-mono text-xs px-4 py-3 rounded-xl border border-surface-container-high bg-surface-container-low text-on-surface focus:outline-none focus:ring-2 focus:ring-nutrition-400 resize-none"
             placeholder="HTML content in English…"
           />
         )}
@@ -95,7 +95,7 @@ export function SummaryEditForm({ summary }: SummaryEditFormProps) {
           type="button"
           onClick={handleDelete}
           disabled={isDeleting}
-          className="text-xs text-red-500 hover:text-red-700 dark:hover:text-red-400 transition-colors disabled:opacity-50"
+          className="text-xs text-red-500 hover:text-red-700 hover:text-red-400 transition-colors disabled:opacity-50"
         >
           {isDeleting ? 'Löschen…' : 'Zusammenfassung löschen'}
         </button>
@@ -104,15 +104,15 @@ export function SummaryEditForm({ summary }: SummaryEditFormProps) {
           <a
             href={`/de/monthly/${monthSlug}`}
             target="_blank"
-            className="text-xs px-3 py-2 border border-ctp-surface1 rounded-lg text-sand-600 dark:text-sand-400 hover:border-sand-300 hover:text-ctp-text transition-colors"
+            className="text-xs px-3 py-2 border border-surface-container-high rounded-lg text-on-surface-variant text-on-surface-variant hover:border-outline hover:text-on-surface transition-colors"
           >
             Vorschau
           </a>
           {saved && (
-            <span className="text-xs text-movement-600 dark:text-movement-400">Gespeichert ✓</span>
+            <span className="text-xs text-movement-600 text-movement-400">Gespeichert ✓</span>
           )}
           {error && (
-            <span className="text-xs text-red-600 dark:text-red-400">{error}</span>
+            <span className="text-xs text-red-600 text-red-400">{error}</span>
           )}
           <button
             type="submit"

--- a/src/components/admin/TiptapEditor.tsx
+++ b/src/components/admin/TiptapEditor.tsx
@@ -32,8 +32,8 @@ function ToolbarButton({ onClick, active, title, children }: ToolbarButtonProps)
       className={clsx(
         'p-1.5 rounded text-sm transition-colors',
         active
-          ? 'bg-ctp-surface1 text-ctp-text'
-          : 'text-sand-500 hover:bg-sand-100 dark:hover:bg-ctp-surface1 hover:text-ctp-text'
+          ? 'bg-surface-container-high text-on-surface'
+          : 'text-on-surface-variant hover:bg-surface-container hover:bg-surface-container-high hover:text-on-surface'
       )}
     >
       {children}
@@ -42,7 +42,7 @@ function ToolbarButton({ onClick, active, title, children }: ToolbarButtonProps)
 }
 
 function Divider() {
-  return <div className="w-px h-5 bg-ctp-surface1 mx-1" />
+  return <div className="w-px h-5 bg-surface-container-high mx-1" />
 }
 
 export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorProps) {
@@ -86,9 +86,9 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
   }
 
   return (
-    <div className="border border-ctp-surface1 rounded-xl overflow-hidden bg-ctp-base focus-within:border-sand-400 transition-colors">
+    <div className="border border-surface-container-high rounded-xl overflow-hidden bg-surface-container focus-within:border-on-surface-variant transition-colors">
       {/* Toolbar */}
-      <div className="flex flex-wrap items-center gap-0.5 px-3 py-2 border-b border-ctp-surface0 bg-ctp-surface0">
+      <div className="flex flex-wrap items-center gap-0.5 px-3 py-2 border-b border-surface-container bg-surface-container">
         <ToolbarButton
           onClick={() => editor.chain().focus().toggleBold().run()}
           active={editor.isActive('bold')}
@@ -217,7 +217,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
       {/* Editor */}
       <EditorContent
         editor={editor}
-        className="prose prose-stone prose-lg dark:prose-invert max-w-none [&_.tiptap]:focus:outline-none [&_.tiptap_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.tiptap_p.is-editor-empty:first-child::before]:text-sand-400 [&_.tiptap_p.is-editor-empty:first-child::before]:pointer-events-none [&_.tiptap_p.is-editor-empty:first-child::before]:float-left [&_.tiptap_p.is-editor-empty:first-child::before]:h-0"
+        className="prose prose-stone prose-lg prose-invert max-w-none [&_.tiptap]:focus:outline-none [&_.tiptap_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.tiptap_p.is-editor-empty:first-child::before]:text-on-surface-variant [&_.tiptap_p.is-editor-empty:first-child::before]:pointer-events-none [&_.tiptap_p.is-editor-empty:first-child::before]:float-left [&_.tiptap_p.is-editor-empty:first-child::before]:h-0"
       />
     </div>
   )

--- a/src/components/admin/TranslateButton.tsx
+++ b/src/components/admin/TranslateButton.tsx
@@ -36,12 +36,12 @@ export function TranslateButton({ id, isTranslated, isStale = false }: Translate
         }
         className={`text-xs px-3 py-1.5 border rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
           error
-            ? 'border-red-300 dark:border-red-700 text-red-600 dark:text-red-400'
+            ? 'border-red-300 border-red-700 text-red-600 text-red-400'
             : isOutdated
-              ? 'border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20'
+              ? 'border-amber-300 border-amber-700 text-amber-700 text-amber-400 hover:bg-amber-50 hover:bg-amber-900/20'
               : isTranslated
-                ? 'border-movement-300 dark:border-movement-700 text-movement-700 dark:text-movement-400 hover:bg-movement-50 dark:hover:bg-movement-900/20'
-                : 'border-ctp-surface1 text-sand-600 dark:text-sand-400 hover:border-sand-300 dark:hover:border-ctp-overlay2 hover:text-ctp-text'
+                ? 'border-movement-300 border-movement-700 text-movement-700 text-movement-400 hover:bg-movement-50 hover:bg-movement-900/20'
+                : 'border-surface-container-high text-on-surface-variant text-on-surface-variant hover:border-outline hover:border-on-surface-variant hover:text-on-surface'
         }`}
       >
         {isPending ? (
@@ -78,11 +78,11 @@ export function TranslateButton({ id, isTranslated, isStale = false }: Translate
       </button>
 
       {error && (
-        <div className="absolute right-0 top-full mt-1 z-10 w-72 rounded-lg border border-red-200 dark:border-red-800 bg-ctp-base shadow-lg p-3">
-          <p className="text-xs text-red-600 dark:text-red-400 leading-snug">{error}</p>
+        <div className="absolute right-0 top-full mt-1 z-10 w-72 rounded-lg border border-red-200 border-red-800 bg-surface-container shadow-lg p-3">
+          <p className="text-xs text-red-600 text-red-400 leading-snug">{error}</p>
           <button
             onClick={() => setError(null)}
-            className="mt-1.5 text-xs text-sand-400 hover:text-sand-600 dark:hover:text-sand-300 transition-colors"
+            className="mt-1.5 text-xs text-on-surface-variant hover:text-on-surface-variant hover:text-outline transition-colors"
           >
             Schließen
           </button>

--- a/src/components/admin/TranslationEditForm.tsx
+++ b/src/components/admin/TranslationEditForm.tsx
@@ -56,51 +56,51 @@ export function TranslationEditForm({
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-xs font-medium text-sand-500 uppercase tracking-wide mb-1.5">
+        <label className="block text-xs font-medium text-on-surface-variant uppercase tracking-wide mb-1.5">
           Titel
         </label>
         <input
           type="text"
           value={title}
           onChange={(e) => { setTitle(e.target.value); setSaveSuccess(false) }}
-          className="w-full px-3 py-2 text-sm bg-ctp-base border border-ctp-surface1 rounded-lg text-ctp-text focus:outline-none focus:border-nutrition-500 dark:focus:border-nutrition-400 transition-colors"
+          className="w-full px-3 py-2 text-sm bg-surface-container border border-surface-container-high rounded-lg text-on-surface focus:outline-none focus:border-nutrition-500 focus:border-nutrition-400 transition-colors"
         />
       </div>
 
       <div>
-        <label className="block text-xs font-medium text-sand-500 uppercase tracking-wide mb-1.5">
+        <label className="block text-xs font-medium text-on-surface-variant uppercase tracking-wide mb-1.5">
           Excerpt
         </label>
         <textarea
           value={excerpt}
           onChange={(e) => { setExcerpt(e.target.value); setSaveSuccess(false) }}
           rows={3}
-          className="w-full px-3 py-2 text-sm bg-ctp-base border border-ctp-surface1 rounded-lg text-ctp-text focus:outline-none focus:border-nutrition-500 dark:focus:border-nutrition-400 transition-colors resize-y"
+          className="w-full px-3 py-2 text-sm bg-surface-container border border-surface-container-high rounded-lg text-on-surface focus:outline-none focus:border-nutrition-500 focus:border-nutrition-400 transition-colors resize-y"
         />
       </div>
 
       <div>
-        <label className="block text-xs font-medium text-sand-500 uppercase tracking-wide mb-1.5">
+        <label className="block text-xs font-medium text-on-surface-variant uppercase tracking-wide mb-1.5">
           Inhalt (HTML)
         </label>
         <textarea
           value={content}
           onChange={(e) => { setContent(e.target.value); setSaveSuccess(false) }}
           rows={14}
-          className="w-full px-3 py-2 text-xs font-mono bg-ctp-base border border-ctp-surface1 rounded-lg text-ctp-text focus:outline-none focus:border-nutrition-500 dark:focus:border-nutrition-400 transition-colors resize-y"
+          className="w-full px-3 py-2 text-xs font-mono bg-surface-container border border-surface-container-high rounded-lg text-on-surface focus:outline-none focus:border-nutrition-500 focus:border-nutrition-400 transition-colors resize-y"
         />
       </div>
 
       {saveError && (
-        <p className="text-sm text-red-600 dark:text-red-400">{saveError}</p>
+        <p className="text-sm text-red-600 text-red-400">{saveError}</p>
       )}
       {translateError && (
-        <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-3">
-          <p className="text-sm text-red-600 dark:text-red-400 leading-snug">{translateError}</p>
+        <div className="rounded-lg border border-red-200 border-red-800 bg-red-50 bg-red-900/20 p-3">
+          <p className="text-sm text-red-600 text-red-400 leading-snug">{translateError}</p>
         </div>
       )}
       {saveSuccess && (
-        <p className="text-sm text-movement-600 dark:text-movement-400">Gespeichert ✓</p>
+        <p className="text-sm text-movement-600 text-movement-400">Gespeichert ✓</p>
       )}
 
       <div className="flex items-center gap-3 pt-1">
@@ -114,7 +114,7 @@ export function TranslationEditForm({
         <button
           onClick={handleRetranslate}
           disabled={isSaving || isTranslating}
-          className="flex items-center gap-2 px-4 py-2 border border-ctp-surface1 rounded-xl text-sm font-medium text-sand-600 dark:text-sand-400 hover:border-sand-300 hover:text-ctp-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-2 px-4 py-2 border border-surface-container-high rounded-xl text-sm font-medium text-on-surface-variant text-on-surface-variant hover:border-outline hover:text-on-surface transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isTranslating ? (
             <>

--- a/src/components/admin/analytics/ViewsChart.tsx
+++ b/src/components/admin/analytics/ViewsChart.tsx
@@ -37,8 +37,8 @@ interface TooltipProps {
 function ViewsTooltip({ active, payload, label }: TooltipProps) {
   if (!active || !payload?.length) return null
   return (
-    <div className="bg-ctp-base border border-ctp-surface1 rounded-lg px-3 py-2 text-sm shadow-sm">
-      <p className="text-sand-400 text-xs mb-1">{label ? formatDateShort(label) : ''}</p>
+    <div className="bg-surface-container border border-surface-container-high rounded-lg px-3 py-2 text-sm shadow-sm">
+      <p className="text-on-surface-variant text-xs mb-1">{label ? formatDateShort(label) : ''}</p>
       {payload.map((p) => (
         <p key={p.name} className="font-semibold" style={{ color: p.color }}>
           {p.value} {p.name === 'views' ? 'Aufrufe' : 'Besucher'}

--- a/src/components/habits/HabitHeatmap.tsx
+++ b/src/components/habits/HabitHeatmap.tsx
@@ -6,23 +6,23 @@ type Pillar = 'movement' | 'nutrition' | 'smoking'
 const COLOR_BY_LEVEL: Record<Pillar, string[]> = {
   // index = level + 1  (level -1 → index 0)
   movement:  [
-    'bg-ctp-mantle',
-    'bg-ctp-surface0',
-    'bg-movement-200 dark:bg-movement-800/40',
-    'bg-movement-500 dark:bg-movement-400',
+    'bg-surface-container-low',
+    'bg-surface-container',
+    'bg-movement-200 bg-movement-800/40',
+    'bg-movement-500 bg-movement-400',
   ],
   nutrition: [
-    'bg-ctp-mantle',
-    'bg-ctp-surface0',
-    'bg-nutrition-100 dark:bg-nutrition-800/30',
-    'bg-nutrition-400 dark:bg-nutrition-500',
-    'bg-nutrition-500 dark:bg-nutrition-400',
+    'bg-surface-container-low',
+    'bg-surface-container',
+    'bg-nutrition-100 bg-nutrition-800/30',
+    'bg-nutrition-400 bg-nutrition-500',
+    'bg-nutrition-500 bg-nutrition-400',
   ],
   smoking: [
-    'bg-ctp-mantle',
-    'bg-ctp-surface0',
-    'bg-smoking-200 dark:bg-smoking-800/40',
-    'bg-smoking-500 dark:bg-smoking-400',
+    'bg-surface-container-low',
+    'bg-surface-container',
+    'bg-smoking-200 bg-smoking-800/40',
+    'bg-smoking-500 bg-smoking-400',
   ],
 }
 
@@ -63,7 +63,7 @@ export function HabitHeatmap({ days, pillar }: HabitHeatmapProps) {
     <div className="space-y-1.5">
       <div className="flex flex-wrap gap-0.5">
         {visible.map(({ date, level }) => {
-          const colorClass = colors[level + 1] ?? 'bg-ctp-mantle'
+          const colorClass = colors[level + 1] ?? 'bg-surface-container-low'
           return (
             <div
               key={date}
@@ -73,7 +73,7 @@ export function HabitHeatmap({ days, pillar }: HabitHeatmapProps) {
           )
         })}
       </div>
-      <p className="text-xs text-sand-400">
+      <p className="text-xs text-on-surface-variant">
         {t('dayCount', { count: visible.length })}
       </p>
     </div>

--- a/src/components/habits/HabitPillar.tsx
+++ b/src/components/habits/HabitPillar.tsx
@@ -15,24 +15,24 @@ interface PillarConfig {
 const PILLAR_CONFIG: Record<Pillar, PillarConfig> = {
   movement: {
     emoji: '🏃',
-    bgClass: 'bg-movement-100 dark:bg-movement-600/10',
-    borderClass: 'border-movement-200 dark:border-movement-600/20',
-    textColorClass: 'text-movement-700 dark:text-movement-400',
-    barColorClass: 'bg-movement-500 dark:bg-movement-400',
+    bgClass: 'bg-movement-600/10',
+    borderClass: 'border-movement-600/20',
+    textColorClass: 'text-movement-400',
+    barColorClass: 'bg-movement-400',
   },
   nutrition: {
     emoji: '🥗',
-    bgClass: 'bg-nutrition-100 dark:bg-nutrition-600/10',
-    borderClass: 'border-nutrition-200 dark:border-nutrition-600/20',
-    textColorClass: 'text-nutrition-700 dark:text-nutrition-400',
-    barColorClass: 'bg-nutrition-500 dark:bg-nutrition-400',
+    bgClass: 'bg-nutrition-600/10',
+    borderClass: 'border-nutrition-600/20',
+    textColorClass: 'text-nutrition-400',
+    barColorClass: 'bg-nutrition-400',
   },
   smoking: {
     emoji: '🚭',
-    bgClass: 'bg-smoking-100 dark:bg-smoking-600/10',
-    borderClass: 'border-smoking-200 dark:border-smoking-600/20',
-    textColorClass: 'text-smoking-700 dark:text-smoking-400',
-    barColorClass: 'bg-smoking-500 dark:bg-smoking-400',
+    bgClass: 'bg-smoking-600/10',
+    borderClass: 'border-smoking-600/20',
+    textColorClass: 'text-smoking-400',
+    barColorClass: 'bg-smoking-400',
   },
 }
 

--- a/src/components/habits/HabitStreak.tsx
+++ b/src/components/habits/HabitStreak.tsx
@@ -30,9 +30,9 @@ export function HabitStreak({
           <span className={`text-5xl font-bold font-display leading-none ${textColorClass}`}>
             {current}
           </span>
-          <span className="text-sm text-sand-500 font-medium leading-tight">{label}</span>
+          <span className="text-sm text-on-surface-variant font-medium leading-tight">{label}</span>
         </div>
-        <p className="text-xs text-sand-400 mt-1 h-4">
+        <p className="text-xs text-on-surface-variant mt-1 h-4">
           {isRecord
             ? t('record')
             : longest > current && longest > 0
@@ -43,7 +43,7 @@ export function HabitStreak({
 
       {totalEntries > 0 && (
         <div className="space-y-1">
-          <div className="flex justify-between text-xs text-sand-400">
+          <div className="flex justify-between text-xs text-on-surface-variant">
             <span>
               {t('outOf', {
                 fulfilled: totalFulfilled,
@@ -53,7 +53,7 @@ export function HabitStreak({
             </span>
             <span>{pct}%</span>
           </div>
-          <div className="h-1 bg-ctp-surface1 rounded-full overflow-hidden">
+          <div className="h-1 bg-surface-container-high rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full ${barColorClass}`}
               style={{ width: `${pct}%` }}

--- a/src/components/habits/HabitYearGrid.tsx
+++ b/src/components/habits/HabitYearGrid.tsx
@@ -7,23 +7,23 @@ type Pillar = 'movement' | 'nutrition' | 'smoking'
 // All class names must be static strings for Tailwind to include them
 const COLOR_BY_LEVEL: Record<Pillar, readonly string[]> = {
   movement: [
-    'bg-ctp-mantle',            // -1: no entry
-    'bg-ctp-surface0',             //  0: minimal
-    'bg-movement-200 dark:bg-movement-800/40',   //  1: steps_only
-    'bg-movement-500 dark:bg-movement-400',      //  2: steps_trained
+    'bg-surface-container-low',            // -1: no entry
+    'bg-surface-container',             //  0: minimal
+    'bg-movement-200 bg-movement-800/40',   //  1: steps_only
+    'bg-movement-500 bg-movement-400',      //  2: steps_trained
   ],
   nutrition: [
-    'bg-ctp-mantle',
-    'bg-ctp-surface0',
-    'bg-nutrition-100 dark:bg-nutrition-800/30',
-    'bg-nutrition-400 dark:bg-nutrition-500',
-    'bg-nutrition-500 dark:bg-nutrition-400',
+    'bg-surface-container-low',
+    'bg-surface-container',
+    'bg-nutrition-100 bg-nutrition-800/30',
+    'bg-nutrition-400 bg-nutrition-500',
+    'bg-nutrition-500 bg-nutrition-400',
   ],
   smoking: [
-    'bg-ctp-mantle',
-    'bg-ctp-surface0',
-    'bg-smoking-200 dark:bg-smoking-800/40',
-    'bg-smoking-500 dark:bg-smoking-400',
+    'bg-surface-container-low',
+    'bg-surface-container',
+    'bg-smoking-200 bg-smoking-800/40',
+    'bg-smoking-500 bg-smoking-400',
   ],
 }
 
@@ -132,8 +132,8 @@ export function HabitYearGrid({ movementDays, nutritionDays, smokingDays }: Habi
   }
 
   return (
-    <div className="mt-3 bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
-      <h3 className="font-display text-sm font-semibold text-ctp-text mb-4">
+    <div className="mt-3 bg-surface-container rounded-2xl border border-surface-container-high p-5">
+      <h3 className="font-display text-sm font-semibold text-on-surface mb-4">
         {tDash('yearOverview')}
       </h3>
 
@@ -147,7 +147,7 @@ export function HabitYearGrid({ movementDays, nutritionDays, smokingDays }: Habi
               {monthLabels.map((label, i) => (
                 <div key={i} className="relative w-[11px] h-3.5">
                   {label && (
-                    <span className="absolute left-0 bottom-0 text-[9px] leading-none text-sand-400 whitespace-nowrap">
+                    <span className="absolute left-0 bottom-0 text-[9px] leading-none text-on-surface-variant whitespace-nowrap">
                       {label}
                     </span>
                   )}
@@ -186,7 +186,7 @@ export function HabitYearGrid({ movementDays, nutritionDays, smokingDays }: Habi
                           }
 
                           const level = levelMap.get(dateStr) ?? -1
-                          const colorClass = colors[level + 1] ?? 'bg-ctp-mantle'
+                          const colorClass = colors[level + 1] ?? 'bg-surface-container-low'
 
                           return (
                             <div
@@ -205,7 +205,7 @@ export function HabitYearGrid({ movementDays, nutritionDays, smokingDays }: Habi
           </div>
 
           {/* Day count */}
-          <p className="text-xs text-sand-400 mt-3 pl-[26px]">
+          <p className="text-xs text-on-surface-variant mt-3 pl-[26px]">
             {t('dayCount', { count: movementDays.length })}
           </p>
 

--- a/src/components/habits/HabitsDashboard.tsx
+++ b/src/components/habits/HabitsDashboard.tsx
@@ -60,8 +60,8 @@ export async function HabitsDashboard() {
   return (
     <section className="mb-14">
       <div className="flex items-baseline gap-3 mb-5">
-        <h2 className="font-display text-xl font-bold text-ctp-text">{t('heading')}</h2>
-        <span className="text-xs text-sand-400 font-medium tracking-wide uppercase">
+        <h2 className="font-display text-xl font-bold text-on-surface">{t('heading')}</h2>
+        <span className="text-xs text-on-surface-variant font-medium tracking-wide uppercase">
           {t('dayCount', { count: entries.length })}
         </span>
       </div>

--- a/src/components/home/HomeTabs.tsx
+++ b/src/components/home/HomeTabs.tsx
@@ -24,7 +24,7 @@ export function HomeTabs({ labels, entriesContent, habitsContent, metricsContent
   return (
     <div>
       {/* Tab Bar */}
-      <div className="flex gap-1 border-b border-sand-200 dark:border-ctp-surface0 mb-8">
+      <div className="flex gap-1 border-b border-surface-container-high border-surface-container mb-8">
         {tabs.map(({ id, label }) => (
           <button
             key={id}
@@ -32,8 +32,8 @@ export function HomeTabs({ labels, entriesContent, habitsContent, metricsContent
             className={clsx(
               'px-4 py-2.5 text-sm font-medium rounded-t-lg -mb-px border-b-2 transition-colors duration-150',
               activeTab === id
-                ? 'border-ctp-peach text-ctp-peach'
-                : 'border-transparent text-sand-500 hover:text-ctp-text hover:border-sand-300 dark:hover:border-ctp-surface2'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-on-surface-variant hover:text-on-surface hover:border-outline hover:border-surface-container-highest'
             )}
           >
             {label}

--- a/src/components/journal/HabitBadges.tsx
+++ b/src/components/journal/HabitBadges.tsx
@@ -45,20 +45,20 @@ export function HabitBadges({ habits }: HabitBadgesProps) {
       <HabitBadge
         label={t(`movement.${habits.movement}` as 'movement.minimal')}
         fulfilled={isMovementFulfilled(habits.movement)}
-        colorClass="bg-movement-100 dark:bg-movement-600/20 text-movement-700 dark:text-movement-400"
-        dimClass="bg-ctp-surface0 text-sand-500"
+        colorClass="bg-movement-600/20 text-movement-400"
+        dimClass="bg-surface-container text-on-surface-variant"
       />
       <HabitBadge
         label={t(`nutrition.${habits.nutrition}` as 'nutrition.none')}
         fulfilled={isNutritionFulfilled(habits.nutrition)}
-        colorClass="bg-nutrition-100 dark:bg-nutrition-600/20 text-nutrition-700 dark:text-nutrition-400"
-        dimClass="bg-ctp-surface0 text-sand-500"
+        colorClass="bg-nutrition-600/20 text-nutrition-400"
+        dimClass="bg-surface-container text-on-surface-variant"
       />
       <HabitBadge
         label={t(`smoking.${habits.smoking}` as 'smoking.smoked')}
         fulfilled={isSmokingFulfilled(habits.smoking)}
-        colorClass="bg-smoking-100 dark:bg-smoking-600/20 text-smoking-700 dark:text-smoking-400"
-        dimClass="bg-ctp-surface0 text-sand-500"
+        colorClass="bg-smoking-600/20 text-smoking-400"
+        dimClass="bg-surface-container text-on-surface-variant"
       />
     </div>
   )

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -29,11 +29,11 @@ export async function JournalCard({ entry }: JournalCardProps) {
   }
 
   return (
-    <article className="group bg-ctp-base rounded-2xl border border-ctp-surface1 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 overflow-hidden">
+    <article className="group bg-surface-container rounded-2xl border border-surface-container-high shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 overflow-hidden">
       <Link href={`/journal/${entry.slug}`} className="block">
 
         {entry.banner ? (
-          <div className="relative w-full aspect-[16/7] bg-ctp-surface0">
+          <div className="relative w-full aspect-[16/7] bg-surface-container">
             <Image
               src={entry.banner}
               alt={entry.title}
@@ -45,7 +45,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
         ) : (
           <div className="relative px-6 pt-5 pb-0 overflow-hidden select-none" aria-hidden="true">
             <span
-              className="block font-display font-bold leading-none text-sand-100 dark:text-ctp-surface0"
+              className="block font-display font-bold leading-none text-surface-container text-surface-container"
               style={{ fontSize: 'clamp(4.5rem, 18vw, 7.5rem)' }}
             >
               {String(dayNumber).padStart(2, '0')}
@@ -55,28 +55,28 @@ export async function JournalCard({ entry }: JournalCardProps) {
 
         <div className="px-6 py-5 space-y-3">
           <div className="flex items-center gap-2.5">
-            <span className="font-display font-bold text-xs tracking-widest uppercase text-sand-400 border border-ctp-surface1 rounded px-1.5 py-0.5">
+            <span className="font-display font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-1.5 py-0.5">
               {t('day', { number: dayNumber })}
             </span>
-            <span className="text-sand-300 dark:text-ctp-surface1 select-none" aria-hidden="true">·</span>
-            <time className="text-xs text-sand-400" dateTime={entry.date}>
+            <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
+            <time className="text-xs text-on-surface-variant" dateTime={entry.date}>
               {formatDate(entry.date)}
             </time>
           </div>
 
-          <h2 className="font-display text-xl sm:text-2xl font-bold leading-snug text-ctp-text group-hover:text-nutrition-700 dark:group-hover:text-nutrition-400 transition-colors duration-200">
+          <h2 className="font-display text-xl sm:text-2xl font-bold leading-snug text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-400 transition-colors duration-200">
             {entry.title}
           </h2>
 
           {excerpt && (
-            <p className="text-sm text-ctp-overlay2 dark:text-ctp-overlay2 leading-relaxed line-clamp-3">
+            <p className="text-sm text-on-surface-variant text-on-surface-variant leading-relaxed line-clamp-3">
               {excerpt}
             </p>
           )}
 
-          <div className="flex items-center justify-between gap-4 pt-1 border-t border-ctp-surface0">
+          <div className="flex items-center justify-between gap-4 pt-1 border-t border-surface-container">
             <HabitBadges habits={entry.habits} />
-            <span className="text-xs font-semibold text-nutrition-600 dark:text-nutrition-400 group-hover:text-nutrition-700 shrink-0 transition-colors">
+            <span className="text-xs font-semibold text-nutrition-600 text-nutrition-400 group-hover:text-nutrition-700 shrink-0 transition-colors">
               {t('readMore')}
             </span>
           </div>

--- a/src/components/journal/JournalCardCompact.tsx
+++ b/src/components/journal/JournalCardCompact.tsx
@@ -36,10 +36,10 @@ export async function JournalCardCompact({ entry }: JournalCardCompactProps) {
     <article className="group">
       <Link
         href={`/journal/${entry.slug}`}
-        className="flex items-center gap-4 px-4 pt-3 pb-2 rounded-t-xl hover:bg-sand-100 dark:hover:bg-ctp-surface0 transition-colors duration-150"
+        className="flex items-center gap-4 px-4 pt-3 pb-2 rounded-t-xl hover:bg-surface-container hover:bg-surface-container transition-colors duration-150"
       >
         {/* Thumbnail */}
-        <div className="relative flex-none w-14 h-14 rounded-lg overflow-hidden bg-ctp-surface0">
+        <div className="relative flex-none w-14 h-14 rounded-lg overflow-hidden bg-surface-container">
           {entry.banner ? (
             <Image
               src={entry.banner}
@@ -50,7 +50,7 @@ export async function JournalCardCompact({ entry }: JournalCardCompactProps) {
             />
           ) : (
             <span
-              className="absolute inset-0 flex items-center justify-center font-display font-bold text-sand-300 dark:text-ctp-surface2 text-sm"
+              className="absolute inset-0 flex items-center justify-center font-display font-bold text-outline text-surface-container-highest text-sm"
             >
               {String(dayNumber).padStart(2, '0')}
             </span>
@@ -60,20 +60,20 @@ export async function JournalCardCompact({ entry }: JournalCardCompactProps) {
         {/* Content */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-0.5">
-            <span className="text-xs font-medium text-sand-400 tabular-nums">
+            <span className="text-xs font-medium text-on-surface-variant tabular-nums">
               {t('day', { number: dayNumber })}
             </span>
-            <span className="text-sand-300 dark:text-ctp-surface2" aria-hidden="true">·</span>
-            <time className="text-xs text-sand-400" dateTime={entry.date}>
+            <span className="text-outline text-surface-container-highest" aria-hidden="true">·</span>
+            <time className="text-xs text-on-surface-variant" dateTime={entry.date}>
               {formatDate(entry.date)}
             </time>
             {/* Habit status dot */}
             <span
-              className={`ml-auto flex-none w-2 h-2 rounded-full ${allOk ? 'bg-movement-500' : 'bg-sand-300 dark:bg-ctp-surface2'}`}
+              className={`ml-auto flex-none w-2 h-2 rounded-full ${allOk ? 'bg-movement-500' : 'bg-outline bg-surface-container-highest'}`}
               title={allOk ? 'Alle Ziele erfüllt' : 'Ziele nicht alle erfüllt'}
             />
           </div>
-          <h2 className="text-sm font-semibold text-ctp-text line-clamp-1 group-hover:text-ctp-peach transition-colors">
+          <h2 className="text-sm font-semibold text-on-surface line-clamp-1 group-hover:text-primary transition-colors">
             {entry.title}
           </h2>
         </div>

--- a/src/components/journal/JournalFeed 2.tsx
+++ b/src/components/journal/JournalFeed 2.tsx
@@ -8,7 +8,7 @@ interface JournalFeedProps {
 export function JournalFeed({ entries }: JournalFeedProps) {
   if (entries.length === 0) {
     return (
-      <div className="py-20 text-center text-sand-400">
+      <div className="py-20 text-center text-on-surface-variant">
         <p className="font-display text-2xl mb-2">Noch keine Einträge</p>
         <p className="text-sm">Die ersten Einträge folgen bald.</p>
       </div>
@@ -16,7 +16,7 @@ export function JournalFeed({ entries }: JournalFeedProps) {
   }
 
   return (
-    <div className="divide-y divide-sand-200">
+    <div className="divide-y divide-surface-container-high">
       {entries.map((entry) => (
         <div key={entry.slug} className="py-12 first:pt-0">
           <JournalCard entry={entry} />

--- a/src/components/journal/JournalFeed.tsx
+++ b/src/components/journal/JournalFeed.tsx
@@ -12,8 +12,8 @@ export function JournalFeed({ entries }: JournalFeedProps) {
   if (entries.length === 0) {
     return (
       <div className="py-20 text-center">
-        <p className="font-display text-2xl text-sand-300 mb-2">{t('empty')}</p>
-        <p className="text-sm text-sand-400">{t('emptyHint')}</p>
+        <p className="font-display text-2xl text-outline mb-2">{t('empty')}</p>
+        <p className="text-sm text-on-surface-variant">{t('emptyHint')}</p>
       </div>
     )
   }

--- a/src/components/journal/JournalPost.tsx
+++ b/src/components/journal/JournalPost.tsx
@@ -35,7 +35,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
   return (
     <article className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
       {entry.banner && (
-        <div className="relative w-full aspect-[16/7] rounded-2xl overflow-hidden mb-10 bg-ctp-surface0">
+        <div className="relative w-full aspect-[16/7] rounded-2xl overflow-hidden mb-10 bg-surface-container">
           <Image
             src={entry.banner}
             alt={entry.title}
@@ -49,19 +49,19 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
 
       <header className="mb-10">
         <div className="flex items-center gap-3 mb-4">
-          <span className="font-display font-bold text-xs tracking-widest uppercase text-sand-400 border border-ctp-surface1 rounded px-2 py-0.5">
+          <span className="font-display font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-2 py-0.5">
             {t('day', { number: dayNumber })}
           </span>
-          <span className="text-sand-300 dark:text-ctp-surface1 select-none" aria-hidden="true">·</span>
-          <time className="text-sm text-sand-400" dateTime={entry.date}>
+          <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
+          <time className="text-sm text-on-surface-variant" dateTime={entry.date}>
             {formatDate(entry.date)}
           </time>
           {isAdmin && (
             <>
-              <span className="text-sand-300 dark:text-ctp-surface1 select-none" aria-hidden="true">·</span>
+              <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
               <Link
                 href={`/admin/entries/${entry.id}/edit`}
-                className="text-xs font-medium text-nutrition-600 dark:text-nutrition-500 hover:text-nutrition-700 dark:hover:text-nutrition-400 transition-colors"
+                className="text-xs font-medium text-nutrition-600 text-nutrition-500 hover:text-nutrition-700 hover:text-nutrition-400 transition-colors"
               >
                 {t('edit')}
               </Link>
@@ -69,7 +69,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
           )}
         </div>
 
-        <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight text-ctp-text mb-5">
+        <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight text-on-surface mb-5">
           {entry.title}
         </h1>
 
@@ -80,7 +80,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
             {entry.tags.map((tag) => (
               <li
                 key={tag}
-                className="text-xs px-2.5 py-1 bg-ctp-surface0 text-sand-500 rounded-full"
+                className="text-xs px-2.5 py-1 bg-surface-container text-on-surface-variant rounded-full"
               >
                 #{tag}
               </li>
@@ -89,26 +89,26 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
         )}
       </header>
 
-      <hr className="border-ctp-surface1 mb-10" />
+      <hr className="border-surface-container-high mb-10" />
 
       <div
-        className="prose prose-stone prose-lg max-w-none dark:prose-invert"
+        className="prose prose-stone prose-lg max-w-none prose-invert"
         dangerouslySetInnerHTML={{ __html: entry.content }}
       />
 
-      <div className="mt-14 pt-8 border-t border-ctp-surface1">
+      <div className="mt-14 pt-8 border-t border-surface-container-high">
         <ReactionBar slug={entry.slug} />
       </div>
 
-      <footer className="mt-8 pt-6 border-t border-ctp-surface0 flex items-center justify-between gap-4">
+      <footer className="mt-8 pt-6 border-t border-surface-container flex items-center justify-between gap-4">
         <Link
           href="/"
-          className="text-sm font-medium text-nutrition-700 dark:text-nutrition-400 hover:text-nutrition-600 transition-colors"
+          className="text-sm font-medium text-nutrition-700 text-nutrition-400 hover:text-nutrition-600 transition-colors"
         >
           {t('back')}
         </Link>
         {isTranslated && (
-          <span className="text-xs text-sand-400 flex items-center gap-1">
+          <span className="text-xs text-on-surface-variant flex items-center gap-1">
             <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
             </svg>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,19 +4,19 @@ export function Footer() {
   const t = useTranslations('Footer')
 
   return (
-    <footer className="border-t border-ctp-surface1 mt-24">
+    <footer className="border-t border-surface-container-high mt-24">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 py-10 flex flex-col sm:flex-row items-center justify-between gap-2">
-        <p className="font-display font-bold text-ctp-text">
+        <p className="font-display font-bold text-on-surface">
           Project <span className="text-nutrition-600">365</span>
         </p>
         <div className="flex items-center gap-4">
-          <p className="text-xs text-sand-400 tracking-wide">
+          <p className="text-xs text-on-surface-variant tracking-wide">
             {t('tagline')}
           </p>
           <a
             href="/feed.xml"
             title={t('rssTitle')}
-            className="flex items-center gap-1.5 text-xs text-sand-400 hover:text-nutrition-600 dark:hover:text-nutrition-500 transition-colors"
+            className="flex items-center gap-1.5 text-xs text-on-surface-variant hover:text-nutrition-600 hover:text-nutrition-500 transition-colors"
           >
             <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20C4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,10 +3,10 @@ import { Navigation } from './Navigation'
 
 export function Header() {
   return (
-    <header className="border-b border-ctp-surface1 bg-sand-50/95 dark:bg-ctp-mantle/95 backdrop-blur-sm sticky top-0 z-10">
+    <header className="border-b border-surface-container-high bg-background/95 bg-surface-container-low/95 backdrop-blur-sm sticky top-0 z-10">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         <Link href="/" className="group flex items-center gap-2">
-          <span className="font-display text-lg font-bold tracking-tight text-ctp-text group-hover:text-nutrition-700 dark:group-hover:text-nutrition-500 transition-colors">
+          <span className="font-display text-lg font-bold tracking-tight text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-500 transition-colors">
             Project <span className="text-nutrition-600">365</span>
           </span>
         </Link>

--- a/src/components/layout/LocaleSwitcher 2.tsx
+++ b/src/components/layout/LocaleSwitcher 2.tsx
@@ -24,7 +24,7 @@ export function LocaleSwitcher() {
       onClick={handleSwitch}
       disabled={isPending}
       aria-label={t('ariaLabel')}
-      className="w-8 h-8 flex items-center justify-center rounded-lg text-xs font-semibold text-sand-500 hover:text-[#1a1714] dark:hover:text-[#faf9f7] hover:bg-sand-100 dark:hover:bg-[#3a3531] transition-colors disabled:opacity-50"
+      className="w-8 h-8 flex items-center justify-center rounded-lg text-xs font-semibold text-on-surface-variant hover:text-[#1a1714] hover:text-[#faf9f7] hover:bg-surface-container hover:bg-[#3a3531] transition-colors disabled:opacity-50"
     >
       {t('label')}
     </button>

--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -31,10 +31,10 @@ export function LocaleSwitcher() {
       onChange={handleChange}
       disabled={isPending}
       aria-label="Sprache / Language / Idioma"
-      className="h-8 px-1.5 rounded-lg text-xs font-semibold text-sand-500 bg-transparent hover:text-ctp-text hover:bg-sand-100 dark:hover:bg-ctp-surface0 transition-colors disabled:opacity-50 cursor-pointer border-0 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:focus:ring-ctp-surface1"
+      className="h-8 px-1.5 rounded-lg text-xs font-semibold text-on-surface-variant bg-transparent hover:text-on-surface hover:bg-surface-container hover:bg-surface-container transition-colors disabled:opacity-50 cursor-pointer border-0 focus:outline-none focus:ring-2 focus:ring-outline focus:ring-surface-container-high"
     >
       {LOCALES.map(({ code, label }) => (
-        <option key={code} value={code} className="bg-ctp-base text-ctp-text">
+        <option key={code} value={code} className="bg-surface-container text-on-surface">
           {label}
         </option>
       ))}

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 import { getTranslations } from 'next-intl/server'
-import { ThemeToggle } from './ThemeToggle'
 import { LocaleSwitcher } from './LocaleSwitcher'
 import { SearchModal } from '@/components/search/SearchModal'
 import { getAuthSession } from '@/lib/auth'
@@ -14,7 +13,7 @@ export async function Navigation() {
     <nav className="flex items-center gap-2" aria-label={t('ariaLabel')}>
       <Link
         href="/"
-        className="text-sm font-medium text-sand-500 hover:text-ctp-text transition-colors"
+        className="text-sm font-medium text-on-surface-variant hover:text-on-surface transition-colors"
       >
         {t('journal')}
       </Link>
@@ -23,13 +22,12 @@ export async function Navigation() {
       {isAdmin && (
         <Link
           href="/admin"
-          className="text-sm font-medium text-nutrition-600 dark:text-nutrition-500 hover:text-nutrition-700 dark:hover:text-nutrition-400 transition-colors"
+          className="text-sm font-medium text-primary hover:text-primary-container transition-colors"
           title={t('adminTitle')}
         >
           {t('admin')}
         </Link>
       )}
-      <ThemeToggle />
     </nav>
   )
 }

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,39 +1,4 @@
-'use client'
-
-import { useTheme } from 'next-themes'
-import { useEffect, useState } from 'react'
-
+// ThemeToggle is no longer used — Kinetic Lab is dark-only.
 export function ThemeToggle() {
-  const { resolvedTheme, setTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => setMounted(true), [])
-
-  // Render placeholder during SSR to avoid layout shift
-  if (!mounted) {
-    return <div className="w-8 h-8" aria-hidden="true" />
-  }
-
-  const isDark = resolvedTheme === 'dark'
-
-  return (
-    <button
-      onClick={() => setTheme(isDark ? 'light' : 'dark')}
-      aria-label={isDark ? 'Zu Hell-Modus wechseln' : 'Zu Dunkel-Modus wechseln'}
-      className="w-8 h-8 flex items-center justify-center rounded-lg text-sand-500 hover:text-ctp-text hover:bg-sand-100 dark:hover:bg-ctp-surface0 transition-colors"
-    >
-      {isDark ? (
-        // Sun icon — switch to light
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <circle cx="12" cy="12" r="4" />
-          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
-        </svg>
-      ) : (
-        // Moon icon — switch to dark
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-        </svg>
-      )}
-    </button>
-  )
+  return null
 }

--- a/src/components/metrics/BodyFatChart.tsx
+++ b/src/components/metrics/BodyFatChart.tsx
@@ -40,9 +40,9 @@ function BodyFatTooltip({ active, payload, label }: TooltipProps) {
   const locale = useLocale()
   if (!active || !payload?.length) return null
   return (
-    <div className="bg-ctp-base border border-ctp-surface1 rounded-lg px-3 py-2 text-sm shadow-sm">
-      <p className="text-sand-400 text-xs mb-0.5">{formatDateLong(label ?? '', locale)}</p>
-      <p className="font-semibold text-ctp-text">{payload[0].value.toFixed(1)} %</p>
+    <div className="bg-surface-container border border-surface-container-high rounded-lg px-3 py-2 text-sm shadow-sm">
+      <p className="text-on-surface-variant text-xs mb-0.5">{formatDateLong(label ?? '', locale)}</p>
+      <p className="font-semibold text-on-surface">{payload[0].value.toFixed(1)} %</p>
     </div>
   )
 }
@@ -62,13 +62,13 @@ export function BodyFatChart({ data, latestBodyFat }: BodyFatChartProps) {
   const yMax = Math.ceil(max + 0.5)
 
   return (
-    <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5">
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
       <div className="flex items-baseline justify-between mb-4">
-        <h3 className="font-display font-semibold text-sm text-ctp-text">{t('bodyFat')}</h3>
+        <h3 className="font-display font-semibold text-sm text-on-surface">{t('bodyFat')}</h3>
         {latestBodyFat !== undefined && (
-          <span className="text-2xl font-bold font-display text-ctp-overlay2 dark:text-ctp-overlay2">
+          <span className="text-2xl font-bold font-display text-on-surface-variant text-on-surface-variant">
             {latestBodyFat.toFixed(1)}{' '}
-            <span className="text-sm font-normal text-sand-400">%</span>
+            <span className="text-sm font-normal text-on-surface-variant">%</span>
           </span>
         )}
       </div>
@@ -95,10 +95,10 @@ export function BodyFatChart({ data, latestBodyFat }: BodyFatChartProps) {
           <Line
             type="monotone"
             dataKey="bodyFat"
-            stroke="var(--ctp-overlay2)"
+            stroke="var(--on-surface-variant)"
             strokeWidth={2}
-            dot={{ fill: 'var(--ctp-overlay2)', r: 2.5, strokeWidth: 0 }}
-            activeDot={{ r: 4, fill: 'var(--ctp-overlay2)' }}
+            dot={{ fill: 'var(--on-surface-variant)', r: 2.5, strokeWidth: 0 }}
+            activeDot={{ r: 4, fill: 'var(--on-surface-variant)' }}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/src/components/metrics/MetricsDashboard.tsx
+++ b/src/components/metrics/MetricsDashboard.tsx
@@ -17,9 +17,9 @@ function toDateString(date: Date | string): string {
 function EmptyState() {
   const t = useTranslations('MetricsDashboard')
   return (
-    <div className="rounded-2xl border border-ctp-surface1 bg-ctp-base px-6 py-10 text-center">
-      <p className="font-display text-lg text-sand-400 mb-1">{t('noData')}</p>
-      <p className="text-sm text-sand-400">{t('noDataHint')}</p>
+    <div className="rounded-2xl border border-surface-container-high bg-surface-container px-6 py-10 text-center">
+      <p className="font-display text-lg text-on-surface-variant mb-1">{t('noData')}</p>
+      <p className="text-sm text-on-surface-variant">{t('noDataHint')}</p>
     </div>
   )
 }
@@ -57,7 +57,7 @@ export async function MetricsDashboard() {
 
   return (
     <section className="mb-14">
-      <h2 className="font-display text-xl font-bold text-ctp-text mb-5">{t('heading')}</h2>
+      <h2 className="font-display text-xl font-bold text-on-surface mb-5">{t('heading')}</h2>
 
       {!hasAnyData ? (
         <EmptyState />

--- a/src/components/metrics/StepsChart.tsx
+++ b/src/components/metrics/StepsChart.tsx
@@ -46,9 +46,9 @@ function StepsTooltip({ active, payload, label }: TooltipProps) {
   const t = useTranslations('Charts')
   if (!active || !payload?.length) return null
   return (
-    <div className="bg-ctp-base border border-ctp-surface1 rounded-lg px-3 py-2 text-sm shadow-sm">
-      <p className="text-sand-400 text-xs mb-0.5">{formatDateLong(label ?? '', locale)}</p>
-      <p className="font-semibold text-ctp-text">{payload[0].value.toLocaleString(locale)} {t('steps')}</p>
+    <div className="bg-surface-container border border-surface-container-high rounded-lg px-3 py-2 text-sm shadow-sm">
+      <p className="text-on-surface-variant text-xs mb-0.5">{formatDateLong(label ?? '', locale)}</p>
+      <p className="font-semibold text-on-surface">{payload[0].value.toLocaleString(locale)} {t('steps')}</p>
     </div>
   )
 }
@@ -64,13 +64,13 @@ export function StepsChart({ data, avgSteps, stepsGoal = 10000 }: StepsChartProp
   const t = useTranslations('Charts')
 
   return (
-    <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5 h-full">
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 h-full">
       <div className="flex items-baseline justify-between mb-4">
-        <h3 className="font-display font-semibold text-sm text-ctp-text">{t('steps')}</h3>
+        <h3 className="font-display font-semibold text-sm text-on-surface">{t('steps')}</h3>
         {avgSteps !== undefined && (
-          <span className="text-2xl font-bold font-display text-movement-700 dark:text-movement-400">
+          <span className="text-2xl font-bold font-display text-movement-700 text-movement-400">
             {formatSteps(avgSteps)}{' '}
-            <span className="text-sm font-normal text-sand-400">{t('avgPerDay')}</span>
+            <span className="text-sm font-normal text-on-surface-variant">{t('avgPerDay')}</span>
           </span>
         )}
       </div>

--- a/src/components/metrics/WeightChart.tsx
+++ b/src/components/metrics/WeightChart.tsx
@@ -40,9 +40,9 @@ function WeightTooltip({ active, payload, label }: TooltipProps) {
   const locale = useLocale()
   if (!active || !payload?.length) return null
   return (
-    <div className="bg-ctp-base border border-ctp-surface1 rounded-lg px-3 py-2 text-sm shadow-sm">
-      <p className="text-sand-400 text-xs mb-0.5">{formatDateLong(label ?? '', locale)}</p>
-      <p className="font-semibold text-ctp-text">{payload[0].value.toFixed(1)} kg</p>
+    <div className="bg-surface-container border border-surface-container-high rounded-lg px-3 py-2 text-sm shadow-sm">
+      <p className="text-on-surface-variant text-xs mb-0.5">{formatDateLong(label ?? '', locale)}</p>
+      <p className="font-semibold text-on-surface">{payload[0].value.toFixed(1)} kg</p>
     </div>
   )
 }
@@ -62,13 +62,13 @@ export function WeightChart({ data, latestWeight }: WeightChartProps) {
   const yMax = Math.ceil(max + 0.5)
 
   return (
-    <div className="bg-ctp-base rounded-2xl border border-ctp-surface1 p-5 h-full">
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 h-full">
       <div className="flex items-baseline justify-between mb-4">
-        <h3 className="font-display font-semibold text-sm text-ctp-text">{t('weight')}</h3>
+        <h3 className="font-display font-semibold text-sm text-on-surface">{t('weight')}</h3>
         {latestWeight !== undefined && (
-          <span className="text-2xl font-bold font-display text-nutrition-700 dark:text-nutrition-400">
+          <span className="text-2xl font-bold font-display text-nutrition-700 text-nutrition-400">
             {latestWeight.toFixed(1)}{' '}
-            <span className="text-sm font-normal text-sand-400">kg</span>
+            <span className="text-sm font-normal text-on-surface-variant">kg</span>
           </span>
         )}
       </div>

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,16 +1,10 @@
 'use client'
 
-import { ThemeProvider as NextThemesProvider } from 'next-themes'
-
 interface ThemeProviderProps {
   children: React.ReactNode
   nonce?: string
 }
 
-export function ThemeProvider({ children, nonce }: ThemeProviderProps) {
-  return (
-    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange nonce={nonce}>
-      {children}
-    </NextThemesProvider>
-  )
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  return <>{children}</>
 }

--- a/src/components/reactions/ReactionBar.tsx
+++ b/src/components/reactions/ReactionBar.tsx
@@ -117,7 +117,7 @@ export function ReactionBar({ slug }: ReactionBarProps) {
 
   return (
     <div className="space-y-2">
-      <p className="text-xs text-sand-400 uppercase tracking-wider font-medium">Reaktionen</p>
+      <p className="text-xs text-on-surface-variant uppercase tracking-wider font-medium">Reaktionen</p>
       <div className="flex flex-wrap gap-2">
         {REACTIONS.map(({ type, emoji, label }) => (
           <ReactionButton

--- a/src/components/reactions/ReactionBarCompact.tsx
+++ b/src/components/reactions/ReactionBarCompact.tsx
@@ -134,10 +134,10 @@ export function ReactionBarCompact({ slug }: ReactionBarCompactProps) {
           aria-pressed={userReactions.has(type)}
           className={cn(
             'flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-all duration-150 select-none',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand-400',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-on-surface-variant',
             userReactions.has(type)
-              ? 'bg-ctp-surface1 text-ctp-text ring-1 ring-sand-300 dark:ring-ctp-overlay2'
-              : 'bg-ctp-surface0 border border-ctp-surface1 text-sand-500 dark:text-sand-400 hover:bg-sand-200 dark:hover:bg-ctp-surface0 hover:text-sand-700 dark:hover:text-ctp-text',
+              ? 'bg-surface-container-high text-on-surface ring-1 ring-outline ring-on-surface-variant'
+              : 'bg-surface-container border border-surface-container-high text-on-surface-variant text-on-surface-variant hover:bg-surface-container-high hover:bg-surface-container hover:text-sand-700 hover:text-on-surface',
             pending !== null && 'opacity-60 cursor-not-allowed',
           )}
         >
@@ -158,8 +158,8 @@ export function ReactionBarCompact({ slug }: ReactionBarCompactProps) {
               aria-label={label}
               className={cn(
                 'flex items-center px-2 py-0.5 rounded-full text-xs font-medium transition-all duration-150 select-none',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand-400',
-                'bg-ctp-surface0 border border-dashed border-ctp-surface1 text-sand-400 dark:text-sand-500 hover:bg-sand-200 dark:hover:bg-ctp-surface0 hover:text-sand-700 dark:hover:text-ctp-text hover:border-solid',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-on-surface-variant',
+                'bg-surface-container border border-dashed border-surface-container-high text-on-surface-variant text-on-surface-variant hover:bg-surface-container-high hover:bg-surface-container hover:text-sand-700 hover:text-on-surface hover:border-solid',
                 pending !== null && 'opacity-60 cursor-not-allowed',
               )}
             >
@@ -169,7 +169,7 @@ export function ReactionBarCompact({ slug }: ReactionBarCompactProps) {
           <button
             onClick={(e) => { stopPropagation(e); setExpanded(false) }}
             aria-label="Schliessen"
-            className="flex items-center justify-center w-5 h-5 rounded-full text-xs bg-ctp-surface0 border border-ctp-surface1 text-sand-400 hover:bg-sand-200 dark:hover:bg-ctp-surface0 transition-all duration-150 select-none"
+            className="flex items-center justify-center w-5 h-5 rounded-full text-xs bg-surface-container border border-surface-container-high text-on-surface-variant hover:bg-surface-container-high hover:bg-surface-container transition-all duration-150 select-none"
           >
             ×
           </button>
@@ -178,7 +178,7 @@ export function ReactionBarCompact({ slug }: ReactionBarCompactProps) {
         <button
           onClick={(e) => { stopPropagation(e); setExpanded(true) }}
           aria-label="Reagieren"
-          className="flex items-center justify-center w-5 h-5 rounded-full text-xs bg-ctp-surface0 border border-ctp-surface1 text-sand-400 hover:bg-sand-200 dark:hover:bg-ctp-surface0 hover:text-sand-600 transition-all duration-150 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand-400"
+          className="flex items-center justify-center w-5 h-5 rounded-full text-xs bg-surface-container border border-surface-container-high text-on-surface-variant hover:bg-surface-container-high hover:bg-surface-container hover:text-on-surface-variant transition-all duration-150 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-on-surface-variant"
         >
           +
         </button>

--- a/src/components/reactions/ReactionButton.tsx
+++ b/src/components/reactions/ReactionButton.tsx
@@ -21,10 +21,10 @@ export function ReactionButton({ emoji, label, count, active, disabled, onClick 
       aria-pressed={active}
       className={cn(
         'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-150 select-none',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sand-400',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-on-surface-variant',
         active
-          ? 'bg-ctp-surface1 text-ctp-text ring-1 ring-sand-300 dark:ring-ctp-overlay2 scale-105'
-          : 'bg-ctp-base border border-ctp-surface1 text-sand-500 dark:text-sand-400 hover:bg-sand-100 dark:hover:bg-ctp-surface0 hover:text-sand-700 dark:hover:text-ctp-text hover:border-sand-300',
+          ? 'bg-surface-container-high text-on-surface ring-1 ring-outline ring-on-surface-variant scale-105'
+          : 'bg-surface-container border border-surface-container-high text-on-surface-variant text-on-surface-variant hover:bg-surface-container hover:bg-surface-container hover:text-sand-700 hover:text-on-surface hover:border-outline',
         disabled && 'cursor-not-allowed opacity-60',
       )}
     >

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -16,7 +16,7 @@ function Highlight({ text, query }: { text: string; query: string }) {
   return (
     <>
       {text.slice(0, idx)}
-      <mark className="bg-nutrition-200 dark:bg-nutrition-800/60 text-inherit not-italic rounded-sm px-0.5">
+      <mark className="bg-nutrition-200 bg-nutrition-800/60 text-inherit not-italic rounded-sm px-0.5">
         {text.slice(idx, idx + query.length)}
       </mark>
       {text.slice(idx + query.length)}
@@ -123,14 +123,14 @@ export function SearchModal() {
         type="button"
         onClick={() => setOpen(true)}
         aria-label={t('ariaLabel')}
-        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sand-500 hover:text-ctp-text hover:bg-sand-100 dark:hover:bg-ctp-base transition-colors"
+        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container hover:bg-surface-container transition-colors"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
           <circle cx="11" cy="11" r="8" />
           <path strokeLinecap="round" d="M21 21l-4.35-4.35" />
         </svg>
         <span className="hidden sm:inline text-xs">
-          <kbd className="font-sans text-sand-400">⌘K</kbd>
+          <kbd className="font-sans text-on-surface-variant">⌘K</kbd>
         </span>
       </button>
 
@@ -144,16 +144,16 @@ export function SearchModal() {
         >
           {/* Backdrop */}
           <div
-            className="absolute inset-0 bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+            className="absolute inset-0 bg-black/40 bg-black/60 backdrop-blur-sm"
             onClick={() => setOpen(false)}
           />
 
           {/* Modal card */}
-          <div className="relative w-full max-w-xl bg-ctp-base rounded-2xl border border-ctp-surface1 shadow-2xl overflow-hidden">
+          <div className="relative w-full max-w-xl bg-surface-container rounded-2xl border border-surface-container-high shadow-2xl overflow-hidden">
 
             {/* Input row */}
-            <div className="flex items-center gap-3 px-4 border-b border-ctp-surface0">
-              <svg className="w-4 h-4 text-sand-400 shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
+            <div className="flex items-center gap-3 px-4 border-b border-surface-container">
+              <svg className="w-4 h-4 text-on-surface-variant shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
                 <circle cx="11" cy="11" r="8" />
                 <path strokeLinecap="round" d="M21 21l-4.35-4.35" />
               </svg>
@@ -164,10 +164,10 @@ export function SearchModal() {
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={onKeyDown}
                 placeholder={t('placeholder')}
-                className="flex-1 py-4 text-sm text-ctp-text bg-transparent focus:outline-none placeholder:text-sand-400"
+                className="flex-1 py-4 text-sm text-on-surface bg-transparent focus:outline-none placeholder:text-on-surface-variant"
               />
               {loading && (
-                <svg className="w-4 h-4 text-sand-400 animate-spin shrink-0" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <svg className="w-4 h-4 text-on-surface-variant animate-spin shrink-0" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth={4} />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
                 </svg>
@@ -175,7 +175,7 @@ export function SearchModal() {
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="shrink-0 text-xs text-sand-400 hover:text-sand-600 dark:hover:text-sand-300 transition-colors px-1.5 py-1 rounded border border-ctp-surface1"
+                className="shrink-0 text-xs text-on-surface-variant hover:text-on-surface-variant hover:text-outline transition-colors px-1.5 py-1 rounded border border-surface-container-high"
               >
                 ESC
               </button>
@@ -183,7 +183,7 @@ export function SearchModal() {
 
             {/* Results */}
             {results.length > 0 && (
-              <ul className="max-h-[60vh] overflow-y-auto divide-y divide-sand-100 dark:divide-ctp-surface0">
+              <ul className="max-h-[60vh] overflow-y-auto divide-y divide-surface-container divide-surface-container">
                 {results.map((result, i) => (
                   <li key={result.slug}>
                     <button
@@ -191,20 +191,20 @@ export function SearchModal() {
                       onClick={() => navigate(result.slug)}
                       className={`w-full text-left px-4 py-3.5 transition-colors ${
                         i === activeIndex
-                          ? 'bg-ctp-surface0'
-                          : 'hover:bg-sand-50 dark:hover:bg-ctp-surface0'
+                          ? 'bg-surface-container'
+                          : 'hover:bg-background hover:bg-surface-container'
                       }`}
                     >
                       <div className="flex items-baseline gap-2 mb-0.5">
-                        <span className="font-display font-semibold text-sm text-ctp-text">
+                        <span className="font-display font-semibold text-sm text-on-surface">
                           <Highlight text={result.title} query={query} />
                         </span>
-                        <span className="text-xs text-sand-400 shrink-0">
+                        <span className="text-xs text-on-surface-variant shrink-0">
                           {t('day')} {result.dayNumber} · {formatDate(result.date)}
                         </span>
                       </div>
                       {result.excerpt && (
-                        <p className="text-xs text-ctp-overlay2 dark:text-ctp-overlay2 line-clamp-2 leading-relaxed">
+                        <p className="text-xs text-on-surface-variant text-on-surface-variant line-clamp-2 leading-relaxed">
                           <Highlight text={result.excerpt} query={query} />
                         </p>
                       )}
@@ -217,9 +217,9 @@ export function SearchModal() {
             {/* Empty state */}
             {showEmpty && (
               <div className="px-4 py-10 text-center">
-                <p className="text-sm text-sand-500">
+                <p className="text-sm text-on-surface-variant">
                   {t('noResults')}{' '}
-                  <span className="font-medium text-ctp-text">&bdquo;{query}&ldquo;</span>
+                  <span className="font-medium text-on-surface">&bdquo;{query}&ldquo;</span>
                 </p>
               </div>
             )}
@@ -227,7 +227,7 @@ export function SearchModal() {
             {/* Idle hint */}
             {!loading && query.trim().length < 2 && (
               <div className="px-4 py-6 text-center">
-                <p className="text-xs text-sand-400">{t('minChars')}</p>
+                <p className="text-xs text-on-surface-variant">{t('minChars')}</p>
               </div>
             )}
 

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -9,7 +9,7 @@ interface SkeletonProps {
 export function Skeleton({ className, style }: SkeletonProps) {
   return (
     <div
-      className={cn('rounded-lg bg-ctp-surface0 animate-pulse', className)}
+      className={cn('rounded-lg bg-surface-container animate-pulse', className)}
       style={style}
       aria-hidden="true"
     />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,68 +4,35 @@
 
 @layer base {
   /* =============================================
-   * Catppuccin Latte — Light Mode
-   * https://catppuccin.com/palette
+   * Kinetic Lab — Dark-Only Theme
    * ============================================= */
   :root {
-    --ctp-rosewater: #dc8a78;
-    --ctp-flamingo:  #dd7878;
-    --ctp-pink:      #ea76cb;
-    --ctp-mauve:     #8839ef;
-    --ctp-red:       #d20f39;
-    --ctp-maroon:    #e64553;
-    --ctp-peach:     #fe640b;
-    --ctp-yellow:    #df8e1d;
-    --ctp-green:     #40a02b;
-    --ctp-teal:      #179299;
-    --ctp-sky:       #04a5e5;
-    --ctp-sapphire:  #209fb5;
-    --ctp-blue:      #1e66f5;
-    --ctp-lavender:  #7287fd;
-    --ctp-text:      #4c4f69;
-    --ctp-subtext1:  #5c5f77;
-    --ctp-subtext0:  #6c6f85;
-    --ctp-overlay2:  #7c7f93;
-    --ctp-overlay1:  #8c8fa1;
-    --ctp-overlay0:  #9ca0b0;
-    --ctp-surface2:  #acb0be;
-    --ctp-surface1:  #bcc0cc;
-    --ctp-surface0:  #ccd0da;
-    --ctp-base:      #eff1f5;
-    --ctp-mantle:    #e6e9ef;
-    --ctp-crust:     #dce0e8;
-  }
+    --background:                  #0e0e0e;
+    --surface-container-lowest:    #000000;
+    --surface-container-low:       #131313;
+    --surface-container:           #1a1919;
+    --surface-container-high:      #201f1f;
+    --surface-container-highest:   #262626;
+    --surface-variant:             #262626;
+    --surface-bright:              #2c2c2c;
+    --primary:                     #ff8f70;
+    --primary-container:           #ff7852;
+    --secondary:                   #fc7c7c;
+    --tertiary:                    #eaa5ff;
+    --error:                       #ff716c;
+    --on-surface:                  #ffffff;
+    --on-surface-variant:          #adaaaa;
+    --outline:                     #767575;
+    --outline-variant:             #484847;
 
-  /* =============================================
-   * Catppuccin Mocha — Dark Mode
-   * ============================================= */
-  .dark {
-    --ctp-rosewater: #f5e0dc;
-    --ctp-flamingo:  #f2cdcd;
-    --ctp-pink:      #f5c2e7;
-    --ctp-mauve:     #cba6f7;
-    --ctp-red:       #f38ba8;
-    --ctp-maroon:    #eba0ac;
-    --ctp-peach:     #fab387;
-    --ctp-yellow:    #f9e2af;
-    --ctp-green:     #a6e3a1;
-    --ctp-teal:      #94e2d5;
-    --ctp-sky:       #89dceb;
-    --ctp-sapphire:  #74c7ec;
-    --ctp-blue:      #89b4fa;
-    --ctp-lavender:  #b4befe;
-    --ctp-text:      #cdd6f4;
-    --ctp-subtext1:  #bac2de;
-    --ctp-subtext0:  #a6adc8;
-    --ctp-overlay2:  #9399b2;
-    --ctp-overlay1:  #7f849c;
-    --ctp-overlay0:  #6c7086;
-    --ctp-surface2:  #585b70;
-    --ctp-surface1:  #45475a;
-    --ctp-surface0:  #313244;
-    --ctp-base:      #1e1e2e;
-    --ctp-mantle:    #181825;
-    --ctp-crust:     #11111b;
+    /* Chart CSS variables — used by Recharts SVG */
+    --chart-grid:             #484847;
+    --chart-axis:             #adaaaa;
+    --chart-axis-line:        #484847;
+    --chart-tooltip-bg:       #131313;
+    --chart-tooltip-border:   #484847;
+    --chart-tooltip-text:     #ffffff;
+    --chart-tooltip-muted:    #adaaaa;
   }
 
   html {
@@ -74,8 +41,8 @@
 
   body {
     font-family: var(--font-body), Georgia, serif;
-    background-color: var(--ctp-base);
-    color: var(--ctp-text);
+    background-color: var(--background);
+    color: var(--on-surface);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
@@ -86,26 +53,13 @@
   }
 
   ::selection {
-    background-color: var(--ctp-mauve);
-    color: var(--ctp-base);
+    background-color: var(--primary);
+    color: #5c1300;
   }
 
   :focus-visible {
-    outline: 2px solid var(--ctp-peach);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
     border-radius: 2px;
-  }
-
-  /* =============================================
-   * Chart CSS variables — used by Recharts SVG
-   * ============================================= */
-  :root, .dark {
-    --chart-grid:         var(--ctp-surface0);
-    --chart-axis:         var(--ctp-overlay1);
-    --chart-axis-line:    var(--ctp-surface0);
-    --chart-tooltip-bg:   var(--ctp-mantle);
-    --chart-tooltip-border: var(--ctp-surface0);
-    --chart-tooltip-text: var(--ctp-text);
-    --chart-tooltip-muted: var(--ctp-overlay1);
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,6 @@ import type { Config } from 'tailwindcss'
 import typography from '@tailwindcss/typography'
 
 const config: Config = {
-  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -12,60 +11,40 @@ const config: Config = {
     extend: {
       colors: {
         // =============================================
-        // Catppuccin semantic tokens (CSS-var-based)
-        // Switch automatically between Latte and Mocha
+        // Kinetic Lab — Dark-Only palette
         // =============================================
-        ctp: {
-          rosewater: 'var(--ctp-rosewater)',
-          flamingo:  'var(--ctp-flamingo)',
-          pink:      'var(--ctp-pink)',
-          mauve:     'var(--ctp-mauve)',
-          red:       'var(--ctp-red)',
-          maroon:    'var(--ctp-maroon)',
-          peach:     'var(--ctp-peach)',
-          yellow:    'var(--ctp-yellow)',
-          green:     'var(--ctp-green)',
-          teal:      'var(--ctp-teal)',
-          sky:       'var(--ctp-sky)',
-          sapphire:  'var(--ctp-sapphire)',
-          blue:      'var(--ctp-blue)',
-          lavender:  'var(--ctp-lavender)',
-          text:      'var(--ctp-text)',
-          subtext1:  'var(--ctp-subtext1)',
-          subtext0:  'var(--ctp-subtext0)',
-          overlay2:  'var(--ctp-overlay2)',
-          overlay1:  'var(--ctp-overlay1)',
-          overlay0:  'var(--ctp-overlay0)',
-          surface2:  'var(--ctp-surface2)',
-          surface1:  'var(--ctp-surface1)',
-          surface0:  'var(--ctp-surface0)',
-          base:      'var(--ctp-base)',
-          mantle:    'var(--ctp-mantle)',
-          crust:     'var(--ctp-crust)',
-        },
+        background:                  '#0e0e0e',
+        'surface-container-lowest':  '#000000',
+        'surface-container-low':     '#131313',
+        'surface-container':         '#1a1919',
+        'surface-container-high':    '#201f1f',
+        'surface-container-highest': '#262626',
+        'surface-variant':           '#262626',
+        'surface-bright':            '#2c2c2c',
+        primary:                     '#ff8f70',
+        'primary-container':         '#ff7852',
+        'primary-dim':               '#ff734c',
+        secondary:                   '#fc7c7c',
+        tertiary:                    '#eaa5ff',
+        error:                       '#ff716c',
+        'on-surface':                '#ffffff',
+        'on-surface-variant':        '#adaaaa',
+        'on-primary':                '#5c1300',
+        'on-primary-container':      '#480d00',
+        outline:                     '#767575',
+        'outline-variant':           '#484847',
+        'inverse-surface':           '#fcf9f8',
+        'inverse-on-surface':        '#565555',
+        'inverse-primary':           '#b22e00',
 
         // =============================================
-        // Surface scale — mapped to Catppuccin Latte
-        // Dark equivalents via hardcoded dark: classes
-        // (progressive migration to ctp-* planned)
-        // =============================================
-        sand: {
-          50:  '#eff1f5', // Latte Base
-          100: '#e6e9ef', // Latte Mantle
-          200: '#dce0e8', // Latte Crust
-          300: '#acb0be', // Latte Surface2
-          400: '#8c8fa1', // Latte Overlay1
-          500: '#7c7f93', // Latte Overlay2
-          600: '#5c5f77', // Latte Subtext1
-        },
-
-        // =============================================
-        // Säule Bewegung — Catppuccin Green
-        // Latte: #40a02b  |  Mocha: #a6e3a1
+        // Säule Bewegung — Grün
         // =============================================
         movement: {
+          50:  '#f0fdf0',
           100: '#e0f5d4',
           200: '#b8e8a0',
+          300: '#84d160',
           400: '#62bc44',
           500: '#40a02b',
           600: '#2e7520',
@@ -75,12 +54,13 @@ const config: Config = {
         },
 
         // =============================================
-        // Säule Ernährung — Catppuccin Peach
-        // Latte: #fe640b  |  Mocha: #fab387
+        // Säule Ernährung — Orange
         // =============================================
         nutrition: {
+          50:  '#fff4f0',
           100: '#fde8d4',
           200: '#fbc3a0',
+          300: '#faa37a',
           400: '#fd8b50',
           500: '#fe640b',
           600: '#d44c08',
@@ -90,12 +70,13 @@ const config: Config = {
         },
 
         // =============================================
-        // Säule Rauchstopp — Catppuccin Blue
-        // Latte: #1e66f5  |  Mocha: #89b4fa
+        // Säule Rauchstopp — Blau
         // =============================================
         smoking: {
+          50:  '#eef4ff',
           100: '#dce8fd',
           200: '#afc9fb',
+          300: '#82aaf9',
           400: '#5b91f7',
           500: '#1e66f5',
           600: '#1250c2',
@@ -105,32 +86,45 @@ const config: Config = {
         },
       },
 
+      borderRadius: {
+        DEFAULT: '0.125rem',
+        sm:      '0.125rem',
+        md:      '0.125rem',
+        lg:      '0.25rem',
+        xl:      '0.5rem',
+        '2xl':   '0.5rem',
+        '3xl':   '0.75rem',
+        full:    '0.75rem',
+      },
+
       fontFamily: {
-        display: ['var(--font-display)', 'Georgia', 'serif'],
-        body:    ['var(--font-body)',    'Georgia', 'serif'],
+        display:  ['var(--font-display)', 'Georgia', 'serif'],
+        body:     ['var(--font-body)',    'Georgia', 'serif'],
+        headline: ['var(--font-display)', 'Georgia', 'serif'],
+        label:    ['var(--font-body)',    'sans-serif'],
       },
 
       typography: {
         DEFAULT: {
           css: {
-            '--tw-prose-body':          'var(--ctp-text)',
-            '--tw-prose-headings':      'var(--ctp-text)',
-            '--tw-prose-links':         'var(--ctp-peach)',
-            '--tw-prose-bold':          'var(--ctp-text)',
-            '--tw-prose-hr':            'var(--ctp-surface0)',
-            '--tw-prose-quotes':        'var(--ctp-subtext0)',
-            '--tw-prose-quote-borders': 'var(--ctp-surface1)',
-            '--tw-prose-captions':      'var(--ctp-overlay1)',
-            '--tw-prose-code':          'var(--ctp-text)',
-            '--tw-prose-invert-body':          'var(--ctp-text)',
-            '--tw-prose-invert-headings':      'var(--ctp-text)',
-            '--tw-prose-invert-links':         'var(--ctp-peach)',
-            '--tw-prose-invert-bold':          'var(--ctp-text)',
-            '--tw-prose-invert-hr':            'var(--ctp-surface0)',
-            '--tw-prose-invert-quotes':        'var(--ctp-subtext0)',
-            '--tw-prose-invert-quote-borders': 'var(--ctp-surface1)',
-            '--tw-prose-invert-captions':      'var(--ctp-overlay1)',
-            '--tw-prose-invert-code':          'var(--ctp-text)',
+            '--tw-prose-body':          '#ffffff',
+            '--tw-prose-headings':      '#ffffff',
+            '--tw-prose-links':         '#ff8f70',
+            '--tw-prose-bold':          '#ffffff',
+            '--tw-prose-hr':            '#484847',
+            '--tw-prose-quotes':        '#adaaaa',
+            '--tw-prose-quote-borders': '#484847',
+            '--tw-prose-captions':      '#adaaaa',
+            '--tw-prose-code':          '#ffffff',
+            '--tw-prose-invert-body':          '#ffffff',
+            '--tw-prose-invert-headings':      '#ffffff',
+            '--tw-prose-invert-links':         '#ff8f70',
+            '--tw-prose-invert-bold':          '#ffffff',
+            '--tw-prose-invert-hr':            '#484847',
+            '--tw-prose-invert-quotes':        '#adaaaa',
+            '--tw-prose-invert-quote-borders': '#484847',
+            '--tw-prose-invert-captions':      '#adaaaa',
+            '--tw-prose-invert-code':          '#ffffff',
             fontFamily: 'var(--font-body), Georgia, serif',
             lineHeight: '1.75',
             maxWidth: 'none',


### PR DESCRIPTION
Closes #125

## Summary

- Komplett neues Farbsystem ersetzt Catppuccin Latte/Mocha: **Kinetic Lab Dark-Only**
- Neue Tailwind-Tokens: `background`, `surface-container-*`, `on-surface`, `on-surface-variant`, `primary` (#ff8f70 — warmes Orange), `secondary`, `tertiary`, `outline`, `outline-variant`
- Minimaler Border-Radius (2–12px) statt der alten abgerundeten Formen
- `darkMode: 'class'` aus Tailwind entfernt — nur noch ein Theme
- `ThemeToggle` ausgebaut, `ThemeProvider` vereinfacht (kein next-themes mehr)
- Migration Script (`scripts/migrate-colors.py`) für 61 Dateien: `ctp-*`/`sand-*` → neue Tokens, `dark:` Prefixe entfernt

## Geänderte Dateien

| Bereich | Dateien |
|---|---|
| Foundation | `tailwind.config.ts`, `globals.css`, `layout.tsx`, `ThemeProvider`, `ThemeToggle`, `Navigation` |
| Komponenten | 61 TSX/TS-Dateien (via Migration Script) |
| HabitPillar/Badges | Manuelle Cleanup der duplizierten light/dark Klassen |

## Test plan

- [ ] Startseite lädt mit dunklem Hintergrund (#0e0e0e) ohne Light-Mode Flash
- [ ] Journal-Feed, Journal-Einzelansicht korrekt gerendert
- [ ] Admin-Bereich vollständig dunkel (Login, Entries, Editor)
- [ ] Habit-Säulen und Jahresgrid zeigen korrekte Farben
- [ ] Charts (Recharts) mit korrekten Achsen-/Grid-Farben
- [ ] Kein ThemeToggle mehr sichtbar
- [ ] `pnpm build` ohne Fehler
- [ ] Type-Check und Lint grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)