### PR TITLE
feat: Typografie-System Space Grotesk + Manrope (Issue #126)

### DIFF
--- a/scripts/migrate-fonts.py
+++ b/scripts/migrate-fonts.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Issue #126: Migrate font class names
+- font-display → font-headline (in TSX/TS/CSS files)
+- --font-display → --font-headline (CSS custom property references)
+"""
+
+import os
+import sys
+
+SRC_DIR = os.path.join(os.path.dirname(__file__), '..', 'src')
+EXTENSIONS = ('.tsx', '.ts', '.css')
+
+REPLACEMENTS = [
+    ('font-display font-semibold', 'font-headline font-semibold'),
+    ('font-display font-bold',     'font-headline font-bold'),
+    ('font-display font-semibold', 'font-headline font-semibold'),
+    ('font-display text-',        'font-headline text-'),
+    ('"font-display"',            '"font-headline"'),
+    ("'font-display'",            "'font-headline'"),
+    # Generic catch-all (e.g. "font-display" followed by space or end of class string)
+    ('font-display',              'font-headline'),
+    # CSS variable
+    ('var(--font-display)',       'var(--font-headline)'),
+    ('--font-display',            '--font-headline'),
+]
+
+changed = []
+skipped = []
+
+for root, dirs, files in os.walk(SRC_DIR):
+    dirs[:] = [d for d in dirs if d not in ('node_modules', '.next')]
+    for fname in files:
+        if not any(fname.endswith(ext) for ext in EXTENSIONS):
+            continue
+        path = os.path.join(root, fname)
+        with open(path, 'r', encoding='utf-8') as f:
+            original = f.read()
+        content = original
+        for old, new in REPLACEMENTS:
+            content = content.replace(old, new)
+        if content != original:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(content)
+            changed.append(os.path.relpath(path, os.path.join(SRC_DIR, '..')))
+        else:
+            skipped.append(os.path.relpath(path, os.path.join(SRC_DIR, '..')))
+
+print(f"\n✅ Changed {len(changed)} files:")
+for p in changed:
+    print(f"   {p}")
+print(f"\n⏭  Skipped {len(skipped)} files (no changes needed)")

--- a/src/app/[locale]/monthly/[month]/page.tsx
+++ b/src/app/[locale]/monthly/[month]/page.tsx
@@ -86,7 +86,7 @@ export default async function MonthSummaryPage({ params }: MonthSummaryPageProps
         <p className="text-xs font-semibold text-nutrition-600 text-nutrition-400 uppercase tracking-wide mb-2">
           {t('summaryLabel')}
         </p>
-        <h1 className="font-display text-4xl font-bold text-on-surface">
+        <h1 className="font-headline text-4xl font-bold text-on-surface">
           {monthName} {year}
         </h1>
         <p className="text-xs text-on-surface-variant mt-2">

--- a/src/app/[locale]/monthly/page.tsx
+++ b/src/app/[locale]/monthly/page.tsx
@@ -22,7 +22,7 @@ export default async function MonthlyOverviewPage({ params }: MonthlyOverviewPag
 
   return (
     <div className="max-w-2xl mx-auto py-12 px-4">
-      <h1 className="font-display text-3xl font-bold text-on-surface mb-2">
+      <h1 className="font-headline text-3xl font-bold text-on-surface mb-2">
         {t('overviewHeading')}
       </h1>
       <p className="text-on-surface-variant mb-10">{t('overviewDescription')}</p>
@@ -38,7 +38,7 @@ export default async function MonthlyOverviewPage({ params }: MonthlyOverviewPag
               className="flex items-center justify-between bg-surface-container rounded-xl border border-surface-container-high px-6 py-4 hover:border-outline hover:border-on-surface-variant hover:shadow-sm transition-all group"
             >
               <div>
-                <p className="font-display font-semibold text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-400 transition-colors">
+                <p className="font-headline font-semibold text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-400 transition-colors">
                   {monthNames[s.month - 1]} {s.year}
                 </p>
                 <p className="text-xs text-on-surface-variant mt-0.5">

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -92,7 +92,7 @@ export default async function HomePage({ params }: HomePageProps) {
           {t('tagline')}
         </p>
 
-        <h1 className="font-display text-4xl sm:text-5xl font-bold leading-tight text-on-surface mb-4">
+        <h1 className="font-headline text-4xl sm:text-5xl font-bold leading-tight text-on-surface mb-4">
           <span className="block">{t('headline_1')}</span>
           <span className="block">{t('headline_2')}</span>
         </h1>
@@ -104,7 +104,7 @@ export default async function HomePage({ params }: HomePageProps) {
         {/* Day counter + streaks */}
         <div className="p-4 rounded-xl bg-surface-container border border-surface-container-high">
           <div className="flex items-baseline gap-3 mb-3">
-            <p className="font-display text-3xl font-bold text-primary leading-none">
+            <p className="font-headline text-3xl font-bold text-primary leading-none">
               {currentDay}
             </p>
             <p className="text-xs text-on-surface-variant">

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -13,7 +13,7 @@ interface StatCardProps {
 function StatCard({ value, label, sub }: StatCardProps) {
   return (
     <div className="bg-surface-container rounded-2xl border border-surface-container-high p-4 text-center">
-      <p className="font-display text-2xl font-bold text-on-surface">{value}</p>
+      <p className="font-headline text-2xl font-bold text-on-surface">{value}</p>
       <p className="text-xs font-medium text-on-surface-variant mt-1">{label}</p>
       {sub && <p className="text-xs text-on-surface-variant mt-0.5">{sub}</p>}
     </div>
@@ -45,7 +45,7 @@ export default async function AnalyticsPage({
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-display text-2xl font-bold text-on-surface mb-1">Analytics</h1>
+        <h1 className="font-headline text-2xl font-bold text-on-surface mb-1">Analytics</h1>
         <p className="text-on-surface-variant text-sm">Privacy-first · Kein Cookie · Keine IP-Speicherung</p>
       </div>
 

--- a/src/app/admin/entries/[id]/edit/page.tsx
+++ b/src/app/admin/entries/[id]/edit/page.tsx
@@ -27,7 +27,7 @@ export default async function EditEntryPage({ params }: EditEntryPageProps) {
 
   return (
     <div className="max-w-3xl">
-      <h1 className="font-display text-2xl font-bold text-on-surface mb-8">Eintrag bearbeiten</h1>
+      <h1 className="font-headline text-2xl font-bold text-on-surface mb-8">Eintrag bearbeiten</h1>
       <EntryForm mode="edit" entryId={entry.id} initial={initial} />
     </div>
   )

--- a/src/app/admin/entries/new/page.tsx
+++ b/src/app/admin/entries/new/page.tsx
@@ -3,7 +3,7 @@ import { EntryForm } from '@/components/admin/EntryForm'
 export default function NewEntryPage() {
   return (
     <div className="max-w-3xl">
-      <h1 className="font-display text-2xl font-bold text-on-surface mb-8">Neuer Eintrag</h1>
+      <h1 className="font-headline text-2xl font-bold text-on-surface mb-8">Neuer Eintrag</h1>
       <EntryForm mode="create" />
     </div>
   )

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -39,7 +39,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="font-display text-2xl font-bold text-on-surface">Einträge</h1>
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Einträge</h1>
         <Link
           href="/admin/entries/new"
           className="flex items-center gap-2 px-4 py-2 bg-nutrition-600 text-white rounded-xl text-sm font-medium hover:bg-nutrition-700 transition-colors"
@@ -80,7 +80,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
 
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-0.5">
-                    <span className="font-display font-semibold text-on-surface truncate">
+                    <span className="font-headline font-semibold text-on-surface truncate">
                       {entry.title}
                     </span>
                     {!entry.published && (

--- a/src/app/admin/fitbit/page.tsx
+++ b/src/app/admin/fitbit/page.tsx
@@ -61,7 +61,7 @@ export default async function FitbitPage({
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-display text-2xl font-bold text-on-surface mb-1">Fitbit Sync</h1>
+        <h1 className="font-headline text-2xl font-bold text-on-surface mb-1">Fitbit Sync</h1>
         <p className="text-on-surface-variant text-sm">
           Metriken manuell synchronisieren oder historische Daten nachfüllen.
         </p>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -21,7 +21,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
       <header className="sticky top-0 z-10 bg-surface-container border-b border-surface-container">
         <div className="flex items-center justify-between px-4 sm:px-6 h-12">
           {/* Logo */}
-          <Link href="/admin" className="font-display text-sm font-bold text-on-surface">
+          <Link href="/admin" className="font-headline text-sm font-bold text-on-surface">
             Project <span className="text-primary">365</span>{' '}
             <span className="text-on-surface-variant font-normal">Admin</span>
           </Link>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -13,7 +13,7 @@ function LoginContent() {
     <div className="min-h-screen bg-background flex items-center justify-center px-4">
       <div className="max-w-sm w-full">
         <div className="text-center mb-8">
-          <h1 className="font-display text-3xl font-bold text-on-surface mb-2">
+          <h1 className="font-headline text-3xl font-bold text-on-surface mb-2">
             Project <span className="text-nutrition-600">365</span>
           </h1>
           <p className="text-on-surface-variant text-sm">Admin-Bereich</p>

--- a/src/app/admin/metrics/page.tsx
+++ b/src/app/admin/metrics/page.tsx
@@ -52,7 +52,7 @@ export default async function MetricsPage({ searchParams }: PageProps) {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="font-display text-2xl font-bold text-on-surface">Metriken erfassen</h1>
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Metriken erfassen</h1>
         <p className="text-on-surface-variant text-sm mt-1">Manuell erfasste Werte überschreiben automatische Importe.</p>
       </div>
 
@@ -61,7 +61,7 @@ export default async function MetricsPage({ searchParams }: PageProps) {
       {/* Recent entries table */}
       {recent.length > 0 && (
         <div className="mt-10">
-          <h2 className="font-display text-base font-semibold text-on-surface mb-3">Letzte Einträge</h2>
+          <h2 className="font-headline text-base font-semibold text-on-surface mb-3">Letzte Einträge</h2>
           <div className="bg-surface-container rounded-2xl border border-surface-container-high overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-xs">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -80,7 +80,7 @@ interface StatCardProps {
 function StatCard({ value, label, sub }: StatCardProps) {
   return (
     <div className="bg-surface-container rounded-2xl border border-surface-container-high p-4 text-center">
-      <p className="font-display text-3xl font-bold text-on-surface">{value}</p>
+      <p className="font-headline text-3xl font-bold text-on-surface">{value}</p>
       <p className="text-xs font-medium text-on-surface-variant mt-1">{label}</p>
       {sub && <p className="text-xs text-on-surface-variant mt-0.5">{sub}</p>}
     </div>
@@ -121,7 +121,7 @@ export default async function AdminPage() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="font-display text-2xl font-bold text-on-surface mb-1">
+        <h1 className="font-headline text-2xl font-bold text-on-surface mb-1">
           Hallo, {session?.user?.name?.split(' ')[0]}
         </h1>
         <p className="text-on-surface-variant text-sm">{formatDate(new Date(today))}</p>
@@ -173,7 +173,7 @@ export default async function AdminPage() {
               </svg>
             </div>
             <div>
-              <p className="font-display text-sm font-semibold text-on-surface">Neuer Eintrag</p>
+              <p className="font-headline text-sm font-semibold text-on-surface">Neuer Eintrag</p>
               <p className="text-xs text-on-surface-variant mt-0.5">Journal-Eintrag mit Habits erfassen</p>
             </div>
           </Link>
@@ -187,7 +187,7 @@ export default async function AdminPage() {
               </svg>
             </div>
             <div>
-              <p className="font-display text-sm font-semibold text-on-surface">Metriken erfassen</p>
+              <p className="font-headline text-sm font-semibold text-on-surface">Metriken erfassen</p>
               <p className="text-xs text-on-surface-variant mt-0.5">Gewicht, Schritte und weitere Werte</p>
             </div>
           </Link>

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -14,7 +14,7 @@ export default async function SettingsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="font-display text-2xl font-bold text-on-surface">Einstellungen</h1>
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Einstellungen</h1>
         <p className="text-on-surface-variant text-sm mt-1">Statische Werte und persönliche Ziele.</p>
       </div>
 

--- a/src/app/admin/summaries/[id]/edit/page.tsx
+++ b/src/app/admin/summaries/[id]/edit/page.tsx
@@ -19,7 +19,7 @@ export default async function SummaryEditPage({ params }: SummaryEditPageProps) 
   return (
     <div>
       <div className="mb-6">
-        <h1 className="font-display text-2xl font-bold text-on-surface">
+        <h1 className="font-headline text-2xl font-bold text-on-surface">
           {monthLabel} — Zusammenfassung bearbeiten
         </h1>
         <p className="text-xs text-on-surface-variant mt-1">

--- a/src/app/admin/summaries/page.tsx
+++ b/src/app/admin/summaries/page.tsx
@@ -24,14 +24,14 @@ export default async function SummariesPage() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="font-display text-2xl font-bold text-on-surface">
+        <h1 className="font-headline text-2xl font-bold text-on-surface">
           Monats-Zusammenfassungen
         </h1>
       </div>
 
       {/* Generator */}
       <div className="bg-surface-container rounded-xl border border-surface-container-high p-5 mb-6">
-        <h2 className="font-display text-sm font-semibold text-on-surface mb-3">
+        <h2 className="font-headline text-sm font-semibold text-on-surface mb-3">
           Neue Zusammenfassung generieren
         </h2>
         <p className="text-xs text-on-surface-variant mb-4">
@@ -53,7 +53,7 @@ export default async function SummariesPage() {
               className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4 flex items-center gap-4 hover:border-outline hover:border-on-surface-variant transition-colors"
             >
               <div className="flex-1 min-w-0">
-                <p className="font-display font-semibold text-on-surface text-sm">
+                <p className="font-headline font-semibold text-on-surface text-sm">
                   {formatMonth(s.year, s.month)}
                 </p>
                 <p className="text-xs text-on-surface-variant mt-0.5">

--- a/src/app/admin/translations/[entryId]/page.tsx
+++ b/src/app/admin/translations/[entryId]/page.tsx
@@ -43,7 +43,7 @@ export default async function TranslationDetailPage({ params }: TranslationDetai
               ← Übersetzungen
             </Link>
           </div>
-          <h1 className="font-display text-2xl font-bold text-on-surface">
+          <h1 className="font-headline text-2xl font-bold text-on-surface">
             {entry.title}
           </h1>
           <div className="flex items-center gap-3 mt-1">

--- a/src/app/admin/translations/page.tsx
+++ b/src/app/admin/translations/page.tsx
@@ -75,22 +75,22 @@ export default async function TranslationsPage() {
 
   return (
     <div>
-      <h1 className="font-display text-2xl font-bold text-on-surface mb-6">
+      <h1 className="font-headline text-2xl font-bold text-on-surface mb-6">
         Übersetzungen
       </h1>
 
       {/* Stats */}
       <div className="grid grid-cols-3 gap-3 mb-6">
         <div className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4">
-          <p className="text-2xl font-bold font-display text-movement-600 text-movement-400">{countCurrent}</p>
+          <p className="text-2xl font-bold font-headline text-movement-600 text-movement-400">{countCurrent}</p>
           <p className="text-xs text-on-surface-variant mt-0.5">Übersetzt</p>
         </div>
         <div className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4">
-          <p className="text-2xl font-bold font-display text-amber-600 text-amber-400">{countStale}</p>
+          <p className="text-2xl font-bold font-headline text-amber-600 text-amber-400">{countStale}</p>
           <p className="text-xs text-on-surface-variant mt-0.5">Veraltet</p>
         </div>
         <div className="bg-surface-container rounded-xl border border-surface-container-high px-5 py-4">
-          <p className="text-2xl font-bold font-display text-on-surface-variant">{countMissing}</p>
+          <p className="text-2xl font-bold font-headline text-on-surface-variant">{countMissing}</p>
           <p className="text-xs text-on-surface-variant mt-0.5">Fehlen</p>
         </div>
       </div>
@@ -116,7 +116,7 @@ export default async function TranslationsPage() {
                 </span>
 
                 <div className="flex-1 min-w-0">
-                  <p className="font-display font-semibold text-on-surface truncate text-sm">
+                  <p className="font-headline font-semibold text-on-surface truncate text-sm">
                     {entry.title}
                   </p>
                   <time className="text-xs text-on-surface-variant">{formatDate(entry.date)}</time>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Playfair_Display, Lora } from 'next/font/google'
+import { Space_Grotesk, Manrope } from 'next/font/google'
 import { getLocale } from 'next-intl/server'
 import { headers } from 'next/headers'
 import '@/styles/globals.css'
@@ -7,14 +7,16 @@ import { AuthSessionProvider } from '@/components/providers/SessionProvider'
 import { ThemeProvider } from '@/components/providers/ThemeProvider'
 import { SITE_NAME, SITE_DESCRIPTION, SITE_URL } from '@/lib/site'
 
-const playfair = Playfair_Display({
+const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
-  variable: '--font-display',
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-headline',
   display: 'swap',
 })
 
-const lora = Lora({
+const manrope = Manrope({
   subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700', '800'],
   variable: '--font-body',
   display: 'swap',
 })
@@ -58,7 +60,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   const [locale, headersList] = await Promise.all([getLocale(), headers()])
   const nonce = headersList.get('x-nonce') ?? undefined
   return (
-    <html lang={locale} className={`${playfair.variable} ${lora.variable}`}>
+    <html lang={locale} className={`${spaceGrotesk.variable} ${manrope.variable}`}>
       <body className="bg-background text-on-surface font-body antialiased">
         <ThemeProvider nonce={nonce}>
           <AuthSessionProvider>

--- a/src/components/admin/DeleteEntryButton.tsx
+++ b/src/components/admin/DeleteEntryButton.tsx
@@ -60,7 +60,7 @@ export function DeleteEntryButton({ id, title }: DeleteEntryButtonProps) {
               <div>
                 <h2
                   id="delete-dialog-title"
-                  className="font-display font-bold text-lg text-on-surface leading-tight"
+                  className="font-headline font-bold text-lg text-on-surface leading-tight"
                 >
                   Eintrag löschen?
                 </h2>

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -152,7 +152,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Titel des Eintrags"
           required
-          className="w-full font-display text-2xl font-bold bg-transparent border-0 border-b-2 border-surface-container-high focus:border-nutrition-500 focus:outline-none pb-2 text-on-surface placeholder:text-outline transition-colors"
+          className="w-full font-headline text-2xl font-bold bg-transparent border-0 border-b-2 border-surface-container-high focus:border-nutrition-500 focus:outline-none pb-2 text-on-surface placeholder:text-outline transition-colors"
         />
       </div>
 

--- a/src/components/admin/EntryPreview.tsx
+++ b/src/components/admin/EntryPreview.tsx
@@ -133,7 +133,7 @@ export function EntryPreview({
         {/* Header */}
         <header className="mb-10">
           <div className="flex items-center gap-3 mb-4">
-            <span className="font-display font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-2 py-0.5">
+            <span className="font-headline font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-2 py-0.5">
               Tag {dayNumber}
             </span>
             {formattedDate && (
@@ -144,7 +144,7 @@ export function EntryPreview({
             )}
           </div>
 
-          <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight text-on-surface mb-5">
+          <h1 className="font-headline text-3xl sm:text-4xl font-bold leading-tight text-on-surface mb-5">
             {title || <span className="text-outline font-normal italic">Titel…</span>}
           </h1>
 

--- a/src/components/admin/FitbitSyncPanel.tsx
+++ b/src/components/admin/FitbitSyncPanel.tsx
@@ -116,7 +116,7 @@ export function FitbitSyncPanel() {
     <div className="space-y-6">
       {/* Single day */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-4">
           Einzelnen Tag synchronisieren
         </h3>
         <div className="flex flex-wrap items-end gap-3">
@@ -144,7 +144,7 @@ export function FitbitSyncPanel() {
 
       {/* Date range backfill */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-1">
           Zeitraum nachfüllen (Backfill)
         </h3>
         <p className="text-xs text-on-surface-variant mb-4">Maximal 30 Tage auf einmal.</p>

--- a/src/components/admin/HabitsPicker.tsx
+++ b/src/components/admin/HabitsPicker.tsx
@@ -91,7 +91,7 @@ export function HabitsPicker({
     <div className="bg-surface-container rounded-2xl border border-surface-container-high overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-surface-container">
-        <h3 className="font-display text-sm font-semibold text-on-surface">Die drei Säulen</h3>
+        <h3 className="font-headline text-sm font-semibold text-on-surface">Die drei Säulen</h3>
         <span
           className={clsx(
             'text-xs font-medium px-2 py-0.5 rounded-full',

--- a/src/components/admin/MetricsForm.tsx
+++ b/src/components/admin/MetricsForm.tsx
@@ -125,7 +125,7 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
 
       {/* Körperwerte */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">Körperwerte</h3>
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-4">Körperwerte</h3>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <MetricField label="Gewicht" unit="kg" value={weight} onChange={setWeight} step="0.1" />
           <MetricField label="Körperfett" unit="%" value={bodyFat} onChange={setBodyFat} step="0.1" />
@@ -135,7 +135,7 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
 
       {/* Aktivität */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">Aktivität</h3>
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-4">Aktivität</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <MetricField label="Schritte" unit="Schritte" value={steps} onChange={setSteps} step="1" inputMode="numeric" />
           <MetricField label="Aktive Minuten" unit="min" value={activeMinutes} onChange={setActiveMinutes} step="1" inputMode="numeric" />
@@ -146,7 +146,7 @@ export function MetricsForm({ date, initial }: MetricsFormProps) {
 
       {/* Vitalwerte */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-4">Vitalwerte</h3>
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-4">Vitalwerte</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <MetricField label="Ruheherzfrequenz" unit="bpm" value={restingHR} onChange={setRestingHR} step="1" inputMode="numeric" />
           <MetricField label="Schlafdauer" unit="min" value={sleepDuration} onChange={setSleepDuration} step="1" inputMode="numeric" />

--- a/src/components/admin/SettingsForm.tsx
+++ b/src/components/admin/SettingsForm.tsx
@@ -68,7 +68,7 @@ export function SettingsForm({ initial }: SettingsFormProps) {
     <form onSubmit={handleSubmit} className="space-y-6">
       {/* Körperprofil */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">Körperprofil</h3>
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-1">Körperprofil</h3>
         <p className="text-xs text-on-surface-variant mb-4">Wird für die automatische BMI-Berechnung verwendet.</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <SettingField
@@ -84,7 +84,7 @@ export function SettingsForm({ initial }: SettingsFormProps) {
 
       {/* Ziele */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">Ziele</h3>
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-1">Ziele</h3>
         <p className="text-xs text-on-surface-variant mb-4">Persönliche Zielwerte für die Metriken-Darstellung.</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <SettingField
@@ -109,7 +109,7 @@ export function SettingsForm({ initial }: SettingsFormProps) {
 
       {/* Projekt */}
       <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <h3 className="font-display text-sm font-semibold text-on-surface mb-1">Projekt</h3>
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-1">Projekt</h3>
         <p className="text-xs text-on-surface-variant mb-4">Bestimmt den Projekttag für alle Anzeigen (Tag 1 = Startdatum).</p>
         <div className="max-w-xs">
           <label className="block text-xs font-medium text-on-surface-variant mb-1">

--- a/src/components/admin/TiptapEditor.tsx
+++ b/src/components/admin/TiptapEditor.tsx
@@ -119,7 +119,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('heading', { level: 2 })}
           title="Überschrift 2"
         >
-          <span className="text-xs font-bold font-display">H2</span>
+          <span className="text-xs font-bold font-headline">H2</span>
         </ToolbarButton>
 
         <ToolbarButton
@@ -127,7 +127,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('heading', { level: 3 })}
           title="Überschrift 3"
         >
-          <span className="text-xs font-bold font-display">H3</span>
+          <span className="text-xs font-bold font-headline">H3</span>
         </ToolbarButton>
 
         <Divider />

--- a/src/components/habits/HabitPillar.tsx
+++ b/src/components/habits/HabitPillar.tsx
@@ -56,7 +56,7 @@ export function HabitPillar({ pillar, streak, totalFulfilled, totalEntries, days
       <div className="p-5 space-y-5">
         <div className="flex items-center gap-2">
           <span className="text-xl" aria-hidden="true">{cfg.emoji}</span>
-          <h3 className={`font-display font-semibold text-base ${cfg.textColorClass}`}>
+          <h3 className={`font-headline font-semibold text-base ${cfg.textColorClass}`}>
             {title}
           </h3>
         </div>

--- a/src/components/habits/HabitStreak.tsx
+++ b/src/components/habits/HabitStreak.tsx
@@ -27,7 +27,7 @@ export function HabitStreak({
     <div className="space-y-3">
       <div>
         <div className="flex items-baseline gap-2">
-          <span className={`text-5xl font-bold font-display leading-none ${textColorClass}`}>
+          <span className={`text-5xl font-bold font-headline leading-none ${textColorClass}`}>
             {current}
           </span>
           <span className="text-sm text-on-surface-variant font-medium leading-tight">{label}</span>

--- a/src/components/habits/HabitYearGrid.tsx
+++ b/src/components/habits/HabitYearGrid.tsx
@@ -133,7 +133,7 @@ export function HabitYearGrid({ movementDays, nutritionDays, smokingDays }: Habi
 
   return (
     <div className="mt-3 bg-surface-container rounded-2xl border border-surface-container-high p-5">
-      <h3 className="font-display text-sm font-semibold text-on-surface mb-4">
+      <h3 className="font-headline text-sm font-semibold text-on-surface mb-4">
         {tDash('yearOverview')}
       </h3>
 

--- a/src/components/habits/HabitsDashboard.tsx
+++ b/src/components/habits/HabitsDashboard.tsx
@@ -60,7 +60,7 @@ export async function HabitsDashboard() {
   return (
     <section className="mb-14">
       <div className="flex items-baseline gap-3 mb-5">
-        <h2 className="font-display text-xl font-bold text-on-surface">{t('heading')}</h2>
+        <h2 className="font-headline text-xl font-bold text-on-surface">{t('heading')}</h2>
         <span className="text-xs text-on-surface-variant font-medium tracking-wide uppercase">
           {t('dayCount', { count: entries.length })}
         </span>

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -45,7 +45,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
         ) : (
           <div className="relative px-6 pt-5 pb-0 overflow-hidden select-none" aria-hidden="true">
             <span
-              className="block font-display font-bold leading-none text-surface-container text-surface-container"
+              className="block font-headline font-bold leading-none text-surface-container text-surface-container"
               style={{ fontSize: 'clamp(4.5rem, 18vw, 7.5rem)' }}
             >
               {String(dayNumber).padStart(2, '0')}
@@ -55,7 +55,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
 
         <div className="px-6 py-5 space-y-3">
           <div className="flex items-center gap-2.5">
-            <span className="font-display font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-1.5 py-0.5">
+            <span className="font-headline font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-1.5 py-0.5">
               {t('day', { number: dayNumber })}
             </span>
             <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
@@ -64,7 +64,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
             </time>
           </div>
 
-          <h2 className="font-display text-xl sm:text-2xl font-bold leading-snug text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-400 transition-colors duration-200">
+          <h2 className="font-headline text-xl sm:text-2xl font-bold leading-snug text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-400 transition-colors duration-200">
             {entry.title}
           </h2>
 

--- a/src/components/journal/JournalCardCompact.tsx
+++ b/src/components/journal/JournalCardCompact.tsx
@@ -50,7 +50,7 @@ export async function JournalCardCompact({ entry }: JournalCardCompactProps) {
             />
           ) : (
             <span
-              className="absolute inset-0 flex items-center justify-center font-display font-bold text-outline text-surface-container-highest text-sm"
+              className="absolute inset-0 flex items-center justify-center font-headline font-bold text-outline text-surface-container-highest text-sm"
             >
               {String(dayNumber).padStart(2, '0')}
             </span>

--- a/src/components/journal/JournalFeed 2.tsx
+++ b/src/components/journal/JournalFeed 2.tsx
@@ -9,7 +9,7 @@ export function JournalFeed({ entries }: JournalFeedProps) {
   if (entries.length === 0) {
     return (
       <div className="py-20 text-center text-on-surface-variant">
-        <p className="font-display text-2xl mb-2">Noch keine Einträge</p>
+        <p className="font-headline text-2xl mb-2">Noch keine Einträge</p>
         <p className="text-sm">Die ersten Einträge folgen bald.</p>
       </div>
     )

--- a/src/components/journal/JournalFeed.tsx
+++ b/src/components/journal/JournalFeed.tsx
@@ -12,7 +12,7 @@ export function JournalFeed({ entries }: JournalFeedProps) {
   if (entries.length === 0) {
     return (
       <div className="py-20 text-center">
-        <p className="font-display text-2xl text-outline mb-2">{t('empty')}</p>
+        <p className="font-headline text-2xl text-outline mb-2">{t('empty')}</p>
         <p className="text-sm text-on-surface-variant">{t('emptyHint')}</p>
       </div>
     )

--- a/src/components/journal/JournalPost.tsx
+++ b/src/components/journal/JournalPost.tsx
@@ -49,7 +49,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
 
       <header className="mb-10">
         <div className="flex items-center gap-3 mb-4">
-          <span className="font-display font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-2 py-0.5">
+          <span className="font-headline font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-2 py-0.5">
             {t('day', { number: dayNumber })}
           </span>
           <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
@@ -69,7 +69,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
           )}
         </div>
 
-        <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight text-on-surface mb-5">
+        <h1 className="font-headline text-3xl sm:text-4xl font-bold leading-tight text-on-surface mb-5">
           {entry.title}
         </h1>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
   return (
     <footer className="border-t border-surface-container-high mt-24">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 py-10 flex flex-col sm:flex-row items-center justify-between gap-2">
-        <p className="font-display font-bold text-on-surface">
+        <p className="font-headline font-bold text-on-surface">
           Project <span className="text-nutrition-600">365</span>
         </p>
         <div className="flex items-center gap-4">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ export function Header() {
     <header className="border-b border-surface-container-high bg-background/95 bg-surface-container-low/95 backdrop-blur-sm sticky top-0 z-10">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         <Link href="/" className="group flex items-center gap-2">
-          <span className="font-display text-lg font-bold tracking-tight text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-500 transition-colors">
+          <span className="font-headline text-lg font-bold tracking-tight text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-500 transition-colors">
             Project <span className="text-nutrition-600">365</span>
           </span>
         </Link>

--- a/src/components/metrics/BodyFatChart.tsx
+++ b/src/components/metrics/BodyFatChart.tsx
@@ -64,9 +64,9 @@ export function BodyFatChart({ data, latestBodyFat }: BodyFatChartProps) {
   return (
     <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
       <div className="flex items-baseline justify-between mb-4">
-        <h3 className="font-display font-semibold text-sm text-on-surface">{t('bodyFat')}</h3>
+        <h3 className="font-headline font-semibold text-sm text-on-surface">{t('bodyFat')}</h3>
         {latestBodyFat !== undefined && (
-          <span className="text-2xl font-bold font-display text-on-surface-variant text-on-surface-variant">
+          <span className="text-2xl font-bold font-headline text-on-surface-variant text-on-surface-variant">
             {latestBodyFat.toFixed(1)}{' '}
             <span className="text-sm font-normal text-on-surface-variant">%</span>
           </span>

--- a/src/components/metrics/MetricsDashboard.tsx
+++ b/src/components/metrics/MetricsDashboard.tsx
@@ -18,7 +18,7 @@ function EmptyState() {
   const t = useTranslations('MetricsDashboard')
   return (
     <div className="rounded-2xl border border-surface-container-high bg-surface-container px-6 py-10 text-center">
-      <p className="font-display text-lg text-on-surface-variant mb-1">{t('noData')}</p>
+      <p className="font-headline text-lg text-on-surface-variant mb-1">{t('noData')}</p>
       <p className="text-sm text-on-surface-variant">{t('noDataHint')}</p>
     </div>
   )
@@ -57,7 +57,7 @@ export async function MetricsDashboard() {
 
   return (
     <section className="mb-14">
-      <h2 className="font-display text-xl font-bold text-on-surface mb-5">{t('heading')}</h2>
+      <h2 className="font-headline text-xl font-bold text-on-surface mb-5">{t('heading')}</h2>
 
       {!hasAnyData ? (
         <EmptyState />

--- a/src/components/metrics/StepsChart.tsx
+++ b/src/components/metrics/StepsChart.tsx
@@ -66,9 +66,9 @@ export function StepsChart({ data, avgSteps, stepsGoal = 10000 }: StepsChartProp
   return (
     <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 h-full">
       <div className="flex items-baseline justify-between mb-4">
-        <h3 className="font-display font-semibold text-sm text-on-surface">{t('steps')}</h3>
+        <h3 className="font-headline font-semibold text-sm text-on-surface">{t('steps')}</h3>
         {avgSteps !== undefined && (
-          <span className="text-2xl font-bold font-display text-movement-700 text-movement-400">
+          <span className="text-2xl font-bold font-headline text-movement-700 text-movement-400">
             {formatSteps(avgSteps)}{' '}
             <span className="text-sm font-normal text-on-surface-variant">{t('avgPerDay')}</span>
           </span>

--- a/src/components/metrics/WeightChart.tsx
+++ b/src/components/metrics/WeightChart.tsx
@@ -64,9 +64,9 @@ export function WeightChart({ data, latestWeight }: WeightChartProps) {
   return (
     <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 h-full">
       <div className="flex items-baseline justify-between mb-4">
-        <h3 className="font-display font-semibold text-sm text-on-surface">{t('weight')}</h3>
+        <h3 className="font-headline font-semibold text-sm text-on-surface">{t('weight')}</h3>
         {latestWeight !== undefined && (
-          <span className="text-2xl font-bold font-display text-nutrition-700 text-nutrition-400">
+          <span className="text-2xl font-bold font-headline text-nutrition-700 text-nutrition-400">
             {latestWeight.toFixed(1)}{' '}
             <span className="text-sm font-normal text-on-surface-variant">kg</span>
           </span>

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -196,7 +196,7 @@ export function SearchModal() {
                       }`}
                     >
                       <div className="flex items-baseline gap-2 mb-0.5">
-                        <span className="font-display font-semibold text-sm text-on-surface">
+                        <span className="font-headline font-semibold text-sm text-on-surface">
                           <Highlight text={result.title} query={query} />
                         </span>
                         <span className="text-xs text-on-surface-variant shrink-0">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,7 +40,7 @@
   }
 
   body {
-    font-family: var(--font-body), Georgia, serif;
+    font-family: var(--font-body), sans-serif;
     background-color: var(--background);
     color: var(--on-surface);
     -webkit-font-smoothing: antialiased;
@@ -49,7 +49,7 @@
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-display), Georgia, serif;
+    font-family: var(--font-headline), sans-serif;
   }
 
   ::selection {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -98,10 +98,10 @@ const config: Config = {
       },
 
       fontFamily: {
-        display:  ['var(--font-display)', 'Georgia', 'serif'],
-        body:     ['var(--font-body)',    'Georgia', 'serif'],
-        headline: ['var(--font-display)', 'Georgia', 'serif'],
-        label:    ['var(--font-body)',    'sans-serif'],
+        headline: ['var(--font-headline)', 'sans-serif'],
+        display:  ['var(--font-headline)', 'sans-serif'],  // alias for backward compat
+        body:     ['var(--font-body)',     'sans-serif'],
+        label:    ['var(--font-body)',     'sans-serif'],
       },
 
       typography: {
@@ -125,11 +125,11 @@ const config: Config = {
             '--tw-prose-invert-quote-borders': '#484847',
             '--tw-prose-invert-captions':      '#adaaaa',
             '--tw-prose-invert-code':          '#ffffff',
-            fontFamily: 'var(--font-body), Georgia, serif',
+            fontFamily: 'var(--font-body), sans-serif',
             lineHeight: '1.75',
             maxWidth: 'none',
-            h2: { fontFamily: 'var(--font-display), Georgia, serif' },
-            h3: { fontFamily: 'var(--font-display), Georgia, serif' },
+            h2: { fontFamily: 'var(--font-headline), sans-serif' },
+            h3: { fontFamily: 'var(--font-headline), sans-serif' },
           },
         },
       },


### PR DESCRIPTION
## Summary

- Replaces Playfair Display + Lora with Kinetic Lab fonts
- **Space Grotesk** (300–700) for headlines — `--font-headline` / `font-headline`
- **Manrope** (300–800) for body + labels — `--font-body` / `font-body`, `font-label`
- Renamed `font-display` → `font-headline` across 41 component/page files
- Updated `tailwind.config.ts` fontFamily + prose typography settings
- Updated `globals.css` h1–h6 and body font-family references
- `font-display` kept as alias in Tailwind for safety

Closes #126

## Test plan

- [ ] Build passes ✅
- [ ] Fonts visually load at `/de` (Space Grotesk for headings, Manrope for body)
- [ ] Admin area fonts look correct
- [ ] No serif fallback fonts appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)