### PR TITLE
feat: Material Symbols Icons + Glassmorphism (Issues #127, #128)

### DIFF
--- a/scripts/migrate-fonts 2.py
+++ b/scripts/migrate-fonts 2.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Issue #126: Migrate font class names
+- font-display → font-headline (in TSX/TS/CSS files)
+- --font-display → --font-headline (CSS custom property references)
+"""
+
+import os
+import sys
+
+SRC_DIR = os.path.join(os.path.dirname(__file__), '..', 'src')
+EXTENSIONS = ('.tsx', '.ts', '.css')
+
+REPLACEMENTS = [
+    ('font-display font-semibold', 'font-headline font-semibold'),
+    ('font-display font-bold',     'font-headline font-bold'),
+    ('font-display font-semibold', 'font-headline font-semibold'),
+    ('font-display text-',        'font-headline text-'),
+    ('"font-display"',            '"font-headline"'),
+    ("'font-display'",            "'font-headline'"),
+    # Generic catch-all (e.g. "font-display" followed by space or end of class string)
+    ('font-display',              'font-headline'),
+    # CSS variable
+    ('var(--font-display)',       'var(--font-headline)'),
+    ('--font-display',            '--font-headline'),
+]
+
+changed = []
+skipped = []
+
+for root, dirs, files in os.walk(SRC_DIR):
+    dirs[:] = [d for d in dirs if d not in ('node_modules', '.next')]
+    for fname in files:
+        if not any(fname.endswith(ext) for ext in EXTENSIONS):
+            continue
+        path = os.path.join(root, fname)
+        with open(path, 'r', encoding='utf-8') as f:
+            original = f.read()
+        content = original
+        for old, new in REPLACEMENTS:
+            content = content.replace(old, new)
+        if content != original:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(content)
+            changed.append(os.path.relpath(path, os.path.join(SRC_DIR, '..')))
+        else:
+            skipped.append(os.path.relpath(path, os.path.join(SRC_DIR, '..')))
+
+print(f"\n✅ Changed {len(changed)} files:")
+for p in changed:
+    print(f"   {p}")
+print(f"\n⏭  Skipped {len(skipped)} files (no changes needed)")

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,6 +61,16 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   const nonce = headersList.get('x-nonce') ?? undefined
   return (
     <html lang={locale} className={`${spaceGrotesk.variable} ${manrope.variable}`}>
+      {/* Material Symbols Outlined — loaded from Google Fonts CDN (not in next/font)
+          CSP updated to allow fonts.googleapis.com + fonts.gstatic.com */}
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+          rel="stylesheet"
+        />
+      </head>
       <body className="bg-background text-on-surface font-body antialiased">
         <ThemeProvider nonce={nonce}>
           <AuthSessionProvider>

--- a/src/components/admin/TiptapEditor.tsx
+++ b/src/components/admin/TiptapEditor.tsx
@@ -6,6 +6,7 @@ import Placeholder from '@tiptap/extension-placeholder'
 import Link from '@tiptap/extension-link'
 import Typography from '@tiptap/extension-typography'
 import { clsx } from 'clsx'
+import { Icon } from '@/components/ui/Icon'
 
 interface TiptapEditorProps {
   content: string
@@ -94,10 +95,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('bold')}
           title="Fett (⌘B)"
         >
-          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" />
-            <path d="M6 12h9a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" />
-          </svg>
+          <Icon name="format_bold" size={18} />
         </ToolbarButton>
 
         <ToolbarButton
@@ -105,11 +103,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('italic')}
           title="Kursiv (⌘I)"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
-            <line x1="19" y1="4" x2="10" y2="4" />
-            <line x1="14" y1="20" x2="5" y2="20" />
-            <line x1="15" y1="4" x2="9" y2="20" />
-          </svg>
+          <Icon name="format_italic" size={18} />
         </ToolbarButton>
 
         <Divider />
@@ -119,7 +113,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('heading', { level: 2 })}
           title="Überschrift 2"
         >
-          <span className="text-xs font-bold font-headline">H2</span>
+          <Icon name="format_h2" size={18} />
         </ToolbarButton>
 
         <ToolbarButton
@@ -127,7 +121,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('heading', { level: 3 })}
           title="Überschrift 3"
         >
-          <span className="text-xs font-bold font-headline">H3</span>
+          <Icon name="format_h3" size={18} />
         </ToolbarButton>
 
         <Divider />
@@ -137,14 +131,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('bulletList')}
           title="Liste"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-            <line x1="9" y1="6" x2="20" y2="6" />
-            <line x1="9" y1="12" x2="20" y2="12" />
-            <line x1="9" y1="18" x2="20" y2="18" />
-            <circle cx="4" cy="6" r="1.5" fill="currentColor" stroke="none" />
-            <circle cx="4" cy="12" r="1.5" fill="currentColor" stroke="none" />
-            <circle cx="4" cy="18" r="1.5" fill="currentColor" stroke="none" />
-          </svg>
+          <Icon name="format_list_bulleted" size={18} />
         </ToolbarButton>
 
         <ToolbarButton
@@ -152,14 +139,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('orderedList')}
           title="Nummerierte Liste"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-            <line x1="10" y1="6" x2="21" y2="6" />
-            <line x1="10" y1="12" x2="21" y2="12" />
-            <line x1="10" y1="18" x2="21" y2="18" />
-            <path d="M4 6h1v4" stroke="currentColor" strokeWidth={2} strokeLinecap="round" />
-            <path d="M4 10h2" stroke="currentColor" strokeWidth={2} strokeLinecap="round" />
-            <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+          <Icon name="format_list_numbered" size={18} />
         </ToolbarButton>
 
         <ToolbarButton
@@ -167,10 +147,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('blockquote')}
           title="Zitat"
         >
-          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V20c0 1 0 1 1 1z" />
-            <path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2h.75c0 2.25.25 4-2.75 4v3c0 1 0 1 1 1z" />
-          </svg>
+          <Icon name="format_quote" size={18} />
         </ToolbarButton>
 
         <Divider />
@@ -180,10 +157,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           active={editor.isActive('link')}
           title="Link einfügen"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+          <Icon name="link" size={18} />
         </ToolbarButton>
 
         {editor.isActive('link') && (
@@ -191,14 +165,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
             onClick={() => editor.chain().focus().unsetLink().run()}
             title="Link entfernen"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-              <path d="M18.84 12.25l1.72-1.71h-.02a5.004 5.004 0 0 0-.12-7.07 5.006 5.006 0 0 0-6.95 0l-1.72 1.71" strokeLinecap="round" strokeLinejoin="round" />
-              <path d="M5.17 11.75l-1.71 1.71a5.004 5.004 0 0 0 .12 7.07 5.006 5.006 0 0 0 6.95 0l1.71-1.71" strokeLinecap="round" strokeLinejoin="round" />
-              <line x1="8" y1="2" x2="8" y2="5" strokeLinecap="round" />
-              <line x1="2" y1="8" x2="5" y2="8" strokeLinecap="round" />
-              <line x1="16" y1="19" x2="16" y2="22" strokeLinecap="round" />
-              <line x1="19" y1="16" x2="22" y2="16" strokeLinecap="round" />
-            </svg>
+            <Icon name="link_off" size={18} />
           </ToolbarButton>
         )}
 
@@ -208,9 +175,7 @@ export function TiptapEditor({ content, onChange, placeholder }: TiptapEditorPro
           onClick={() => editor.chain().focus().setHorizontalRule().run()}
           title="Trennlinie"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-            <line x1="3" y1="12" x2="21" y2="12" strokeLinecap="round" />
-          </svg>
+          <Icon name="horizontal_rule" size={18} />
         </ToolbarButton>
       </div>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,7 +3,7 @@ import { Navigation } from './Navigation'
 
 export function Header() {
   return (
-    <header className="border-b border-surface-container-high bg-background/95 bg-surface-container-low/95 backdrop-blur-sm sticky top-0 z-10">
+    <header className="border-b border-outline-variant/15 bg-surface-container-low/80 backdrop-blur-xl sticky top-0 z-10">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
         <Link href="/" className="group flex items-center gap-2">
           <span className="font-headline text-lg font-bold tracking-tight text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-500 transition-colors">

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { useLocale, useTranslations } from 'next-intl'
 import type { SearchResult } from '@/app/api/search/route'
+import { Icon } from '@/components/ui/Icon'
 
 // =============================================
 // Highlight — wraps matched substring
@@ -123,12 +124,9 @@ export function SearchModal() {
         type="button"
         onClick={() => setOpen(true)}
         aria-label={t('ariaLabel')}
-        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container hover:bg-surface-container transition-colors"
+        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container transition-colors"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
-          <circle cx="11" cy="11" r="8" />
-          <path strokeLinecap="round" d="M21 21l-4.35-4.35" />
-        </svg>
+        <Icon name="search" size={18} />
         <span className="hidden sm:inline text-xs">
           <kbd className="font-sans text-on-surface-variant">⌘K</kbd>
         </span>
@@ -144,19 +142,16 @@ export function SearchModal() {
         >
           {/* Backdrop */}
           <div
-            className="absolute inset-0 bg-black/40 bg-black/60 backdrop-blur-sm"
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
             onClick={() => setOpen(false)}
           />
 
-          {/* Modal card */}
-          <div className="relative w-full max-w-xl bg-surface-container rounded-2xl border border-surface-container-high shadow-2xl overflow-hidden">
+          {/* Modal card — glassmorphism */}
+          <div className="relative w-full max-w-xl bg-surface-container-low/90 backdrop-blur-xl rounded-xl border border-outline-variant/20 shadow-2xl overflow-hidden">
 
             {/* Input row */}
-            <div className="flex items-center gap-3 px-4 border-b border-surface-container">
-              <svg className="w-4 h-4 text-on-surface-variant shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true">
-                <circle cx="11" cy="11" r="8" />
-                <path strokeLinecap="round" d="M21 21l-4.35-4.35" />
-              </svg>
+            <div className="flex items-center gap-3 px-4 border-b border-outline-variant/15">
+              <Icon name="search" size={18} className="text-on-surface-variant shrink-0" />
               <input
                 ref={inputRef}
                 type="text"
@@ -175,7 +170,7 @@ export function SearchModal() {
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="shrink-0 text-xs text-on-surface-variant hover:text-on-surface-variant hover:text-outline transition-colors px-1.5 py-1 rounded border border-surface-container-high"
+                className="shrink-0 text-xs text-on-surface-variant hover:text-outline transition-colors px-1.5 py-1 rounded border border-outline-variant/30"
               >
                 ESC
               </button>

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,0 +1,47 @@
+/**
+ * Material Symbols Outlined icon component.
+ *
+ * Usage:
+ *   <Icon name="search" />
+ *   <Icon name="close" size={20} fill />
+ *   <Icon name="format_bold" className="text-primary" />
+ *
+ * Icon names: https://fonts.google.com/icons
+ */
+
+interface IconProps {
+  /** Material Symbols ligature name, e.g. "search", "close", "format_bold" */
+  name: string
+  /** Font size in px (also controls optical size). Default: 20 */
+  size?: number
+  /** Render filled variant (FILL=1). Default: false (outlined) */
+  fill?: boolean
+  /** Additional Tailwind / CSS classes */
+  className?: string
+  'aria-hidden'?: boolean
+  'aria-label'?: string
+}
+
+export function Icon({
+  name,
+  size = 20,
+  fill = false,
+  className,
+  'aria-hidden': ariaHidden = true,
+  'aria-label': ariaLabel,
+}: IconProps) {
+  const opsz = Math.min(Math.max(size, 20), 48)
+  return (
+    <span
+      className={`material-symbols-outlined select-none leading-none${className ? ` ${className}` : ''}`}
+      style={{
+        fontSize: size,
+        fontVariationSettings: `'FILL' ${fill ? 1 : 0}, 'wght' 400, 'GRAD' 0, 'opsz' ${opsz}`,
+      }}
+      aria-hidden={ariaHidden || undefined}
+      aria-label={ariaLabel}
+    >
+      {name}
+    </span>
+  )
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,10 +10,12 @@ function buildCsp(nonce: string): string {
   const directives = [
     `default-src 'self'`,
     `script-src 'nonce-${nonce}' 'strict-dynamic'`,
-    `style-src 'self' 'unsafe-inline'`,
+    // Material Symbols is loaded from Google Fonts CDN (not available via next/font)
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
     // Google avatar images in admin layout use lh3.googleusercontent.com
     `img-src 'self' data: blob: https://*.googleusercontent.com`,
-    `font-src 'self'`,
+    // Material Symbols font files served from fonts.gstatic.com
+    `font-src 'self' https://fonts.gstatic.com`,
     `connect-src 'self'`,
     `media-src 'self'`,
     `object-src 'none'`,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,4 +62,24 @@
     outline-offset: 2px;
     border-radius: 2px;
   }
+
+  /* =============================================
+   * Material Symbols — variable font icon class
+   * ============================================= */
+  .material-symbols-outlined {
+    font-family: 'Material Symbols Outlined';
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: 'liga';
+  }
 }


### PR DESCRIPTION
## Summary

### Issue #127 — Material Symbols Outlined
- Variable font loaded via Google Fonts CDN (`opsz`, `wght`, `FILL`, `GRAD` axes)
- CSP in `middleware.ts` updated: `style-src` + `font-src` now allow `fonts.googleapis.com` / `fonts.gstatic.com`
- New `Icon` component at `src/components/ui/Icon.tsx` with `fill` and `size` props
- TiptapEditor toolbar: all inline SVGs replaced with Material Symbol icons
- SearchModal trigger: inline SVG replaced with `<Icon name="search" />`

### Issue #128 — Glassmorphism design tokens applied
- **Header**: `backdrop-blur-xl` + `bg-surface-container-low/80` + `border-outline-variant/15`
- **SearchModal card**: `backdrop-blur-xl` + `bg-surface-container-low/90` + `border-outline-variant/20`

Closes #127, #128

## Test plan

- [ ] Build passes ✅
- [ ] Material Symbol icons visible in TiptapEditor toolbar (format_bold, format_italic, etc.)
- [ ] Search icon appears in navigation trigger
- [ ] Header has glass blur effect when scrolling over content
- [ ] Search modal card has glass effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)