### PR TITLE
feat: Navigation + Footer im Kinetic Lab Stil (Issues #129, #133)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,26 +1,26 @@
 import { useTranslations } from 'next-intl'
+import { Icon } from '@/components/ui/Icon'
 
 export function Footer() {
   const t = useTranslations('Footer')
 
   return (
-    <footer className="border-t border-surface-container-high mt-24">
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-10 flex flex-col sm:flex-row items-center justify-between gap-2">
-        <p className="font-headline font-bold text-on-surface">
-          Project <span className="text-nutrition-600">365</span>
+    <footer className="border-t border-outline-variant/15 mt-24">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 flex flex-col sm:flex-row items-center justify-between gap-4">
+        <p className="font-headline font-bold tracking-tighter text-on-surface">
+          PROJECT <span className="text-primary">365</span>
         </p>
-        <div className="flex items-center gap-4">
-          <p className="text-xs text-on-surface-variant tracking-wide">
+
+        <div className="flex items-center gap-6">
+          <p className="text-xs font-label text-on-surface-variant tracking-widest uppercase">
             {t('tagline')}
           </p>
           <a
             href="/feed.xml"
             title={t('rssTitle')}
-            className="flex items-center gap-1.5 text-xs text-on-surface-variant hover:text-nutrition-600 hover:text-nutrition-500 transition-colors"
+            className="flex items-center gap-1.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant hover:text-primary transition-colors"
           >
-            <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20C4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z" />
-            </svg>
+            <Icon name="rss_feed" size={14} />
             {t('rss')}
           </a>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,13 +3,18 @@ import { Navigation } from './Navigation'
 
 export function Header() {
   return (
-    <header className="border-b border-outline-variant/15 bg-surface-container-low/80 backdrop-blur-xl sticky top-0 z-10">
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
-        <Link href="/" className="group flex items-center gap-2">
-          <span className="font-headline text-lg font-bold tracking-tight text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-500 transition-colors">
-            Project <span className="text-nutrition-600">365</span>
+    <header className="border-b border-outline-variant/15 bg-surface-container-low/80 backdrop-blur-xl sticky top-0 z-40">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+        {/* Logo */}
+        <Link href="/" className="group flex items-center gap-0.5">
+          <span className="font-headline font-bold tracking-tighter text-sm text-on-surface-variant group-hover:text-on-surface transition-colors">
+            PROJECT{' '}
+          </span>
+          <span className="font-headline font-bold tracking-tighter text-sm text-primary">
+            365
           </span>
         </Link>
+
         <Navigation />
       </div>
     </header>

--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -3,6 +3,7 @@
 import { useLocale } from 'next-intl'
 import { usePathname, useRouter } from '@/i18n/navigation'
 import { useTransition } from 'react'
+import { Icon } from '@/components/ui/Icon'
 
 const LOCALES = [
   { code: 'de', label: 'DE' },
@@ -18,26 +19,36 @@ export function LocaleSwitcher() {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
 
-  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const next = e.target.value as LocaleCode
+  function switchLocale(next: LocaleCode) {
     startTransition(() => {
       router.replace(pathname, { locale: next })
     })
   }
 
   return (
-    <select
-      value={locale}
-      onChange={handleChange}
-      disabled={isPending}
+    <div
+      className="flex items-center border border-outline-variant/20 rounded overflow-hidden"
       aria-label="Sprache / Language / Idioma"
-      className="h-8 px-1.5 rounded-lg text-xs font-semibold text-on-surface-variant bg-transparent hover:text-on-surface hover:bg-surface-container hover:bg-surface-container transition-colors disabled:opacity-50 cursor-pointer border-0 focus:outline-none focus:ring-2 focus:ring-outline focus:ring-surface-container-high"
     >
-      {LOCALES.map(({ code, label }) => (
-        <option key={code} value={code} className="bg-surface-container text-on-surface">
+      <Icon name="language" size={14} className="text-on-surface-variant ml-1.5 shrink-0" />
+      {LOCALES.map(({ code, label }, i) => (
+        <button
+          key={code}
+          type="button"
+          onClick={() => switchLocale(code)}
+          disabled={isPending || locale === code}
+          aria-current={locale === code ? 'true' : undefined}
+          className={[
+            'h-7 px-2 text-xs font-label font-bold tracking-widest transition-colors',
+            i > 0 ? 'border-l border-outline-variant/20' : '',
+            locale === code
+              ? 'text-on-surface cursor-default bg-surface-container'
+              : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container cursor-pointer disabled:opacity-40',
+          ].join(' ')}
+        >
           {label}
-        </option>
+        </button>
       ))}
-    </select>
+    </div>
   )
 }

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from 'next-intl/server'
 import { LocaleSwitcher } from './LocaleSwitcher'
 import { SearchModal } from '@/components/search/SearchModal'
 import { getAuthSession } from '@/lib/auth'
+import { Icon } from '@/components/ui/Icon'
 
 export async function Navigation() {
   const session = await getAuthSession()
@@ -10,21 +11,26 @@ export async function Navigation() {
   const t = await getTranslations('Navigation')
 
   return (
-    <nav className="flex items-center gap-2" aria-label={t('ariaLabel')}>
+    <nav className="flex items-center gap-1" aria-label={t('ariaLabel')}>
       <Link
         href="/"
-        className="text-sm font-medium text-on-surface-variant hover:text-on-surface transition-colors"
+        className="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant hover:text-on-surface hover:bg-surface-container transition-colors"
       >
+        <Icon name="article" size={16} />
         {t('journal')}
       </Link>
+
       <SearchModal />
+
       <LocaleSwitcher />
+
       {isAdmin && (
         <Link
           href="/admin"
-          className="text-sm font-medium text-primary hover:text-primary-container transition-colors"
           title={t('adminTitle')}
+          className="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs font-label font-bold tracking-widest uppercase text-primary hover:text-on-surface hover:bg-primary/10 transition-colors"
         >
+          <Icon name="shield_person" size={16} />
           {t('admin')}
         </Link>
       )}


### PR DESCRIPTION
## Summary

### Issue #129 — Navigation im Kinetic-Stil redesignen
- **Header**: `max-w-4xl`, Logo `"PROJECT 365"` mit `text-primary` Akzent, `font-headline font-bold tracking-tighter`
- **Navigation links**: `font-label font-bold tracking-widest uppercase` + Material Symbol Icons (`article` für Journal, `shield_person` für Admin)
- **LocaleSwitcher**: `<select>` → Pill-Button-Gruppe mit `language`-Icon, Border-Divider, aktiver Locale hervorgehoben
- **Admin-Link**: primary Farbe + `hover:bg-primary/10`

### Issue #133 — Footer im neuen Design-Stil
- Logo `"PROJECT 365"` konsistent mit Header
- `font-label tracking-widest uppercase` für Tagline + RSS
- Material Symbol `rss_feed` Icon
- `border-outline-variant/15` Border (konsistent mit Header-Glassmorphism)
- `max-w-4xl` Container (konsistent mit Header)

Closes #129, #133

## Test plan

- [ ] Build passes ✅
- [ ] Navigation links zeigen uppercase Labels mit Icons
- [ ] LocaleSwitcher: Pill-Buttons, aktive Locale hervorgehoben, Locale-Wechsel funktioniert
- [ ] Footer: "PROJECT 365" mit Primary-Akzent, RSS-Link mit Icon
- [ ] Admin-Link erscheint nur wenn eingeloggt

🤖 Generated with [Claude Code](https://claude.com/claude-code)