### PR TITLE
feat: Hero-Section mit Glow-Hintergrund und CTA (Issue #130)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -22,6 +22,7 @@
     "entriesHeading": "Einträge",
     "allEntries": "Alle {count} Einträge anzeigen",
     "streakDays": "Tage",
+    "ctaEntries": "Einträge lesen",
     "streakMovement": "Aktuelle Bewegungs-Serie",
     "streakNutrition": "Aktuelle Ernährungs-Serie",
     "streakSmoking": "Aktuelle Rauchstopp-Serie"

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,6 +22,7 @@
     "entriesHeading": "Entries",
     "allEntries": "Show all {count} entries",
     "streakDays": "days",
+    "ctaEntries": "Read entries",
     "streakMovement": "Current movement streak",
     "streakNutrition": "Current nutrition streak",
     "streakSmoking": "Current smoke-free streak"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -22,6 +22,7 @@
     "entriesHeading": "Entradas",
     "allEntries": "Ver todas as {count} entradas",
     "streakDays": "dias",
+    "ctaEntries": "Ler entradas",
     "streakMovement": "Sequência atual de movimento",
     "streakNutrition": "Sequência atual de alimentação",
     "streakSmoking": "Sequência atual sem fumar"

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -11,10 +11,10 @@ import {
   isSmokingFulfilled,
 } from '@/lib/habits'
 import { JournalCardCompact } from '@/components/journal/JournalCardCompact'
-import { JournalFeed } from '@/components/journal/JournalFeed'
 import { HabitsDashboard } from '@/components/habits/HabitsDashboard'
 import { MetricsDashboard } from '@/components/metrics/MetricsDashboard'
 import { HomeTabs } from '@/components/home/HomeTabs'
+import { Icon } from '@/components/ui/Icon'
 import {
   SITE_NAME,
   SITE_DESCRIPTION,
@@ -84,89 +84,125 @@ export default async function HomePage({ params }: HomePageProps) {
   const smokingStreak   = calculateStreak(entries.map((e) => isSmokingFulfilled(e.habits.smoking)))
 
   return (
-    <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
+    <div>
 
-      {/* ── Hero ───────────────────────────────────── */}
-      <header className="mb-10">
-        <p className="text-xs font-medium tracking-widest uppercase text-on-surface-variant mb-3">
-          {t('tagline')}
-        </p>
+      {/* ── Hero Section ───────────────────────────────────────────── */}
+      <section className="relative overflow-hidden border-b border-outline-variant/10">
 
-        <h1 className="font-headline text-4xl sm:text-5xl font-bold leading-tight text-on-surface mb-4">
-          <span className="block">{t('headline_1')}</span>
-          <span className="block">{t('headline_2')}</span>
-        </h1>
-
-        <p className="text-lg text-on-surface-variant max-w-xl leading-relaxed mb-6">
-          {t('description')}
-        </p>
-
-        {/* Day counter + streaks */}
-        <div className="p-4 rounded-xl bg-surface-container border border-surface-container-high">
-          <div className="flex items-baseline gap-3 mb-3">
-            <p className="font-headline text-3xl font-bold text-primary leading-none">
-              {currentDay}
-            </p>
-            <p className="text-xs text-on-surface-variant">
-              {t('dayCounter', { day: currentDay })}
-            </p>
-          </div>
-
-          {/* Habit streaks */}
-          <div className="flex gap-4">
-            <div className="flex items-center gap-1.5" title={t('streakMovement')}>
-              <span className="text-base leading-none">🏃</span>
-              <span className="text-sm font-semibold text-on-surface tabular-nums">{movementStreak.current}</span>
-              <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
-            </div>
-            <div className="flex items-center gap-1.5" title={t('streakNutrition')}>
-              <span className="text-base leading-none">🥗</span>
-              <span className="text-sm font-semibold text-on-surface tabular-nums">{nutritionStreak.current}</span>
-              <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
-            </div>
-            <div className="flex items-center gap-1.5" title={t('streakSmoking')}>
-              <span className="text-base leading-none">🚭</span>
-              <span className="text-sm font-semibold text-on-surface tabular-nums">{smokingStreak.current}</span>
-              <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
-            </div>
-          </div>
+        {/* Subtle warm glow backdrop */}
+        <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+          <div className="absolute -top-40 left-1/2 -translate-x-1/2 w-[900px] h-[500px] rounded-full bg-primary/[0.04] blur-3xl" />
         </div>
-      </header>
 
-      {/* ── Tabs ───────────────────────────────────── */}
-      <HomeTabs
-        labels={{
-          entries: t('tabEntries'),
-          habits:  t('tabHabits'),
-          metrics: t('tabMetrics'),
-        }}
-        entriesContent={
-          <div>
-            <div className="space-y-1">
-              {previewEntries.map((entry) => (
-                <JournalCardCompact key={entry.slug} entry={entry} />
-              ))}
-            </div>
-            {hasMore && (
-              <div className="mt-6 pt-5 border-t border-surface-container-high border-surface-container">
-                <details className="group">
-                  <summary className="cursor-pointer text-sm font-medium text-on-surface-variant hover:text-primary transition-colors list-none flex items-center gap-2">
-                    <span className="group-open:hidden">{t('allEntries', { count: entries.length })}</span>
-                    <span className="hidden group-open:inline">Weniger anzeigen</span>
-                  </summary>
-                  <div className="mt-4 space-y-1">
-                    {entries.slice(FEED_PREVIEW_COUNT).map((entry) => (
-                      <JournalCardCompact key={entry.slug} entry={entry} />
-                    ))}
-                  </div>
-                </details>
-              </div>
-            )}
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 pt-16 pb-14 sm:pt-24 sm:pb-20">
+
+          {/* Live day badge */}
+          <div className="inline-flex items-center gap-2 mb-8 px-3 py-1.5 rounded border border-primary/20 bg-primary/5">
+            <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" aria-hidden="true" />
+            <span className="text-xs font-label font-bold tracking-widest uppercase text-primary">
+              {t('dayCounter', { day: currentDay })}
+            </span>
           </div>
-        }
-        habitsContent={<HabitsDashboard />}
-        metricsContent={<MetricsDashboard />}
-      />
+
+          {/* Headline */}
+          <h1 className="font-headline font-bold tracking-tighter leading-none mb-6">
+            <span className="block text-5xl sm:text-7xl text-on-surface">{t('headline_1')}</span>
+            <span className="block text-5xl sm:text-7xl text-primary">{t('headline_2')}</span>
+          </h1>
+
+          {/* Description */}
+          <p className="text-base sm:text-lg text-on-surface-variant max-w-lg leading-relaxed mb-8">
+            {t('description')}
+          </p>
+
+          {/* CTAs */}
+          <div className="flex flex-wrap items-center gap-3 mb-12">
+            <a
+              href="#journal"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-primary text-on-primary font-label font-bold tracking-widest uppercase text-xs rounded hover:bg-primary-container transition-colors"
+            >
+              <Icon name="arrow_downward" size={14} />
+              {t('ctaEntries')}
+            </a>
+            <a
+              href="#journal"
+              className="inline-flex items-center gap-2 px-5 py-2.5 border border-outline-variant/30 text-on-surface-variant font-label font-bold tracking-widest uppercase text-xs rounded hover:bg-surface-container hover:text-on-surface transition-colors"
+            >
+              {t('tabHabits')}
+            </a>
+          </div>
+
+          {/* Streak indicators */}
+          <div className="flex flex-wrap gap-8">
+            <div className="flex items-center gap-2.5" title={t('streakMovement')}>
+              <span className="text-xl leading-none" aria-hidden="true">🏃</span>
+              <div className="flex items-baseline gap-1">
+                <span className="text-2xl font-headline font-bold text-movement-400 leading-none tabular-nums">
+                  {movementStreak.current}
+                </span>
+                <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2.5" title={t('streakNutrition')}>
+              <span className="text-xl leading-none" aria-hidden="true">🥗</span>
+              <div className="flex items-baseline gap-1">
+                <span className="text-2xl font-headline font-bold text-nutrition-400 leading-none tabular-nums">
+                  {nutritionStreak.current}
+                </span>
+                <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2.5" title={t('streakSmoking')}>
+              <span className="text-xl leading-none" aria-hidden="true">🚭</span>
+              <div className="flex items-baseline gap-1">
+                <span className="text-2xl font-headline font-bold text-smoking-400 leading-none tabular-nums">
+                  {smokingStreak.current}
+                </span>
+                <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </section>
+
+      {/* ── Journal / Habits / Metrics Tabs ────────────────────────── */}
+      <section id="journal" className="max-w-4xl mx-auto px-4 sm:px-6 py-12">
+        <HomeTabs
+          labels={{
+            entries: t('tabEntries'),
+            habits:  t('tabHabits'),
+            metrics: t('tabMetrics'),
+          }}
+          entriesContent={
+            <div>
+              <div className="space-y-1">
+                {previewEntries.map((entry) => (
+                  <JournalCardCompact key={entry.slug} entry={entry} />
+                ))}
+              </div>
+              {hasMore && (
+                <div className="mt-6 pt-5 border-t border-outline-variant/15">
+                  <details className="group">
+                    <summary className="cursor-pointer text-sm font-medium text-on-surface-variant hover:text-primary transition-colors list-none flex items-center gap-2">
+                      <span className="group-open:hidden">{t('allEntries', { count: entries.length })}</span>
+                      <span className="hidden group-open:inline">Weniger anzeigen</span>
+                    </summary>
+                    <div className="mt-4 space-y-1">
+                      {entries.slice(FEED_PREVIEW_COUNT).map((entry) => (
+                        <JournalCardCompact key={entry.slug} entry={entry} />
+                      ))}
+                    </div>
+                  </details>
+                </div>
+              )}
+            </div>
+          }
+          habitsContent={<HabitsDashboard />}
+          metricsContent={<MetricsDashboard />}
+        />
+      </section>
+
     </div>
   )
 }

--- a/src/components/home/HomeTabs.tsx
+++ b/src/components/home/HomeTabs.tsx
@@ -24,16 +24,16 @@ export function HomeTabs({ labels, entriesContent, habitsContent, metricsContent
   return (
     <div>
       {/* Tab Bar */}
-      <div className="flex gap-1 border-b border-surface-container-high border-surface-container mb-8">
+      <div className="flex gap-0 border-b border-outline-variant/15 mb-8">
         {tabs.map(({ id, label }) => (
           <button
             key={id}
             onClick={() => setActiveTab(id)}
             className={clsx(
-              'px-4 py-2.5 text-sm font-medium rounded-t-lg -mb-px border-b-2 transition-colors duration-150',
+              'px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase -mb-px border-b-2 transition-colors duration-150',
               activeTab === id
                 ? 'border-primary text-primary'
-                : 'border-transparent text-on-surface-variant hover:text-on-surface hover:border-outline hover:border-surface-container-highest'
+                : 'border-transparent text-on-surface-variant hover:text-on-surface hover:border-outline-variant'
             )}
           >
             {label}


### PR DESCRIPTION
## Summary

- **Full-width Hero** (max-w-4xl, bricht aus dem Content-Container heraus)
- **Subtiler Warm-Glow Hintergrund** — `bg-primary/[0.04] blur-3xl` Radial-Glow ohne Bilddatei
- **Live Day Badge** — `TAG X VON 365` mit pulsierendem Punkt + primary-Border
- **Headline** — `font-headline tracking-tighter` 5xl/7xl, Zeile 1 `text-on-surface`, Zeile 2 `text-primary`
- **CTA-Buttons**: `Einträge lesen` (primary filled) + `Habits` (outlined)
- **Streak-Indikatoren** — Emojis + farbige Zahl (`text-movement-400`, `text-nutrition-400`, `text-smoking-400`)
- **HomeTabs** — Tabs jetzt `font-label tracking-widest uppercase`
- **i18n** — `ctaEntries` Key in de/en/pt

Closes #130

## Test plan

- [ ] Build passes ✅
- [ ] Hero erscheint full-width über den Tabs
- [ ] Puls-Animation am Day-Badge sichtbar
- [ ] "Einträge lesen" CTA scrollt zu `#journal`
- [ ] Streak-Zahlen laden korrekt
- [ ] Tabs-Labels sind uppercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)