### PR TITLE
feat: Live Status bento-grid section on homepage (#131)

### DIFF
--- a/scripts/seed-sample-data.ts
+++ b/scripts/seed-sample-data.ts
@@ -1,0 +1,210 @@
+/**
+ * Seed script: inserts 45 sample journal entries + metrics into the local DB.
+ * Run: npx tsx scripts/seed-sample-data.ts
+ *
+ * Safe to re-run — uses upsert so existing entries are not duplicated.
+ */
+
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+// Project starts 45 days ago
+const today = new Date()
+const START_DATE = new Date(today)
+START_DATE.setDate(today.getDate() - 44)
+
+function addDays(base: Date, n: number): Date {
+  const d = new Date(base)
+  d.setDate(d.getDate() + n)
+  return d
+}
+
+function dateStr(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+import type { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
+
+// Realistic-ish habit patterns — not perfect every day
+const MOVEMENT_PATTERN: MovementLevel[] = [
+  'STEPS_TRAINED','STEPS_ONLY','STEPS_TRAINED','MINIMAL','STEPS_ONLY',
+  'STEPS_TRAINED','STEPS_TRAINED','STEPS_ONLY','TRAINED_ONLY','STEPS_TRAINED',
+  'MINIMAL','STEPS_TRAINED','STEPS_ONLY','STEPS_TRAINED','STEPS_TRAINED',
+  'STEPS_ONLY','STEPS_TRAINED','MINIMAL','STEPS_TRAINED','STEPS_ONLY',
+  'STEPS_TRAINED','STEPS_TRAINED','STEPS_ONLY','STEPS_TRAINED','TRAINED_ONLY',
+  'STEPS_TRAINED','STEPS_ONLY','STEPS_TRAINED','STEPS_TRAINED','MINIMAL',
+  'STEPS_TRAINED','STEPS_ONLY','STEPS_TRAINED','STEPS_TRAINED','STEPS_ONLY',
+  'STEPS_TRAINED','TRAINED_ONLY','STEPS_TRAINED','STEPS_ONLY','STEPS_TRAINED',
+  'STEPS_TRAINED','MINIMAL','STEPS_TRAINED','STEPS_ONLY','STEPS_TRAINED',
+]
+
+const NUTRITION_PATTERN: NutritionLevel[] = [
+  'THREE_MEALS','TWO_MEALS','THREE_MEALS','ONE_MEAL','TWO_MEALS',
+  'THREE_MEALS','THREE_MEALS','TWO_MEALS','THREE_MEALS','TWO_MEALS',
+  'ONE_MEAL','THREE_MEALS','TWO_MEALS','THREE_MEALS','TWO_MEALS',
+  'THREE_MEALS','TWO_MEALS','TWO_MEALS','THREE_MEALS','ONE_MEAL',
+  'THREE_MEALS','TWO_MEALS','THREE_MEALS','THREE_MEALS','TWO_MEALS',
+  'THREE_MEALS','ONE_MEAL','THREE_MEALS','TWO_MEALS','THREE_MEALS',
+  'THREE_MEALS','TWO_MEALS','THREE_MEALS','THREE_MEALS','ONE_MEAL',
+  'THREE_MEALS','TWO_MEALS','THREE_MEALS','THREE_MEALS','TWO_MEALS',
+  'THREE_MEALS','TWO_MEALS','THREE_MEALS','ONE_MEAL','THREE_MEALS',
+]
+
+const SMOKING_PATTERN: SmokingStatus[] = [
+  'SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','NICOTINE_REPLACEMENT','SMOKE_FREE',
+  'SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','NICOTINE_REPLACEMENT','SMOKE_FREE',
+  'SMOKE_FREE','SMOKED','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE',
+  'SMOKE_FREE','SMOKE_FREE','NICOTINE_REPLACEMENT','SMOKE_FREE','SMOKE_FREE',
+  'SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','NICOTINE_REPLACEMENT',
+  'SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE',
+  'SMOKE_FREE','SMOKE_FREE','NICOTINE_REPLACEMENT','SMOKE_FREE','SMOKE_FREE',
+  'SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE',
+  'SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE','SMOKE_FREE',
+]
+
+const TITLES = [
+  'Neuer Start, alter Rhythmus',
+  'Früh raus, trotzdem gute Laune',
+  "Regentag — aber ich hab's geschafft",
+  'Kleiner Rückfall, großes Aufstehen',
+  'Heute war einfach gut',
+  'Müde, aber dabei',
+  'Training trotz Stress',
+  'Ein Schritt nach dem anderen',
+  'Fokus auf das Wesentliche',
+  'Nicht perfekt, aber ehrlich',
+  'Morgens laufen, abends reflektieren',
+  'Gewohnheiten brauchen Zeit',
+  'Warum ich das hier mache',
+  'Guter Tag, schlechte Nacht',
+  'Die Säulen halten',
+  'Wieder auf Kurs',
+  'Kleinigkeiten zählen',
+  'Kein grosser Tag — und das ist ok',
+  'Mehr Energie heute',
+  'Zwischen den Zeilen',
+  'Draussen sein hilft',
+  'Konsequenz über Motivation',
+  'Heute: viel Wasser, wenig Quatsch',
+  'Schlechte Ausrede, gute Ausführung',
+  'Fortschritt ist nicht linear',
+  'Willenskraft ist trainierbar',
+  'Die kleinen Momente',
+  'Alles im Grünen',
+  'Wochenende ohne Ausrede',
+  'Auf mich selbst hören',
+  'Rückschritt als Lektion',
+  'Heute hab ich mich selbst überrascht',
+  'Wieder angefangen',
+  'Warum Ehrlichkeit wichtig ist',
+  'Tag 35 — Halbzeit',
+  'Momentum aufbauen',
+  'Ich bin kein Roboter',
+  'Klarheit durch Bewegung',
+  'Drei Säulen, ein Ziel',
+  'Heute war hart — ich bin trotzdem hier',
+  'Die Lücken füllen',
+  'Augen auf, Kopf hoch',
+  'Nächste Woche ist auch noch ein Tag',
+  'Kurz innehalten',
+  "Weiter geht's",
+]
+
+const EXCERPTS = [
+  'Heute Morgen um 6 raus, Laufrunde um den See. Der Kopf war klar danach.',
+  'Wieder mal einen Rückschlag gehabt, aber aufgestanden und weitergemacht.',
+  'Drei Mahlzeiten, 12.000 Schritte — ich merk, wie sich das aufbaut.',
+  'Manchmal reicht es, einfach dabei zu bleiben.',
+  'Der Körper will sich bewegen. Ich hab aufgehört zu kämpfen.',
+  'Kein grosser Tag, aber ein ehrlicher.',
+  'Schlechter Schlaf, trotzdem Training — manchmal macht man es einfach.',
+  'Heute zum ersten Mal seit Wochen keinen Gedanken ans Rauchen.',
+  'Kleine Schritte, grosse Wirkung.',
+  'Accountability durch Öffentlichkeit — das ist der Punkt.',
+]
+
+const CONTENT = `<p>Heute war wieder ein Tag, der zeigt: Konsequenz schlägt Motivation. Ich hatte keine grosse Lust, aber ich hab es trotzdem gemacht.</p><p>Die drei Säulen halten sich gut. Bewegung ist inzwischen fast automatisch. Ernährung braucht noch Aufmerksamkeit. Beim Rauchstopp bin ich stolz auf mich.</p>`
+
+async function main() {
+  console.log('🌱 Seeding sample data...\n')
+
+  // Ensure UserProfile with start date exists
+  await prisma.userProfile.upsert({
+    where: { id: 'singleton' },
+    update: { projectStartDate: dateStr(START_DATE) },
+    create: {
+      id: 'singleton',
+      projectStartDate: dateStr(START_DATE),
+      heightCm: 180,
+      targetWeight: 78,
+      targetSteps: 10000,
+    },
+  })
+  console.log(`✓ UserProfile: project starts ${dateStr(START_DATE)}`)
+
+  // Insert 45 journal entries
+  let created = 0
+  let skipped = 0
+
+  for (let i = 0; i < 45; i++) {
+    const date = addDays(START_DATE, i)
+    const slug = `tag-${String(i + 1).padStart(3, '0')}-sample`
+
+    try {
+      await prisma.journalEntry.upsert({
+        where: { slug },
+        update: {},
+        create: {
+          slug,
+          title: TITLES[i % TITLES.length],
+          content: CONTENT,
+          excerpt: EXCERPTS[i % EXCERPTS.length],
+          date: new Date(dateStr(date) + 'T12:00:00Z'),
+          published: true,
+          movement:  MOVEMENT_PATTERN[i],
+          nutrition: NUTRITION_PATTERN[i],
+          smoking:   SMOKING_PATTERN[i],
+        },
+      })
+      created++
+    } catch (e) {
+      skipped++
+    }
+  }
+  console.log(`✓ JournalEntries: ${created} created, ${skipped} skipped`)
+
+  // Insert 45 days of metrics (weight + steps + body fat)
+  let mCreated = 0
+  let mSkipped = 0
+
+  for (let i = 0; i < 45; i++) {
+    const date = addDays(START_DATE, i)
+    const noise = () => (Math.random() - 0.5) * 0.4
+    const stepsNoise = () => Math.round((Math.random() - 0.3) * 3000)
+
+    try {
+      await prisma.dailyMetrics.upsert({
+        where: { date: new Date(dateStr(date) + 'T00:00:00Z') },
+        update: {},
+        create: {
+          date: new Date(dateStr(date) + 'T00:00:00Z'),
+          weight: parseFloat((84.2 - i * 0.08 + noise()).toFixed(1)),
+          bodyFat: parseFloat((22.5 - i * 0.04 + noise() * 0.3).toFixed(1)),
+          steps: Math.max(3000, 9500 + stepsNoise()),
+          source: 'MANUAL',
+        },
+      })
+      mCreated++
+    } catch (e) {
+      mSkipped++
+    }
+  }
+  console.log(`✓ DailyMetrics:   ${mCreated} created, ${mSkipped} skipped`)
+
+  console.log('\n✅ Done! Restart the dev server or hard-refresh to see the data.')
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1) })
+  .finally(() => prisma.$disconnect())

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,16 +4,11 @@ import type { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import { getAllEntriesForLocale, getDayNumber } from '@/lib/journal'
 import { getProjectStartDate } from '@/lib/project-config'
-import {
-  calculateStreak,
-  isMovementFulfilled,
-  isNutritionFulfilled,
-  isSmokingFulfilled,
-} from '@/lib/habits'
 import { JournalCardCompact } from '@/components/journal/JournalCardCompact'
 import { HabitsDashboard } from '@/components/habits/HabitsDashboard'
 import { MetricsDashboard } from '@/components/metrics/MetricsDashboard'
 import { HomeTabs } from '@/components/home/HomeTabs'
+import { LiveStatus } from '@/components/home/LiveStatus'
 import { Icon } from '@/components/ui/Icon'
 import {
   SITE_NAME,
@@ -79,10 +74,6 @@ export default async function HomePage({ params }: HomePageProps) {
   const previewEntries = entries.slice(0, FEED_PREVIEW_COUNT)
   const hasMore = entries.length > FEED_PREVIEW_COUNT
 
-  const movementStreak = calculateStreak(entries.map((e) => isMovementFulfilled(e.habits.movement)))
-  const nutritionStreak = calculateStreak(entries.map((e) => isNutritionFulfilled(e.habits.nutrition)))
-  const smokingStreak   = calculateStreak(entries.map((e) => isSmokingFulfilled(e.habits.smoking)))
-
   return (
     <div>
 
@@ -115,8 +106,8 @@ export default async function HomePage({ params }: HomePageProps) {
             {t('description')}
           </p>
 
-          {/* CTAs */}
-          <div className="flex flex-wrap items-center gap-3 mb-12">
+          {/* CTA */}
+          <div className="flex flex-wrap items-center gap-3">
             <a
               href="#journal"
               className="inline-flex items-center gap-2 px-5 py-2.5 bg-primary text-on-primary font-label font-bold tracking-widest uppercase text-xs rounded hover:bg-primary-container transition-colors"
@@ -124,47 +115,13 @@ export default async function HomePage({ params }: HomePageProps) {
               <Icon name="arrow_downward" size={14} />
               {t('ctaEntries')}
             </a>
-            <a
-              href="#journal"
-              className="inline-flex items-center gap-2 px-5 py-2.5 border border-outline-variant/30 text-on-surface-variant font-label font-bold tracking-widest uppercase text-xs rounded hover:bg-surface-container hover:text-on-surface transition-colors"
-            >
-              {t('tabHabits')}
-            </a>
-          </div>
-
-          {/* Streak indicators */}
-          <div className="flex flex-wrap gap-8">
-            <div className="flex items-center gap-2.5" title={t('streakMovement')}>
-              <span className="text-xl leading-none" aria-hidden="true">🏃</span>
-              <div className="flex items-baseline gap-1">
-                <span className="text-2xl font-headline font-bold text-movement-400 leading-none tabular-nums">
-                  {movementStreak.current}
-                </span>
-                <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2.5" title={t('streakNutrition')}>
-              <span className="text-xl leading-none" aria-hidden="true">🥗</span>
-              <div className="flex items-baseline gap-1">
-                <span className="text-2xl font-headline font-bold text-nutrition-400 leading-none tabular-nums">
-                  {nutritionStreak.current}
-                </span>
-                <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2.5" title={t('streakSmoking')}>
-              <span className="text-xl leading-none" aria-hidden="true">🚭</span>
-              <div className="flex items-baseline gap-1">
-                <span className="text-2xl font-headline font-bold text-smoking-400 leading-none tabular-nums">
-                  {smokingStreak.current}
-                </span>
-                <span className="text-xs text-on-surface-variant">{t('streakDays')}</span>
-              </div>
-            </div>
           </div>
 
         </div>
       </section>
+
+      {/* ── Live Status Bento-Grid ──────────────────────────────────── */}
+      <LiveStatus />
 
       {/* ── Journal / Habits / Metrics Tabs ────────────────────────── */}
       <section id="journal" className="max-w-4xl mx-auto px-4 sm:px-6 py-12">

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -1,0 +1,166 @@
+import { getTranslations } from 'next-intl/server'
+import { getAllEntries } from '@/lib/journal'
+import { getLatestMetrics } from '@/lib/metrics'
+import { getProfile } from '@/lib/profile'
+import {
+  calculateStreak,
+  isMovementFulfilled,
+  isNutritionFulfilled,
+  isSmokingFulfilled,
+} from '@/lib/habits'
+
+// ─── Compact streak card ───────────────────────────────────────────────────
+
+interface StreamCardProps {
+  emoji: string
+  label: string
+  current: number
+  streakDays: string
+  textColorClass: string
+  barColorClass: string
+  pct: number
+}
+
+function StreamCard({ emoji, label, current, streakDays, textColorClass, barColorClass, pct }: StreamCardProps) {
+  return (
+    <div className="bg-surface-container border border-outline-variant/15 rounded-xl p-4 flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className={`text-xs font-label font-bold tracking-widest uppercase ${textColorClass}`}>
+          {label}
+        </span>
+        <span className="text-base leading-none" aria-hidden="true">{emoji}</span>
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <span className={`text-4xl font-headline font-bold tracking-tighter leading-none ${textColorClass}`}>
+          {current}
+        </span>
+        <span className="text-xs text-on-surface-variant">{streakDays}</span>
+      </div>
+      <div className="h-0.5 bg-surface-container-high rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full ${barColorClass} transition-all duration-500`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+// ─── Metric card ───────────────────────────────────────────────────────────
+
+interface MetricCardProps {
+  label: string
+  value: string
+  unit: string
+  sub?: string
+  icon: string
+}
+
+function MetricCard({ label, value, unit, sub, icon }: MetricCardProps) {
+  return (
+    <div className="bg-surface-container border border-outline-variant/15 rounded-xl p-4 flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
+          {label}
+        </span>
+        <span className="text-base leading-none" aria-hidden="true">{icon}</span>
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-4xl font-headline font-bold tracking-tighter leading-none text-on-surface">
+          {value}
+        </span>
+        <span className="text-xs text-on-surface-variant">{unit}</span>
+      </div>
+      {sub && <p className="text-xs text-on-surface-variant">{sub}</p>}
+    </div>
+  )
+}
+
+// ─── Live Status section ───────────────────────────────────────────────────
+
+export async function LiveStatus() {
+  const [entries, metrics, profile, t] = await Promise.all([
+    getAllEntries(),
+    getLatestMetrics(),
+    getProfile(),
+    getTranslations('HomePage'),
+  ])
+
+  const movementStreak = calculateStreak(entries.map((e) => isMovementFulfilled(e.habits.movement)))
+  const nutritionStreak = calculateStreak(entries.map((e) => isNutritionFulfilled(e.habits.nutrition)))
+  const smokingStreak   = calculateStreak(entries.map((e) => isSmokingFulfilled(e.habits.smoking)))
+
+  const total = entries.length
+  const movementPct = total > 0 ? Math.round(entries.filter((e) => isMovementFulfilled(e.habits.movement)).length / total * 100) : 0
+  const nutritionPct = total > 0 ? Math.round(entries.filter((e) => isNutritionFulfilled(e.habits.nutrition)).length / total * 100) : 0
+  const smokingPct   = total > 0 ? Math.round(entries.filter((e) => isSmokingFulfilled(e.habits.smoking)).length / total * 100) : 0
+
+  const streakDays = t('streakDays')
+  const stepsGoal = profile.targetSteps ?? 10000
+
+  const hasWeight = metrics.latestWeight !== undefined
+  const hasSteps  = metrics.avgSteps30d  !== undefined
+
+  return (
+    <section className="max-w-4xl mx-auto px-4 sm:px-6 py-8 border-b border-outline-variant/10">
+
+      {/* Section label */}
+      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant mb-4">
+        {t('tagline')}
+      </p>
+
+      {/* Bento grid */}
+      <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
+
+        {/* Habit streaks — 3 cells */}
+        <StreamCard
+          emoji="🏃"
+          label={t('streakMovement').replace('Aktuelle ', '').replace('Current ', '')}
+          current={movementStreak.current}
+          streakDays={streakDays}
+          textColorClass="text-movement-400"
+          barColorClass="bg-movement-400"
+          pct={movementPct}
+        />
+        <StreamCard
+          emoji="🥗"
+          label={t('streakNutrition').replace('Aktuelle ', '').replace('Current ', '')}
+          current={nutritionStreak.current}
+          streakDays={streakDays}
+          textColorClass="text-nutrition-400"
+          barColorClass="bg-nutrition-400"
+          pct={nutritionPct}
+        />
+        <StreamCard
+          emoji="🚭"
+          label={t('streakSmoking').replace('Aktuelle ', '').replace('Current ', '')}
+          current={smokingStreak.current}
+          streakDays={streakDays}
+          textColorClass="text-smoking-400"
+          barColorClass="bg-smoking-400"
+          pct={smokingPct}
+        />
+
+        {/* Metric cards — up to 2 cells (hidden on mobile if no data) */}
+        {hasWeight && (
+          <MetricCard
+            label="Gewicht"
+            value={metrics.latestWeight!.toFixed(1)}
+            unit="kg"
+            icon="⚖️"
+          />
+        )}
+        {hasSteps && (
+          <MetricCard
+            label="Ø Schritte"
+            value={metrics.avgSteps30d!.toLocaleString()}
+            unit={`/ ${stepsGoal.toLocaleString()}`}
+            sub="30-Tage Ø"
+            icon="👣"
+          />
+        )}
+
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a new always-visible **Live Status** section between Hero and tabs on the homepage
- 5-card bento grid (`grid-cols-3 sm:grid-cols-5`): 3 habit streak cards + weight + avg steps
- Each streak card shows current streak count, a colored label, and a progress bar (% of days fulfilled)
- Metric cards show latest weight (kg) and 30-day average steps vs. goal
- Streak data derives from `calculateStreak()` + fulfillment helpers; metrics from `getLatestMetrics()`
- Also adds `scripts/seed-sample-data.ts` for local dev: seeds 45 days of journal entries + metrics via idempotent upserts

## Test plan

- [ ] `pnpm tsc --noEmit` passes
- [ ] `pnpm build` passes
- [ ] Visit `/de` — Live Status section visible between Hero and Journal/Habits/Metrics tabs
- [ ] 5 cards render: Movement streak, Nutrition streak, Smoking streak, Weight, Avg Steps
- [ ] Progress bars reflect % of fulfilled days
- [ ] Section is hidden / cards missing only when DB has no entries or metrics (graceful empty state: cards simply don't render)
- [ ] Responsive: 3 columns on mobile, 5 on sm+

🤖 Generated with [Claude Code](https://claude.com/claude-code)