### PR TITLE
feat: Über das Projekt Seite (Issue #134)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1,6 +1,7 @@
 {
   "Navigation": {
     "journal": "Journal",
+    "about": "Projekt",
     "admin": "Admin",
     "ariaLabel": "Hauptnavigation",
     "adminTitle": "Admin-Bereich"
@@ -23,11 +24,38 @@
     "allEntries": "Alle {count} Einträge anzeigen",
     "journalSectionHeading": "Daily Journals",
     "journalViewAll": "Alle Einträge",
+    "ctaAbout": "Über das Projekt",
     "streakDays": "Tage",
     "ctaEntries": "Einträge lesen",
     "streakMovement": "Aktuelle Bewegungs-Serie",
     "streakNutrition": "Aktuelle Ernährungs-Serie",
     "streakSmoking": "Aktuelle Rauchstopp-Serie"
+  },
+  "AboutPage": {
+    "metaTitle": "Über das Projekt — Project 365",
+    "metaDescription": "Was steckt hinter Project 365? 365 Tage öffentliches Accountability-Journal mit drei Säulen und einem grossen Finale.",
+    "badge": "Das Projekt",
+    "headline": "365 Tage. Öffentlich. Ehrlich.",
+    "intro": "Platzhalter — Dom ersetzt diesen Text. Kurze Einleitung über das Projekt, die Motivation und was den Leser auf dieser Seite erwartet.",
+    "whatTitle": "Was ist Project 365?",
+    "whatText": "Platzhalter — Dom ersetzt diesen Text. Beschreibung des Projekts: 365 Tage öffentliches Accountability-Journal, täglich dokumentiert, ohne Hochglanz.",
+    "pillarsTitle": "Die drei Säulen",
+    "pillar1Title": "Bewegung & Training",
+    "pillar1Text": "Platzhalter — täglich 10.000 Schritte oder Training. Was bedeutet das konkret, warum diese Ziele?",
+    "pillar2Title": "Ernährung",
+    "pillar2Text": "Platzhalter — mindestens zwei gesunde Mahlzeiten pro Tag. Hintergrund und persönliche Motivation.",
+    "pillar3Title": "Rauchstopp",
+    "pillar3Text": "Platzhalter — der Weg in die Rauchfreiheit. Wie lange, warum jetzt, was hat sich verändert?",
+    "finaleTitle": "Das grosse Finale",
+    "finaleSubtitle": "21-Tage-Wanderung",
+    "finaleText": "Platzhalter — Dom ersetzt diesen Text. Beschreibung der geplanten 21-Tage-Wanderung als krönender Abschluss des Projekts.",
+    "finaleItem1": "Loslaufen — jeden Tag neu planen",
+    "finaleItem2": "2 CHF pro Kilometer zurücklegen",
+    "finaleItem3": "Betterplace-Spendenkampagne",
+    "finaleItem4": "Erlös geht an eine Tierschutzorganisation",
+    "whyTitle": "Warum öffentlich?",
+    "whyText": "Platzhalter — Dom ersetzt diesen Text. Gedanken zu Accountability durch Transparenz, warum das Öffentlichmachen hilft und was es bedeutet, ehrlich zu dokumentieren.",
+    "ctaJournal": "Zum Journal"
   },
   "HabitsDashboard": {
     "heading": "Die drei Säulen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "Navigation": {
     "journal": "Journal",
+    "about": "Project",
     "admin": "Admin",
     "ariaLabel": "Main navigation",
     "adminTitle": "Admin area"
@@ -23,11 +24,38 @@
     "allEntries": "Show all {count} entries",
     "journalSectionHeading": "Daily Journals",
     "journalViewAll": "View All Logs",
+    "ctaAbout": "About the Project",
     "streakDays": "days",
     "ctaEntries": "Read entries",
     "streakMovement": "Current movement streak",
     "streakNutrition": "Current nutrition streak",
     "streakSmoking": "Current smoke-free streak"
+  },
+  "AboutPage": {
+    "metaTitle": "About the Project — Project 365",
+    "metaDescription": "What is Project 365? 365 days of public accountability journaling with three pillars and one big finale.",
+    "badge": "The Project",
+    "headline": "365 Days. Public. Honest.",
+    "intro": "Placeholder — Dom replaces this text. Short introduction about the project, the motivation and what the reader can expect on this page.",
+    "whatTitle": "What is Project 365?",
+    "whatText": "Placeholder — Dom replaces this text. Description of the project: 365 days of public accountability journaling, documented daily, no gloss.",
+    "pillarsTitle": "The Three Pillars",
+    "pillar1Title": "Movement & Training",
+    "pillar1Text": "Placeholder — 10,000 steps or a workout every day. What does that mean in practice, why these goals?",
+    "pillar2Title": "Nutrition",
+    "pillar2Text": "Placeholder — at least two healthy meals per day. Background and personal motivation.",
+    "pillar3Title": "No Smoking",
+    "pillar3Text": "Placeholder — the journey to becoming smoke-free. How long, why now, what has changed?",
+    "finaleTitle": "The Grand Finale",
+    "finaleSubtitle": "21-Day Hike",
+    "finaleText": "Placeholder — Dom replaces this text. Description of the planned 21-day hike as the crowning conclusion of the project.",
+    "finaleItem1": "Start walking — plan each day fresh",
+    "finaleItem2": "Set aside CHF 2 per kilometre",
+    "finaleItem3": "Betterplace donation campaign",
+    "finaleItem4": "Proceeds go to an animal welfare organisation",
+    "whyTitle": "Why Public?",
+    "whyText": "Placeholder — Dom replaces this text. Thoughts on accountability through transparency, why making it public helps and what it means to document honestly.",
+    "ctaJournal": "Go to Journal"
   },
   "HabitsDashboard": {
     "heading": "The Three Pillars",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,7 @@
 {
   "Navigation": {
     "journal": "Diário",
+    "about": "Projeto",
     "admin": "Admin",
     "ariaLabel": "Navegação principal",
     "adminTitle": "Área administrativa"
@@ -26,6 +27,32 @@
     "streakMovement": "Sequência atual de movimento",
     "streakNutrition": "Sequência atual de alimentação",
     "streakSmoking": "Sequência atual sem fumar"
+  },
+  "AboutPage": {
+    "metaTitle": "Sobre o Projeto — Project 365",
+    "metaDescription": "O que é o Project 365? 365 dias de diário público de responsabilidade com três pilares e um grande final.",
+    "badge": "O Projeto",
+    "headline": "365 Dias. Público. Honesto.",
+    "intro": "Placeholder — Dom substitui este texto.",
+    "whatTitle": "O que é o Project 365?",
+    "whatText": "Placeholder — Dom substitui este texto.",
+    "pillarsTitle": "Os Três Pilares",
+    "pillar1Title": "Movimento & Treino",
+    "pillar1Text": "Placeholder — 10.000 passos ou treino todos os dias.",
+    "pillar2Title": "Alimentação",
+    "pillar2Text": "Placeholder — pelo menos duas refeições saudáveis por dia.",
+    "pillar3Title": "Sem Fumar",
+    "pillar3Text": "Placeholder — a jornada para parar de fumar.",
+    "finaleTitle": "O Grande Final",
+    "finaleSubtitle": "Caminhada de 21 Dias",
+    "finaleText": "Placeholder — Dom substitui este texto.",
+    "finaleItem1": "Começar a caminhar — planear cada dia de novo",
+    "finaleItem2": "Reservar CHF 2 por quilómetro",
+    "finaleItem3": "Campanha de doações no Betterplace",
+    "finaleItem4": "Receitas vão para uma organização de proteção animal",
+    "whyTitle": "Porquê Público?",
+    "whyText": "Placeholder — Dom substitui este texto.",
+    "ctaJournal": "Ir ao Diário"
   },
   "HabitsDashboard": {
     "heading": "Os Três Pilares",

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { getTranslations } from 'next-intl/server'
+import { Icon } from '@/components/ui/Icon'
+import { SITE_URL, buildAlternates, OG_LOCALE } from '@/lib/site'
+
+interface AboutPageProps {
+  params: { locale: string }
+}
+
+export async function generateMetadata({ params }: AboutPageProps): Promise<Metadata> {
+  const t = await getTranslations('AboutPage')
+  const canonicalUrl = `${SITE_URL}/${params.locale}/about`
+  const ogLocale = OG_LOCALE[params.locale] ?? OG_LOCALE.de
+
+  return {
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+    alternates: {
+      ...buildAlternates(`${SITE_URL}/de/about`, `${SITE_URL}/en/about`, `${SITE_URL}/pt/about`),
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      type: 'website',
+      url: canonicalUrl,
+      title: t('metaTitle'),
+      description: t('metaDescription'),
+      locale: ogLocale,
+    },
+  }
+}
+
+const PILLARS = [
+  { key: 'pillar1', icon: 'directions_run' },
+  { key: 'pillar2', icon: 'restaurant' },
+  { key: 'pillar3', icon: 'smoking_rooms' },
+] as const
+
+const FINALE_ITEMS = ['finaleItem1', 'finaleItem2', 'finaleItem3', 'finaleItem4'] as const
+
+export default async function AboutPage({ params }: AboutPageProps) {
+  const t = await getTranslations('AboutPage')
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 py-16 space-y-16">
+
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <section className="space-y-6">
+        <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded border border-primary/20 bg-primary/5">
+          <span className="text-xs font-label font-bold tracking-widest uppercase text-primary">
+            {t('badge')}
+          </span>
+        </div>
+        <h1 className="font-headline font-bold tracking-tighter leading-none text-5xl sm:text-6xl text-on-surface">
+          {t('headline')}
+        </h1>
+        <p className="text-base sm:text-lg text-on-surface-variant leading-relaxed max-w-2xl">
+          {t('intro')}
+        </p>
+      </section>
+
+      {/* ── Was ist Project 365? ──────────────────────────────────────── */}
+      <section className="bg-surface-variant/40 backdrop-blur-xl border border-outline-variant/15 rounded-xl p-6 sm:p-8 space-y-4">
+        <div className="flex items-center gap-3">
+          <Icon name="calendar_month" size={20} className="text-primary" />
+          <h2 className="text-xs font-label font-bold tracking-widest uppercase text-primary">
+            {t('whatTitle')}
+          </h2>
+        </div>
+        <p className="text-on-surface-variant leading-relaxed">
+          {t('whatText')}
+        </p>
+      </section>
+
+      {/* ── Die drei Säulen ──────────────────────────────────────────── */}
+      <section className="space-y-4">
+        <h2 className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
+          {t('pillarsTitle')}
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {PILLARS.map(({ key, icon }) => (
+            <div
+              key={key}
+              className="bg-surface-container border border-outline-variant/15 rounded-xl p-5 space-y-3"
+            >
+              <Icon name={icon} size={20} className="text-primary" />
+              <h3 className="font-headline font-bold text-on-surface">
+                {t(`${key}Title`)}
+              </h3>
+              <p className="text-sm text-on-surface-variant leading-relaxed">
+                {t(`${key}Text`)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Das grosse Finale ─────────────────────────────────────────── */}
+      <section className="bg-primary/5 border border-primary/20 rounded-xl p-6 sm:p-8 space-y-5">
+        <div className="space-y-1">
+          <p className="text-xs font-label font-bold tracking-widest uppercase text-primary">
+            {t('finaleTitle')}
+          </p>
+          <h2 className="text-2xl font-headline font-bold text-on-surface">
+            {t('finaleSubtitle')}
+          </h2>
+        </div>
+        <p className="text-on-surface-variant leading-relaxed">
+          {t('finaleText')}
+        </p>
+        <ul className="space-y-2">
+          {FINALE_ITEMS.map((item) => (
+            <li key={item} className="flex items-start gap-3">
+              <Icon name="check_circle" size={16} className="text-primary mt-0.5 flex-none" />
+              <span className="text-sm text-on-surface-variant">{t(item)}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* ── Warum öffentlich? ─────────────────────────────────────────── */}
+      <section className="bg-surface-variant/40 backdrop-blur-xl border border-outline-variant/15 rounded-xl p-6 sm:p-8 space-y-4">
+        <div className="flex items-center gap-3">
+          <Icon name="public" size={20} className="text-primary" />
+          <h2 className="text-xs font-label font-bold tracking-widest uppercase text-primary">
+            {t('whyTitle')}
+          </h2>
+        </div>
+        <p className="text-on-surface-variant leading-relaxed">
+          {t('whyText')}
+        </p>
+      </section>
+
+      {/* ── CTA zum Journal ───────────────────────────────────────────── */}
+      <div className="pt-4 border-t border-outline-variant/15 flex justify-center">
+        <Link
+          href={`/${params.locale}`}
+          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary font-label font-bold tracking-widest uppercase text-xs rounded hover:bg-primary-container transition-colors"
+        >
+          <Icon name="article" size={14} />
+          {t('ctaJournal')}
+        </Link>
+      </div>
+
+    </div>
+  )
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -115,6 +115,13 @@ export default async function HomePage({ params }: HomePageProps) {
               <Icon name="arrow_downward" size={14} />
               {t('ctaEntries')}
             </a>
+            <Link
+              href={`/${params.locale}/about`}
+              className="inline-flex items-center gap-2 px-5 py-2.5 border border-outline-variant/30 text-on-surface-variant font-label font-bold tracking-widest uppercase text-xs rounded hover:border-primary/40 hover:text-primary transition-colors"
+            >
+              <Icon name="info" size={14} />
+              {t('ctaAbout')}
+            </Link>
           </div>
 
         </div>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { getTranslations } from 'next-intl/server'
+import { getTranslations, getLocale } from 'next-intl/server'
 import { LocaleSwitcher } from './LocaleSwitcher'
 import { SearchModal } from '@/components/search/SearchModal'
 import { getAuthSession } from '@/lib/auth'
@@ -8,7 +8,7 @@ import { Icon } from '@/components/ui/Icon'
 export async function Navigation() {
   const session = await getAuthSession()
   const isAdmin = !!session?.user?.isAdmin
-  const t = await getTranslations('Navigation')
+  const [t, locale] = await Promise.all([getTranslations('Navigation'), getLocale()])
 
   return (
     <nav className="flex items-center gap-1" aria-label={t('ariaLabel')}>
@@ -18,6 +18,13 @@ export async function Navigation() {
       >
         <Icon name="article" size={16} />
         {t('journal')}
+      </Link>
+      <Link
+        href={`/${locale}/about`}
+        className="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant hover:text-on-surface hover:bg-surface-container transition-colors"
+      >
+        <Icon name="info" size={16} />
+        {t('about')}
       </Link>
 
       <SearchModal />


### PR DESCRIPTION
## Summary

- New `/[locale]/about` page with Kinetic Lab design (glassmorphism cards, warm orange accents)
- Sections: intro, three pillars, 21-day hike finale, why public, CTA back to journal
- All texts are placeholders — Dom can replace them directly in the message files
- Adds "Projekt/Project" link to navigation
- Adds secondary "Über das Projekt" CTA button in hero section
- Multilingual: DE, EN, PT

## Test plan

- [ ] `/de/about`, `/en/about`, `/pt/about` reachable
- [ ] Navigation link works
- [ ] Hero CTA links correctly
- [ ] Responsive on mobile

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)