### PR TITLE
feat: Journal-Einzelansicht im Kinetic Lab Stil (Issue #135)

### DIFF
--- a/src/app/[locale]/journal/[slug]/loading.tsx
+++ b/src/app/[locale]/journal/[slug]/loading.tsx
@@ -2,22 +2,30 @@ import { Skeleton } from '@/components/ui/Skeleton'
 
 export default function Loading() {
   return (
-    <article className="max-w-2xl mx-auto px-4 py-10">
-      <Skeleton className="h-4 w-28 mb-8" />
-      <Skeleton className="h-52 w-full rounded-2xl mb-8" />
-      <div className="space-y-3 mb-8">
-        <div className="flex gap-2">
-          <Skeleton className="h-4 w-16 rounded" />
-          <Skeleton className="h-4 w-28" />
+    <article className="max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+      {/* Banner hero */}
+      <Skeleton className="w-full aspect-[16/7] rounded-xl mb-8" />
+
+      {/* Meta row + title */}
+      <div className="mb-8 space-y-3">
+        <div className="flex items-center gap-2.5">
+          <Skeleton className="h-5 w-16 rounded" />
+          <Skeleton className="h-4 w-40" />
         </div>
         <Skeleton className="h-9 w-5/6" />
         <Skeleton className="h-9 w-3/4" />
       </div>
+
+      {/* Habit badges */}
       <div className="flex gap-2 mb-8">
         {[0, 1, 2].map((i) => (
-          <Skeleton key={i} className="h-7 w-24 rounded-full" />
+          <Skeleton key={i} className="h-7 w-28 rounded-full" />
         ))}
       </div>
+
+      <Skeleton className="h-px w-full mb-8" />
+
+      {/* Content lines */}
       <div className="space-y-3">
         {[100, 90, 95, 85, 92, 80, 70].map((w, i) => (
           <Skeleton key={i} className="h-4" style={{ width: `${w}%` }} />
@@ -27,7 +35,9 @@ export default function Loading() {
           <Skeleton key={i} className="h-4" style={{ width: `${w}%` }} />
         ))}
       </div>
-      <div className="mt-12 pt-8 border-t border-surface-container space-y-3">
+
+      {/* Reactions */}
+      <div className="mt-14 pt-8 border-t border-outline-variant/20 space-y-3">
         <Skeleton className="h-3 w-20" />
         <div className="flex gap-2">
           {[0, 1, 2, 3, 4].map((i) => (

--- a/src/components/journal/HabitBadges.tsx
+++ b/src/components/journal/HabitBadges.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from 'next-intl'
 import type { HabitsFrontmatter } from '@/lib/journal'
 import { isMovementFulfilled, isNutritionFulfilled, isSmokingFulfilled } from '@/lib/habits'
+import { Icon } from '@/components/ui/Icon'
 
 interface HabitBadgesProps {
   habits: HabitsFrontmatter
@@ -9,29 +10,20 @@ interface HabitBadgesProps {
 interface BadgeProps {
   label: string
   fulfilled: boolean
-  level?: 'full' | 'partial'
   colorClass: string
   dimClass: string
+  icon: string
 }
 
-function HabitBadge({ label, fulfilled, level = 'full', colorClass, dimClass }: BadgeProps) {
-  const active = fulfilled
+function HabitBadge({ label, fulfilled, colorClass, dimClass, icon }: BadgeProps) {
   return (
     <span
-      className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-        active ? colorClass : dimClass
+      className={`inline-flex items-center gap-1.5 text-xs font-label font-bold tracking-widest uppercase px-2.5 py-1 rounded-full border ${
+        fulfilled ? colorClass : dimClass
       }`}
       title={label}
     >
-      <span
-        className={`w-1.5 h-1.5 rounded-full ${
-          active
-            ? level === 'partial'
-              ? 'bg-current opacity-50'
-              : 'bg-current'
-            : 'bg-current opacity-30'
-        }`}
-      />
+      <Icon name={icon} size={14} fill={fulfilled} />
       {label}
     </span>
   )
@@ -41,24 +33,27 @@ export function HabitBadges({ habits }: HabitBadgesProps) {
   const t = useTranslations('HabitBadges')
 
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div className="flex flex-wrap gap-2">
       <HabitBadge
         label={t(`movement.${habits.movement}` as 'movement.minimal')}
         fulfilled={isMovementFulfilled(habits.movement)}
-        colorClass="bg-movement-600/20 text-movement-400"
-        dimClass="bg-surface-container text-on-surface-variant"
+        icon="directions_run"
+        colorClass="bg-movement-600/20 text-movement-400 border-movement-600/30"
+        dimClass="bg-surface-container border-outline-variant/20 text-on-surface-variant"
       />
       <HabitBadge
         label={t(`nutrition.${habits.nutrition}` as 'nutrition.none')}
         fulfilled={isNutritionFulfilled(habits.nutrition)}
-        colorClass="bg-nutrition-600/20 text-nutrition-400"
-        dimClass="bg-surface-container text-on-surface-variant"
+        icon="restaurant"
+        colorClass="bg-nutrition-600/20 text-nutrition-400 border-nutrition-600/30"
+        dimClass="bg-surface-container border-outline-variant/20 text-on-surface-variant"
       />
       <HabitBadge
         label={t(`smoking.${habits.smoking}` as 'smoking.smoked')}
         fulfilled={isSmokingFulfilled(habits.smoking)}
-        colorClass="bg-smoking-600/20 text-smoking-400"
-        dimClass="bg-surface-container text-on-surface-variant"
+        icon="air"
+        colorClass="bg-smoking-600/20 text-smoking-400 border-smoking-600/30"
+        dimClass="bg-surface-container border-outline-variant/20 text-on-surface-variant"
       />
     </div>
   )

--- a/src/components/journal/JournalPost.tsx
+++ b/src/components/journal/JournalPost.tsx
@@ -6,6 +6,7 @@ import { getDayNumber } from '@/lib/journal'
 import { getProjectStartDate } from '@/lib/project-config'
 import { HabitBadges } from './HabitBadges'
 import { ReactionBar } from '@/components/reactions/ReactionBar'
+import { Icon } from '@/components/ui/Icon'
 import { getAuthSession } from '@/lib/auth'
 
 interface JournalPostProps {
@@ -32,10 +33,33 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
     })
   }
 
+  const metaRow = (
+    <div className="flex items-center flex-wrap gap-2.5">
+      <span className="font-label font-bold text-xs tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2.5 py-1">
+        {t('day', { number: dayNumber })}
+      </span>
+      <span className="text-outline-variant/60 select-none" aria-hidden="true">·</span>
+      <time className="text-sm font-label text-on-surface-variant" dateTime={entry.date}>
+        {formatDate(entry.date)}
+      </time>
+      {isAdmin && (
+        <>
+          <span className="text-outline-variant/60 select-none" aria-hidden="true">·</span>
+          <Link
+            href={`/admin/entries/${entry.id}/edit`}
+            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+          >
+            {t('edit')}
+          </Link>
+        </>
+      )}
+    </div>
+  )
+
   return (
-    <article className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
-      {entry.banner && (
-        <div className="relative w-full aspect-[16/7] rounded-2xl overflow-hidden mb-10 bg-surface-container">
+    <article className="max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+      {entry.banner ? (
+        <div className="relative w-full aspect-[16/7] rounded-xl overflow-hidden mb-8 bg-surface-container">
           <Image
             src={entry.banner}
             alt={entry.title}
@@ -44,74 +68,61 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
             priority
             sizes="(max-width: 768px) 100vw, 672px"
           />
+          <div className="absolute inset-0 bg-gradient-to-t from-background via-background/55 to-transparent" />
+          <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
+            {metaRow}
+            <h1 className="font-headline text-3xl sm:text-4xl font-bold leading-tight text-on-surface mt-3">
+              {entry.title}
+            </h1>
+          </div>
         </div>
+      ) : (
+        <header className="mb-8">
+          {metaRow}
+          <h1 className="font-headline text-3xl sm:text-4xl font-bold leading-tight text-on-surface mt-4">
+            {entry.title}
+          </h1>
+        </header>
       )}
 
-      <header className="mb-10">
-        <div className="flex items-center gap-3 mb-4">
-          <span className="font-headline font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-2 py-0.5">
-            {t('day', { number: dayNumber })}
-          </span>
-          <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
-          <time className="text-sm text-on-surface-variant" dateTime={entry.date}>
-            {formatDate(entry.date)}
-          </time>
-          {isAdmin && (
-            <>
-              <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
-              <Link
-                href={`/admin/entries/${entry.id}/edit`}
-                className="text-xs font-medium text-nutrition-600 text-nutrition-500 hover:text-nutrition-700 hover:text-nutrition-400 transition-colors"
-              >
-                {t('edit')}
-              </Link>
-            </>
-          )}
-        </div>
-
-        <h1 className="font-headline text-3xl sm:text-4xl font-bold leading-tight text-on-surface mb-5">
-          {entry.title}
-        </h1>
-
+      <div className="flex flex-col gap-3 mb-8">
         <HabitBadges habits={entry.habits} />
-
         {entry.tags && entry.tags.length > 0 && (
-          <ul className="flex flex-wrap gap-2 mt-3">
+          <ul className="flex flex-wrap gap-2">
             {entry.tags.map((tag) => (
               <li
                 key={tag}
-                className="text-xs px-2.5 py-1 bg-surface-container text-on-surface-variant rounded-full"
+                className="text-xs px-2.5 py-1 bg-surface-variant/40 border border-outline-variant/15 text-on-surface-variant rounded-full backdrop-blur-sm"
               >
                 #{tag}
               </li>
             ))}
           </ul>
         )}
-      </header>
+      </div>
 
-      <hr className="border-surface-container-high mb-10" />
+      <hr className="border-outline-variant/20 mb-8" />
 
       <div
         className="prose prose-stone prose-lg max-w-none prose-invert"
         dangerouslySetInnerHTML={{ __html: entry.content }}
       />
 
-      <div className="mt-14 pt-8 border-t border-surface-container-high">
+      <div className="mt-14 pt-8 border-t border-outline-variant/20">
         <ReactionBar slug={entry.slug} />
       </div>
 
-      <footer className="mt-8 pt-6 border-t border-surface-container flex items-center justify-between gap-4">
+      <footer className="mt-8 pt-6 border-t border-outline-variant/15 flex items-center justify-between gap-4">
         <Link
           href="/"
-          className="text-sm font-medium text-nutrition-700 text-nutrition-400 hover:text-nutrition-600 transition-colors"
+          className="inline-flex items-center gap-1 text-sm font-medium text-on-surface-variant hover:text-on-surface transition-colors group"
         >
+          <Icon name="arrow_back" size={16} className="group-hover:-translate-x-0.5 transition-transform" />
           {t('back')}
         </Link>
         {isTranslated && (
-          <span className="text-xs text-on-surface-variant flex items-center gap-1">
-            <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
-            </svg>
+          <span className="text-xs text-on-surface-variant flex items-center gap-1.5">
+            <Icon name="translate" size={14} />
             {t('aiTranslated')}
           </span>
         )}


### PR DESCRIPTION
## Summary

- **Banner als Hero**: Gradient-Overlay von unten, Titel und Datumszeile direkt auf dem Bild — Magazine-Style-Layout
- **HabitBadges**: Dots durch Material Symbols Icons ersetzt (`directions_run`, `restaurant`, `air`), filled bei erfüllt / outlined bei nicht erfüllt; border-basierte Farbgebung im `font-label`-Stil
- **Material Symbols via Icon-Komponente**: Back-Link mit `arrow_back`, AI-Übersetzungs-Badge mit `translate` (ersetzt SVG-Pfad)
- **Tags**: Glassmorphism-Stil (`backdrop-blur-sm`, `bg-surface-variant/40`, `border border-outline-variant/15`)
- **Trennlinien**: Auf `border-outline-variant/20` vereinheitlicht
- **Loading-Skeleton**: An neues Layout angepasst (`max-w-3xl`, Banner-Hero-Placeholder, korrigierte Habit-Badge-Breiten)
- Kein Banner vorhanden: Fallback-Header mit gleicher Meta-Zeile direkt oberhalb des Titels

## Test plan

- [ ] Journal-Einzelansicht mit Banner-Bild aufrufen → Titel und Datum erscheinen über dem Bild mit Gradient
- [ ] Habit-Badges prüfen: erfüllte Säulen zeigen filled Icon + Farbe, nicht erfüllte outlined + gedimmt
- [ ] Tags zeigen Glassmorphism-Stil (halbtransparent, blur)
- [ ] Back-Link zeigt `arrow_back` Icon, hover animiert nach links
- [ ] AI-Übersetzungs-Badge zeigt `translate` Icon (nur bei nicht-DE Locale mit Übersetzung)
- [ ] Eintrag ohne Banner aufrufen → normaler Header ohne Bild-Hero
- [ ] Loading-State prüfen (Netzwerk throttlen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)