### PR TITLE
feat: Journal-Übersichtsseite im Kinetic Lab Stil (Issue #136)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -108,6 +108,12 @@
     "noData": "Noch keine Metriken",
     "noDataHint": "Daten werden täglich via Fitbit automatisch importiert."
   },
+  "JournalPage": {
+    "title": "Journal",
+    "entryCount": "{count} Einträge",
+    "backHome": "Startseite",
+    "description": "Alle täglichen Einträge — Bewegung, Ernährung und der Weg zum Rauchstopp."
+  },
   "JournalFeed": {
     "empty": "Noch keine Einträge",
     "emptyHint": "Die ersten Einträge folgen bald."

--- a/messages/en.json
+++ b/messages/en.json
@@ -108,6 +108,12 @@
     "noData": "No metrics yet",
     "noDataHint": "Data is automatically imported daily via Fitbit."
   },
+  "JournalPage": {
+    "title": "Journal",
+    "entryCount": "{count} entries",
+    "backHome": "Home",
+    "description": "All daily journal entries — movement, nutrition and the path to quitting smoking."
+  },
   "JournalFeed": {
     "empty": "No entries yet",
     "emptyHint": "The first entries are coming soon."

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -105,6 +105,12 @@
     "noData": "Ainda sem métricas",
     "noDataHint": "Os dados são importados automaticamente todos os dias via Fitbit."
   },
+  "JournalPage": {
+    "title": "Diário",
+    "entryCount": "{count} entradas",
+    "backHome": "Início",
+    "description": "Todas as entradas diárias — movimento, alimentação e o caminho para parar de fumar."
+  },
   "JournalFeed": {
     "empty": "Ainda sem entradas",
     "emptyHint": "As primeiras entradas vêm em breve."

--- a/src/app/[locale]/journal/loading.tsx
+++ b/src/app/[locale]/journal/loading.tsx
@@ -1,0 +1,44 @@
+import { Skeleton } from '@/components/ui/Skeleton'
+
+export default function Loading() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 sm:py-14">
+      {/* Header */}
+      <div className="mb-10 space-y-3">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-12 w-48" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+
+      {/* 2-column grid of card skeletons */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <div
+            key={i}
+            className="bg-surface-variant/40 border border-outline-variant/15 rounded-xl overflow-hidden"
+          >
+            <Skeleton className="w-full aspect-[16/7] rounded-none" />
+            <div className="px-5 py-4 space-y-3">
+              <div className="flex items-center gap-2.5">
+                <Skeleton className="h-5 w-14 rounded" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <Skeleton className="h-6 w-5/6" />
+              <Skeleton className="h-6 w-3/4" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <div className="flex items-center justify-between pt-2">
+                <div className="flex gap-2">
+                  {[0, 1, 2].map((j) => (
+                    <Skeleton key={j} className="h-6 w-20 rounded-full" />
+                  ))}
+                </div>
+                <Skeleton className="h-4 w-16" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/[locale]/journal/page.tsx
+++ b/src/app/[locale]/journal/page.tsx
@@ -1,0 +1,78 @@
+export const dynamic = 'force-dynamic'
+
+import type { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
+import Link from 'next/link'
+import { getAllEntriesForLocale } from '@/lib/journal'
+import { JournalFeed } from '@/components/journal/JournalFeed'
+import { Icon } from '@/components/ui/Icon'
+import { SITE_NAME, SITE_URL, buildAlternates, OG_LOCALE } from '@/lib/site'
+
+interface JournalPageProps {
+  params: { locale: string }
+}
+
+export async function generateMetadata({ params }: JournalPageProps): Promise<Metadata> {
+  const { locale } = params
+  const t = await getTranslations({ locale, namespace: 'JournalPage' })
+
+  const title = `${t('title')} — ${SITE_NAME}`
+  const description = t('description')
+  const canonicalUrl = `${SITE_URL}/${locale}/journal`
+  const ogLocale = OG_LOCALE[locale] ?? OG_LOCALE.de
+
+  return {
+    title,
+    description,
+    alternates: {
+      ...buildAlternates(
+        `${SITE_URL}/de/journal`,
+        `${SITE_URL}/en/journal`,
+        `${SITE_URL}/pt/journal`,
+      ),
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      type: 'website',
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      title,
+      description,
+      locale: ogLocale,
+      images: [{ url: '/og-default.png', width: 1200, height: 630, alt: SITE_NAME }],
+    },
+  }
+}
+
+export default async function JournalPage({ params }: JournalPageProps) {
+  const [entries, t] = await Promise.all([
+    getAllEntriesForLocale(params.locale),
+    getTranslations('JournalPage'),
+  ])
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 sm:py-14">
+
+      {/* Page header */}
+      <header className="mb-10">
+        <Link
+          href={`/${params.locale}`}
+          className="inline-flex items-center gap-1.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant hover:text-on-surface transition-colors group mb-6"
+        >
+          <Icon name="arrow_back" size={14} className="group-hover:-translate-x-0.5 transition-transform" />
+          {t('backHome')}
+        </Link>
+
+        <h1 className="font-headline font-bold tracking-tighter text-4xl sm:text-5xl text-on-surface mb-3">
+          {t('title')}
+        </h1>
+        <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
+          {t('entryCount', { count: entries.length })}
+        </p>
+      </header>
+
+      <JournalFeed entries={entries} />
+
+    </div>
+  )
+}

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -5,6 +5,7 @@ import type { JournalEntryMeta } from '@/lib/journal'
 import { getDayNumber } from '@/lib/journal'
 import { getProjectStartDate } from '@/lib/project-config'
 import { HabitBadges } from './HabitBadges'
+import { Icon } from '@/components/ui/Icon'
 
 interface JournalCardProps {
   entry: JournalEntryMeta
@@ -29,23 +30,24 @@ export async function JournalCard({ entry }: JournalCardProps) {
   }
 
   return (
-    <article className="group bg-surface-container rounded-2xl border border-surface-container-high shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 overflow-hidden">
+    <article className="group bg-surface-variant/40 backdrop-blur-xl border border-outline-variant/15 rounded-xl overflow-hidden hover:bg-surface-variant/60 transition-colors duration-150">
       <Link href={`/journal/${entry.slug}`} className="block">
 
         {entry.banner ? (
-          <div className="relative w-full aspect-[16/7] bg-surface-container">
+          <div className="relative w-full aspect-[16/7] bg-surface-container overflow-hidden">
             <Image
               src={entry.banner}
               alt={entry.title}
               fill
               className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
-              sizes="(max-width: 768px) 100vw, 672px"
+              sizes="(max-width: 768px) 100vw, 800px"
             />
+            <div className="absolute inset-0 bg-gradient-to-t from-background/70 to-transparent" />
           </div>
         ) : (
-          <div className="relative px-6 pt-5 pb-0 overflow-hidden select-none" aria-hidden="true">
+          <div className="relative px-6 pt-5 pb-0 overflow-hidden select-none bg-surface-container-low" aria-hidden="true">
             <span
-              className="block font-headline font-bold leading-none text-surface-container text-surface-container"
+              className="block font-headline font-bold leading-none text-surface-container-highest"
               style={{ fontSize: 'clamp(4.5rem, 18vw, 7.5rem)' }}
             >
               {String(dayNumber).padStart(2, '0')}
@@ -53,31 +55,32 @@ export async function JournalCard({ entry }: JournalCardProps) {
           </div>
         )}
 
-        <div className="px-6 py-5 space-y-3">
+        <div className="px-5 py-4 space-y-3">
           <div className="flex items-center gap-2.5">
-            <span className="font-headline font-bold text-xs tracking-widest uppercase text-on-surface-variant border border-surface-container-high rounded px-1.5 py-0.5">
+            <span className="font-label font-bold text-xs tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2.5 py-0.5">
               {t('day', { number: dayNumber })}
             </span>
-            <span className="text-outline text-surface-container-high select-none" aria-hidden="true">·</span>
-            <time className="text-xs text-on-surface-variant" dateTime={entry.date}>
+            <span className="text-outline-variant/60 select-none" aria-hidden="true">·</span>
+            <time className="text-xs font-label text-on-surface-variant" dateTime={entry.date}>
               {formatDate(entry.date)}
             </time>
           </div>
 
-          <h2 className="font-headline text-xl sm:text-2xl font-bold leading-snug text-on-surface group-hover:text-nutrition-700 group-hover:text-nutrition-400 transition-colors duration-200">
+          <h2 className="font-headline text-xl sm:text-2xl font-bold leading-snug text-on-surface group-hover:text-primary transition-colors duration-150">
             {entry.title}
           </h2>
 
           {excerpt && (
-            <p className="text-sm text-on-surface-variant text-on-surface-variant leading-relaxed line-clamp-3">
+            <p className="text-sm text-on-surface-variant leading-relaxed line-clamp-2">
               {excerpt}
             </p>
           )}
 
-          <div className="flex items-center justify-between gap-4 pt-1 border-t border-surface-container">
+          <div className="flex items-center justify-between gap-4 pt-2 border-t border-outline-variant/10">
             <HabitBadges habits={entry.habits} />
-            <span className="text-xs font-semibold text-nutrition-600 text-nutrition-400 group-hover:text-nutrition-700 shrink-0 transition-colors">
+            <span className="inline-flex items-center gap-1 text-xs font-label font-bold tracking-widest uppercase text-primary shrink-0 group-hover:gap-1.5 transition-all duration-150">
               {t('readMore')}
+              <Icon name="arrow_forward" size={12} />
             </span>
           </div>
         </div>

--- a/src/components/journal/JournalFeed.tsx
+++ b/src/components/journal/JournalFeed.tsx
@@ -19,7 +19,7 @@ export function JournalFeed({ entries }: JournalFeedProps) {
   }
 
   return (
-    <div className="space-y-5">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
       {entries.map((entry) => (
         <JournalCard key={entry.slug} entry={entry} />
       ))}


### PR DESCRIPTION
## Summary

- **Neue Seite** `/[locale]/journal/page.tsx` mit SEO-Metadata (title, description, OpenGraph, hreflang), Page-Header mit Back-Link, h1 und Entry-Count
- **JournalCard**: Komplettes Kinetic Lab Redesign — Glassmorphism-Karte (`backdrop-blur-xl`, `bg-surface-variant/40`, `border-outline-variant/15`), Banner mit Gradient-Overlay, Day-Badge im `font-label`-Stil mit primary-Farbe, Titel-Hover `group-hover:text-primary`, `arrow_forward` Icon im "Weiterlesen"-Link
- **JournalFeed**: Layout von `space-y-5` auf `grid-cols-1 sm:grid-cols-2 gap-5` umgestellt
- **Loading-Skeleton** `journal/loading.tsx`: 2-Spalten-Grid mit Banner + Content-Skeletons
- **i18n**: `JournalPage`-Namespace in DE, EN und PT (`title`, `entryCount`, `backHome`, `description`)
- Keine Änderungen an `JournalCardHome` (Homepage-Karten bleiben wie sie sind)

## Test plan

- [ ] `/de/journal` aufrufen → Übersichtsseite zeigt alle Einträge im 2-Spalten-Grid
- [ ] Karte mit Banner: Gradient-Overlay sichtbar, Hover skaliert das Bild leicht
- [ ] Karte ohne Banner: Grosse Tagnummer-Fallback-Anzeige
- [ ] Day-Badge in orange/primary, Titel hover wechselt auf primary
- [ ] "Weiterlesen" zeigt `arrow_forward` Icon, Abstand wächst beim hover
- [ ] Back-Link führt zur Startseite des jeweiligen Locale
- [ ] `/en/journal` und `/pt/journal` zeigen korrekte i18n-Texte
- [ ] Loading-State testen (Netzwerk drosseln)
- [ ] Homepage "Alle Einträge"-Link zeigt auf die neue Seite ✓ (Link war bereits vorhanden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)