### PR TITLE
fix: Analytics tracking bypasses auth proxy via NEXT_INTERNAL_URL (#149)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -85,7 +85,8 @@ export async function middleware(req: NextRequest) {
       req.headers.get('x-real-ip') ??
       '0.0.0.0'
     const referrer = req.headers.get('referer') ?? ''
-    await fetch(new URL('/api/internal/track', req.url).toString(), {
+    const internalBase = process.env.NEXT_INTERNAL_URL ?? new URL('/', req.url).origin
+    await fetch(`${internalBase}/api/internal/track`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-internal-secret': internalSecret },
       body: JSON.stringify({ path: pathname, referrer, ua, ip }),


### PR DESCRIPTION
## Root Cause

Das Middleware baute die interne Track-URL mit `new URL('/api/internal/track', req.url)`, wobei `req.url` die öffentliche Domain enthält (`https://project365.dom42.ch/...`). Diese Anfrage lief über Nginx und einen Auth-Proxy, der sie mit 401 blockierte.

Lokal fehlten ausserdem `INTERNAL_SECRET` und `ANALYTICS_SALT` in `.env.local`, weshalb das Tracking auch lokal nie gestartet wurde.

## Änderungen

- `src/middleware.ts`: Interne URL wird jetzt via `NEXT_INTERNAL_URL` aus der Umgebung gelesen (Fallback: `req.url`-Origin). Dies ermöglicht, direkt auf den Container-internen Port (localhost:3000) zu zeigen, ohne den externen Auth-Proxy zu durchlaufen.
- `.env.local`: `INTERNAL_SECRET`, `ANALYTICS_SALT`, `NEXT_INTERNAL_URL` hinzugefügt (für lokale Entwicklung)
- Auf `pilab01`: `NEXT_INTERNAL_URL=http://localhost:3000` direkt in `/container/project365blog/app/.env` eingetragen

## Deploy

Nach Merge: Container neu starten damit die neue Env-Variable aktiv wird.

```bash
cd /container/project365blog/app && docker compose pull && docker compose up -d
```

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)