### PR TITLE
feat: Privates Notizfeld für Journal-Einträge (#151)

### DIFF
--- a/prisma/migrations/20260413000000_add_private_notes/migration.sql
+++ b/prisma/migrations/20260413000000_add_private_notes/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "JournalEntry" ADD COLUMN "privateNotes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,9 @@ model JournalEntry {
   nutrition NutritionLevel
   smoking   SmokingStatus
 
+  // Privates Notizfeld — niemals in öffentlichen Queries zurückgeben
+  privateNotes String? @db.Text
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/app/admin/entries/[id]/edit/page.tsx
+++ b/src/app/admin/entries/[id]/edit/page.tsx
@@ -23,6 +23,7 @@ export default async function EditEntryPage({ params }: EditEntryPageProps) {
     smoking: entry.smoking,
     tags: entry.tags,
     published: entry.published,
+    privateNotes: entry.privateNotes ?? '',
   }
 
   return (

--- a/src/app/admin/entries/actions.ts
+++ b/src/app/admin/entries/actions.ts
@@ -18,6 +18,7 @@ export interface EntryFormData {
   smoking: SmokingStatus
   tags: string[]
   published: boolean
+  privateNotes?: string
 }
 
 export interface ActionResult {
@@ -59,6 +60,7 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
         smoking: data.smoking,
         tags: data.tags,
         published: data.published,
+        privateNotes: data.privateNotes?.trim() || null,
       },
     })
 
@@ -94,6 +96,7 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
         smoking: data.smoking,
         tags: data.tags,
         published: data.published,
+        privateNotes: data.privateNotes?.trim() || null,
       },
     })
 

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -53,6 +53,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
   const [bannerUrl, setBannerUrl] = useState<string | undefined>(initial?.bannerUrl)
   const [tags, setTags] = useState<string>(initial?.tags?.join(', ') ?? '')
   const [published, setPublished] = useState(initial?.published ?? true)
+  const [privateNotes, setPrivateNotes] = useState(initial?.privateNotes ?? '')
   const [error, setError] = useState<string | null>(null)
   const [isPreview, setIsPreview] = useState(false)
 
@@ -80,6 +81,7 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
       smoking,
       tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
       published,
+      privateNotes,
     }
 
     startTransition(async () => {
@@ -250,6 +252,22 @@ export function EntryForm({ mode, entryId, initial }: EntryFormProps) {
           rows={2}
           placeholder="1–2 Sätze, die den Eintrag zusammenfassen..."
           className="w-full border border-surface-container-high rounded-lg px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container resize-none"
+        />
+      </div>
+
+      {/* Private Notizen */}
+      <div className="rounded-xl border border-dashed border-outline-variant bg-surface-container-low p-4 space-y-2">
+        <label className="flex items-center gap-1.5 text-xs font-medium text-on-surface-variant">
+          <span className="material-symbols-outlined text-base" style={{ fontVariationSettings: "'FILL' 0" }}>lock</span>
+          Private Notizen
+          <span className="font-normal ml-1">— nur im Admin sichtbar, niemals öffentlich</span>
+        </label>
+        <textarea
+          value={privateNotes}
+          onChange={(e) => setPrivateNotes(e.target.value)}
+          rows={3}
+          placeholder="Persönliche Gedanken, Kontext oder Erinnerungen die nicht veröffentlicht werden..."
+          className="w-full border border-outline-variant/40 rounded-lg px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-outline-variant bg-surface-container-lowest resize-none"
         />
       </div>
 


### PR DESCRIPTION
## Änderungen

- **Prisma**: Neues optionales Feld `privateNotes String? @db.Text` im `JournalEntry`-Model
- **Migration**: `20260413000000_add_private_notes` — einfaches `ALTER TABLE ADD COLUMN`
- **Admin-Editor**: Textarea mit Lock-Icon, gestricheltem Rahmen und Hinweis «nur im Admin sichtbar»
- **Server Actions**: `createEntry` und `updateEntry` speichern `privateNotes`

## Sicherheit

Vier Schutzschichten verhindern, dass `privateNotes` öffentlich erscheint:

1. **TypeScript-Typen** `JournalEntry` / `JournalEntryMeta` enthalten kein `privateNotes` — Compile-Time-Fehler wenn versehentlich hinzugefügt
2. **`toMeta()` / `toFull()`** in `lib/journal.ts` mappen explizit nur bekannte Felder — keine Wildcard-Weitergabe
3. **Öffentliche Queries** (`search`, `sitemap`, `month-summary`) verwenden bereits explicit `select` ohne `privateNotes`
4. **Alle öffentlichen Routes** laufen durch die Transformation-Layer, nie direkt an Prisma-Output

## Sicherheits-Checkliste
- [x] Feld in keiner öffentlichen API-Route enthalten
- [x] Prisma `select` in allen öffentlichen Queries schliesst Feld aus (via Typ-Mapping)
- [x] Server-Component für öffentliche Ansicht hat keinen Zugriff
- [x] TypeScript-Kompilierung fehlerfrei

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)