### PR TITLE
fix: correct water portion size from 500ml to 600ml

### DIFF
--- a/prisma/migrations/20260416000000_fix_water_portion_600ml/migration.sql
+++ b/prisma/migrations/20260416000000_fix_water_portion_600ml/migration.sql
@@ -1,0 +1,5 @@
+-- Fix: correct water portion from 500ml to 600ml
+-- Update all existing WATER entries that were logged with the old 500ml constant
+UPDATE "DrinkLog"
+SET "volume" = 600
+WHERE "type" = 'WATER' AND "volume" = 500;

--- a/src/components/admin/QuickLogButtons.tsx
+++ b/src/components/admin/QuickLogButtons.tsx
@@ -55,7 +55,7 @@ export function QuickLogButtons({ recentEntries }: QuickLogButtonsProps) {
           )}
           <span className="text-5xl">💧</span>
           <span className="font-label text-xs font-bold tracking-widest uppercase text-on-surface-variant">Wasser</span>
-          <span className="text-xs text-on-surface-variant">500 ml</span>
+          <span className="text-xs text-on-surface-variant">600 ml</span>
         </button>
 
         <button

--- a/src/lib/drinks.ts
+++ b/src/lib/drinks.ts
@@ -1,7 +1,7 @@
 import { DrinkType } from '@prisma/client'
 
 export const DRINK_VOLUME: Record<DrinkType, number> = {
-  WATER: 500,     // ml per bottle
+  WATER: 600,     // ml per bottle
   COLA_ZERO: 330, // ml per can
 }
 


### PR DESCRIPTION
Closes #165

## Summary
- `DRINK_VOLUME.WATER` in `src/lib/drinks.ts` von 500 auf 600ml korrigiert
- UI-Label in `QuickLogButtons.tsx` von „500 ml" auf „600 ml" angepasst
- Prisma-Migration: alle bestehenden `DrinkLog`-Einträge mit `type = WATER` und `volume = 500` werden auf 600 aktualisiert

## Test plan
- [ ] Neuer Wasser-Eintrag via Quick-Log speichert mit 600ml
- [ ] Migration läuft auf DB durch (`migrate deploy`)
- [ ] Dashboard-Aggregate zeigen korrigierte Werte

🤖 Generated with [Claude Code](https://claude.com/claude-code)