### PR TITLE
fix: improve fitbit-cron container reliability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     restart: unless-stopped
     environment:
       CRON_SECRET: ${CRON_SECRET:-}
+      TZ: Europe/Zurich
     dns:
       - 1.1.1.1
       - 8.8.8.8
@@ -76,8 +77,8 @@ services:
       - /bin/sh
       - -c
       - |
-        apk update -q && apk add --no-cache curl -q
-        printf 'CRON_SECRET=%s\n0 4 * * * curl -sf -H "Authorization: Bearer $$CRON_SECRET" http://web:3000/api/cron/fitbit-sync\n' "$$CRON_SECRET" | crontab -
+        apk update -q; apk add --no-cache -q curl tzdata
+        printf 'CRON_SECRET=%s\nTZ=Europe/Zurich\n0 4 * * * curl -s --fail-with-body --retry 2 --retry-delay 60 --connect-timeout 30 --max-time 60 -H "Authorization: Bearer $$CRON_SECRET" http://web:3000/api/cron/fitbit-sync\n' "$$CRON_SECRET" | crontab -
         crond -f -d 6
 
 volumes:


### PR DESCRIPTION
Closes #167

## Root Cause Analysis

Container-Logs zeigten **9 Neustarts in 7 Tagen** und zwei vollständig unsichtbare Fehler (Apr 14/15).

### Bug 1: Crash-Loop durch `&&` in apk-Befehl
`apk update -q && apk add curl` — bei einem transienten Netzwerkfehler schlägt `apk update` fehl, der Container crasht, Docker startet ihn neu (`restart: unless-stopped`). Jeder Neustart wiederholt das gleiche Pattern. Bei einem Neustart kurz vor 04:00 Uhr (Cron-Zeit) wurde das Cron-Fenster verpasst.

**Fix:** `&&` → `;` — crond startet immer, auch wenn curl-Installation scheitert.

### Bug 2: `curl -sf` unterdrückt Error-Response-Body
`-f` macht curl bei HTTP ≥ 400 stumm (Exit 22, kein Body). Daher waren die Fehler vom 14. und 15. April komplett unsichtbar — `crond` loggte zwar die Ausführung, aber keine Fehlermeldung.

**Fix:** `-sf` → `-s --fail-with-body` — Error-JSON (z.B. `{"error":"Fitbit auth failed"}`) erscheint jetzt im Container-Log.

### Bug 3: Kein Retry bei transienten Fehlern
Ein kurzzeitiger Netzwerk-Hiccup oder ein noch nicht vollständig gestarteter `web`-Container führte zu sofortigem Abbruch ohne zweiten Versuch.

**Fix:** `--retry 2 --retry-delay 60` — bis zu 2 Wiederholungsversuche mit 60s Pause.

## Changes (`docker-compose.yml`)
- `apk update -q && apk add curl` → `apk update -q; apk add --no-cache -q curl tzdata`
- `curl -sf` → `curl -s --fail-with-body --retry 2 --retry-delay 60 --connect-timeout 30 --max-time 60`
- `TZ: Europe/Zurich` zum Environment hinzugefügt + `TZ=Europe/Zurich` in crontab
- `tzdata` Package für korrekte Timezone-Auflösung

## Test plan
- [ ] Container neu starten auf pilab01: `docker compose up -d --force-recreate fitbit-cron`
- [ ] Manueller Test-Run: `docker exec project365blog-fitbit-cron-1 curl -s --fail-with-body -H "Authorization: Bearer $CRON_SECRET" http://web:3000/api/cron/fitbit-sync`
- [ ] Container-Logs für 7 aufeinanderfolgende Nächte beobachten
- [ ] Bei Fehler: Error-JSON erscheint jetzt im Log statt leerem Output

🤖 Generated with [Claude Code](https://claude.com/claude-code)