### PR TITLE
fix: correct timezone handling for drink log timestamps

### DIFF
--- a/src/app/admin/quick-log/actions.ts
+++ b/src/app/admin/quick-log/actions.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { DrinkType } from '@prisma/client'
 import { DRINK_VOLUME, type TodayDrinks } from '@/lib/drinks'
+import { zurichDayStart } from '@/lib/timezone'
 
 export async function logDrink(type: DrinkType): Promise<{ error?: string }> {
   const session = await requireAdmin()
@@ -28,8 +29,7 @@ export async function deleteDrink(id: string): Promise<{ error?: string }> {
 }
 
 export async function getTodayDrinks(): Promise<TodayDrinks> {
-  const start = new Date()
-  start.setHours(0, 0, 0, 0)
+  const start = zurichDayStart()
 
   const rows = await prisma.drinkLog.findMany({
     where: { timestamp: { gte: start } },

--- a/src/app/admin/quick-log/page.tsx
+++ b/src/app/admin/quick-log/page.tsx
@@ -1,16 +1,12 @@
 import { prisma } from '@/lib/db'
 import { QuickLogButtons } from '@/components/admin/QuickLogButtons'
 import { DRINK_VOLUME } from '@/lib/drinks'
+import { zurichDayStart, formatZurichTime } from '@/lib/timezone'
 
 export const dynamic = 'force-dynamic'
 
-function formatTime(date: Date): string {
-  return date.toLocaleTimeString('de-CH', { hour: '2-digit', minute: '2-digit' })
-}
-
 export default async function QuickLogPage() {
-  const start = new Date()
-  start.setHours(0, 0, 0, 0)
+  const start = zurichDayStart()
 
   const todayEntries = await prisma.drinkLog.findMany({
     where: { timestamp: { gte: start } },
@@ -24,7 +20,7 @@ export default async function QuickLogPage() {
   const recentEntries = todayEntries.map((e) => ({
     id: e.id,
     type: e.type,
-    time: formatTime(e.timestamp),
+    time: formatZurichTime(e.timestamp),
   }))
 
   return (

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,31 @@
+const TZ = 'Europe/Zurich'
+
+/**
+ * Returns the UTC timestamp for midnight of the current day in Europe/Zurich.
+ * Use this instead of `new Date(); d.setHours(0,0,0,0)` on UTC servers to get
+ * the correct "today" boundary for Swiss users (UTC+1/+2 depending on DST).
+ */
+export function zurichDayStart(now = new Date()): Date {
+  const parts = new Intl.DateTimeFormat('de-CH', {
+    timeZone: TZ,
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+  }).formatToParts(now)
+  const h = Number(parts.find((p) => p.type === 'hour')!.value)
+  const m = Number(parts.find((p) => p.type === 'minute')!.value)
+  const s = Number(parts.find((p) => p.type === 'second')!.value)
+  return new Date(now.getTime() - (h * 3600 + m * 60 + s) * 1000 - (now.getTime() % 1000))
+}
+
+/**
+ * Formats a UTC Date as a time string in Europe/Zurich local time.
+ */
+export function formatZurichTime(date: Date, locale = 'de-CH'): string {
+  return date.toLocaleTimeString(locale, {
+    timeZone: TZ,
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}


### PR DESCRIPTION
Closes #169

## Root Cause Analysis

**Server environment** (verified on pilab01):
- Node.js: `getTimezoneOffset() = 0` (UTC, no TZ env var)
- PostgreSQL: `SHOW timezone → UTC`

→ Data stored by `@default(now())` is **correct UTC**. No migration needed.

### Bug 1: Wrong time display (–2h offset)

`formatTime()` in `quick-log/page.tsx` called `toLocaleTimeString('de-CH')` without a `timeZone` option. Node.js running in UTC uses UTC as local timezone, so the display showed UTC instead of Europe/Zurich time. At 14:00 CEST (= 12:00 UTC), the display showed `12:00` — 2 hours behind.

**Fix:** New `formatZurichTime()` in `src/lib/timezone.ts` passes `timeZone: 'Europe/Zurich'` explicitly.

### Bug 2: Wrong "today" boundary

`start.setHours(0, 0, 0, 0)` on a UTC server gives midnight UTC. For Swiss users (CEST = UTC+2), "today" starts at 22:00 UTC the previous day. Entries logged between 00:00–02:00 CEST were silently excluded from "today's" summary.

**Fix:** New `zurichDayStart()` subtracts the elapsed Zurich time-of-day from the current UTC timestamp, giving exact midnight Zurich in UTC. Handles CET/CEST DST transitions correctly without hardcoding offsets.

## Changes

| File | Change |
|------|--------|
| `src/lib/timezone.ts` | New module: `zurichDayStart()` + `formatZurichTime()` |
| `src/app/admin/quick-log/page.tsx` | Use `zurichDayStart()` + `formatZurichTime()` |
| `src/app/admin/quick-log/actions.ts` | Use `zurichDayStart()` in `getTodayDrinks()` |

## Test plan
- [ ] Log a drink → timestamp displayed matches current Zurich local time
- [ ] At 23:30 CEST: drinks logged after 00:00 CEST appear in "heute" view
- [ ] TypeScript: `pnpm tsc --noEmit` passes (verified ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)