### PR TITLE
feat: add water and cola zero metrics to public dashboard

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -40,7 +40,11 @@
     "metricNoData": "Noch keine Daten",
     "metricSteps": "Ø Schritte (30d)",
     "metricBodyFat": "Körperfett",
-    "metricAvg30d": "30-Tage-Durchschnitt"
+    "metricAvg30d": "30-Tage-Durchschnitt",
+    "metricWater": "Ø Wasser (7T)",
+    "metricColaZero": "Ø Cola Zero (7T)",
+    "metricDailyGoal": "Tagesziel",
+    "metricDailyLimit": "Tageslimit"
   },
   "AboutPage": {
     "metaTitle": "Über das Projekt — Project 365",

--- a/messages/en.json
+++ b/messages/en.json
@@ -40,7 +40,11 @@
     "metricNoData": "No data yet",
     "metricSteps": "Avg Steps (30d)",
     "metricBodyFat": "Body Fat",
-    "metricAvg30d": "30-day average"
+    "metricAvg30d": "30-day average",
+    "metricWater": "Avg Water (7d)",
+    "metricColaZero": "Avg Cola Zero (7d)",
+    "metricDailyGoal": "Daily goal",
+    "metricDailyLimit": "Daily limit"
   },
   "AboutPage": {
     "metaTitle": "About the Project — Project 365",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -37,7 +37,11 @@
     "metricNoData": "Sem dados ainda",
     "metricSteps": "Média Passos (30d)",
     "metricBodyFat": "Gordura Corporal",
-    "metricAvg30d": "Média 30 dias"
+    "metricAvg30d": "Média 30 dias",
+    "metricWater": "Média Água (7d)",
+    "metricColaZero": "Média Cola Zero (7d)",
+    "metricDailyGoal": "Meta diária",
+    "metricDailyLimit": "Limite diário"
   },
   "AboutPage": {
     "metaTitle": "Sobre o Projeto — Project 365",

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -8,6 +8,11 @@ import {
   isNutritionFulfilled,
   isSmokingFulfilled,
 } from '@/lib/habits'
+import {
+  getDrinkAvg7d,
+  WATER_DAILY_TARGET_ML,
+  COLA_ZERO_DAILY_LIMIT_ML,
+} from '@/lib/drinks'
 
 // ─── SVG Ring Chart ────────────────────────────────────────────────────────
 
@@ -362,6 +367,63 @@ function StackedMetricTile({ steps, stepsGoal, bodyFat, labelSteps, labelBodyFat
   )
 }
 
+// ─── Drink Metric Tile ────────────────────────────────────────────────────
+
+interface DrinkMetricTileProps {
+  label: string
+  avgMl: number
+  targetMl: number
+  /** true = higher is better (water); false = lower is better (cola zero) */
+  moreIsBetter: boolean
+  labelGoal: string
+  unit?: string
+}
+
+function DrinkMetricTile({ label, avgMl, targetMl, moreIsBetter, labelGoal, unit = 'ml' }: DrinkMetricTileProps) {
+  const ratio = targetMl > 0 ? avgMl / targetMl : 0
+  const barPct = Math.min(100, Math.round(ratio * 100))
+  const goalMet = moreIsBetter ? avgMl >= targetMl : avgMl <= targetMl
+  const barColor = goalMet ? 'bg-movement-400' : moreIsBetter ? 'bg-primary' : 'bg-error'
+  const valueColor = goalMet ? 'text-movement-300' : 'text-on-surface'
+
+  const display = unit === 'L'
+    ? `${(avgMl / 1000).toFixed(1)} L`
+    : `${avgMl} ml`
+  const goalDisplay = unit === 'L'
+    ? `${(targetMl / 1000).toFixed(1)} L`
+    : `${targetMl} ml`
+
+  return (
+    <div className="col-span-1 sm:col-span-1 lg:col-span-6 bg-surface-container-high border border-outline-variant/10 rounded-xl p-4 flex flex-col gap-3">
+      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
+        {label}
+      </p>
+
+      <div className="flex items-end justify-between gap-2">
+        <div className="flex items-baseline gap-1.5">
+          <span className={`text-3xl font-headline font-bold tracking-tighter leading-none ${valueColor}`}>
+            {(avgMl / 1000).toFixed(1)}
+          </span>
+          <span className="text-xs text-on-surface-variant">L</span>
+        </div>
+        <span className="text-xs text-on-surface-variant shrink-0">
+          {labelGoal}: {goalDisplay}
+        </span>
+      </div>
+
+      <div className="space-y-1">
+        <div className="h-1 bg-surface-container rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full ${barColor} transition-all duration-700`}
+            style={{ width: `${barPct}%` }}
+          />
+        </div>
+        <p className="text-xs text-on-surface-variant text-right">{barPct}%</p>
+      </div>
+    </div>
+  )
+}
+
 // ─── Helper: compute 7-day vs 30-day success rate ─────────────────────────
 
 function computeRates(booleans: boolean[]): { pct30d: number; pct7d: number } {
@@ -375,10 +437,11 @@ function computeRates(booleans: boolean[]): { pct30d: number; pct7d: number } {
 // ─── Live Status section ───────────────────────────────────────────────────
 
 export async function LiveStatus() {
-  const [entries, metrics, profile, t] = await Promise.all([
+  const [entries, metrics, profile, drinkAvg, t] = await Promise.all([
     getAllEntries(),
     getLatestMetrics(),
     getProfile(),
+    getDrinkAvg7d(),
     getTranslations('HomePage'),
   ])
 
@@ -458,6 +521,23 @@ export async function LiveStatus() {
           labelSteps={t('metricSteps')}
           labelBodyFat={t('metricBodyFat')}
           labelAvg30d={t('metricAvg30d')}
+        />
+
+        {/* Row 3 — Drink metrics */}
+        <DrinkMetricTile
+          label={t('metricWater')}
+          avgMl={drinkAvg.waterMl}
+          targetMl={WATER_DAILY_TARGET_ML}
+          moreIsBetter={true}
+          labelGoal={t('metricDailyGoal')}
+        />
+
+        <DrinkMetricTile
+          label={t('metricColaZero')}
+          avgMl={drinkAvg.colaZeroMl}
+          targetMl={COLA_ZERO_DAILY_LIMIT_ML}
+          moreIsBetter={false}
+          labelGoal={t('metricDailyLimit')}
         />
 
       </div>

--- a/src/lib/drinks.ts
+++ b/src/lib/drinks.ts
@@ -1,13 +1,41 @@
 import { DrinkType } from '@prisma/client'
+import { prisma } from './db'
+import { zurichDayStart } from './timezone'
 
 export const DRINK_VOLUME: Record<DrinkType, number> = {
   WATER: 600,     // ml per bottle
   COLA_ZERO: 330, // ml per can
 }
 
+export const WATER_DAILY_TARGET_ML = 2500
+export const COLA_ZERO_DAILY_LIMIT_ML = 660
+
 export interface TodayDrinks {
   water: number
   colaZero: number
   waterMl: number
   colaZeroMl: number
+}
+
+export interface DrinkAvg7d {
+  waterMl: number
+  colaZeroMl: number
+}
+
+export async function getDrinkAvg7d(): Promise<DrinkAvg7d> {
+  const todayStart = zurichDayStart()
+  const sevenDaysAgo = new Date(todayStart.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+  const rows = await prisma.drinkLog.findMany({
+    where: { timestamp: { gte: sevenDaysAgo, lt: todayStart } },
+    select: { type: true, volume: true },
+  })
+
+  const waterTotal = rows.filter((r) => r.type === 'WATER').reduce((s, r) => s + r.volume, 0)
+  const colaTotal  = rows.filter((r) => r.type === 'COLA_ZERO').reduce((s, r) => s + r.volume, 0)
+
+  return {
+    waterMl: Math.round(waterTotal / 7),
+    colaZeroMl: Math.round(colaTotal / 7),
+  }
 }


### PR DESCRIPTION
Closes #171

## Summary
- Neue Reihe im LiveStatus-Dashboard (Startseite) mit zwei Getränke-Kacheln
- 7-Tages-Durchschnitt basierend auf Europe/Zurich Tagesgrenzen (nutzt `zurichDayStart()` aus BL-19)
- Korrekte Farbsemantik: Wasser grün bei ≥ 2.5L, Cola Zero grün bei ≤ 660ml

## Neue Kacheln

| Kachel | Ziel | Semantik |
|--------|------|----------|
| Ø Wasser (7T) | 2.5 L/Tag | Grün wenn Ziel erreicht, Orange darunter |
| Ø Cola Zero (7T) | 660 ml/Tag | Grün wenn unter Limit, Rot darüber |

## Änderungen

| Datei | Änderung |
|-------|----------|
| `src/lib/drinks.ts` | `getDrinkAvg7d()` + Ziel-Konstanten |
| `src/components/home/LiveStatus.tsx` | `DrinkMetricTile` + neue Reihe in Bento-Grid |
| `messages/de.json` | 4 neue i18n-Keys |
| `messages/en.json` | 4 neue i18n-Keys |
| `messages/pt.json` | 4 neue i18n-Keys |

## Test plan
- [ ] Startseite /de/ und /en/ zeigen neue Kacheln korrekt
- [ ] Mobile: Kacheln stacken auf 1-col
- [ ] Wasser mit ≥ 2.5L Schnitt → grüne Bar
- [ ] Cola Zero über 660ml Schnitt → rote Bar
- [ ] TypeScript: `pnpm tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)