### PR TITLE
feat: add water and cola zero analytics charts to admin dashboard

### DIFF
--- a/src/app/admin/drinks/page.tsx
+++ b/src/app/admin/drinks/page.tsx
@@ -1,0 +1,93 @@
+import Link from 'next/link'
+import { getDrinkAnalytics, WATER_DAILY_TARGET_ML, COLA_ZERO_DAILY_LIMIT_ML } from '@/lib/drinks'
+import { DrinkChartSection } from '@/components/admin/DrinkAnalyticsChart'
+
+export const dynamic = 'force-dynamic'
+
+const PERIODS = [
+  { value: '7',   label: '7T' },
+  { value: '30',  label: '30T' },
+  { value: '90',  label: '90T' },
+  { value: 'all', label: 'Alles' },
+] as const
+
+type Period = (typeof PERIODS)[number]['value']
+
+function parsePeriod(raw: string | undefined): Period {
+  const valid: Period[] = ['7', '30', '90', 'all']
+  return valid.includes(raw as Period) ? (raw as Period) : '30'
+}
+
+interface PageProps {
+  searchParams: { period?: string }
+}
+
+export default async function DrinksAnalyticsPage({ searchParams }: PageProps) {
+  const period = parsePeriod(searchParams.period)
+  const data = await getDrinkAnalytics(period === 'all' ? 'all' : parseInt(period))
+
+  return (
+    <div className="max-w-4xl space-y-8">
+
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="font-headline text-2xl font-bold text-on-surface">Getränke-Analytics</h1>
+          <p className="text-on-surface-variant text-sm mt-1">
+            {data.days.length > 0
+              ? `${data.days.length} Tage · ${data.days[0].date} – ${data.days[data.days.length - 1].date}`
+              : 'Keine Daten vorhanden'}
+          </p>
+        </div>
+
+        {/* Period toggle */}
+        <div className="flex gap-1 bg-surface-container rounded-lg p-1">
+          {PERIODS.map(({ value, label }) => (
+            <Link
+              key={value}
+              href={`/admin/drinks?period=${value}`}
+              className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+                period === value
+                  ? 'bg-surface-container-high text-on-surface'
+                  : 'text-on-surface-variant hover:text-on-surface'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* Water */}
+      <DrinkChartSection
+        title="💧 Wasser"
+        days={data.days}
+        dataKey="waterMl"
+        stats={data.waterStats}
+        barColor="#38bdf8"
+        lineColor="#0284c7"
+        accentClass="text-sky-400"
+        goalMl={WATER_DAILY_TARGET_ML}
+        goalLabel="Tagesziel"
+        goalLineLabel="Ziel"
+        moreIsBetter={true}
+      />
+
+      {/* Cola Zero */}
+      <DrinkChartSection
+        title="🥤 Cola Zero"
+        days={data.days}
+        dataKey="colaZeroMl"
+        stats={data.colaStats}
+        barColor="#f472b6"
+        lineColor="#db2777"
+        accentClass="text-pink-400"
+        goalMl={COLA_ZERO_DAILY_LIMIT_ML}
+        goalLabel="Tageslimit"
+        goalLineLabel="Limit"
+        moreIsBetter={false}
+      />
+
+    </div>
+  )
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -20,7 +20,8 @@ const NAV_GROUPS = [
   {
     label: 'Daten',
     items: [
-      { href: '/admin/quick-log', label: 'Quick Log', exact: false },
+      { href: '/admin/quick-log',  label: 'Quick Log',  exact: false },
+      { href: '/admin/drinks',     label: 'Getränke',   exact: false },
       { href: '/admin/metrics',            label: 'Metriken',    exact: false },
       { href: '/admin/body-measurements', label: 'Körpermasse', exact: false },
       { href: '/admin/reading',            label: 'Lesen',         exact: false },

--- a/src/components/admin/DrinkAnalyticsChart.tsx
+++ b/src/components/admin/DrinkAnalyticsChart.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts'
+import type { DrinkDayData, DrinkStats } from '@/lib/drinks'
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function formatDateShort(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('de-CH', {
+    day: 'numeric',
+    month: 'short',
+  })
+}
+
+function formatDateLong(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('de-CH', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+function mlToL(ml: number): number {
+  return Math.round(ml) / 1000
+}
+
+function rollingAvg(values: number[], window = 7): (number | null)[] {
+  return values.map((_, i) => {
+    const slice = values.slice(Math.max(0, i - window + 1), i + 1)
+    return Math.round(slice.reduce((s, v) => s + v, 0) / slice.length)
+  })
+}
+
+// ─── Tooltip ───────────────────────────────────────────────────────────────
+
+interface ChartTooltipProps {
+  active?: boolean
+  payload?: Array<{ name: string; value: number; color: string }>
+  label?: string
+  unit: string
+}
+
+function DrinkTooltip({ active, payload, label, unit }: ChartTooltipProps) {
+  if (!active || !payload?.length || !label) return null
+  return (
+    <div className="bg-surface-container border border-outline-variant/15 rounded px-3 py-2 text-sm">
+      <p className="text-on-surface-variant text-xs mb-1">{formatDateLong(label)}</p>
+      {payload.map((p) => (
+        <p key={p.name} style={{ color: p.color }} className="font-semibold">
+          {(p.value / 1000).toFixed(2)} {unit}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+// ─── Stats panel ───────────────────────────────────────────────────────────
+
+interface StatsPanelProps {
+  stats: DrinkStats
+  accentClass: string
+  goalMl: number
+  goalLabel: string
+}
+
+function StatsPanel({ stats, accentClass, goalMl, goalLabel }: StatsPanelProps) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm">
+      <div className="bg-surface-container rounded-lg p-3">
+        <p className="text-xs text-on-surface-variant mb-1">Gesamt</p>
+        <p className={`font-headline font-bold text-lg ${accentClass}`}>
+          {(stats.total / 1000).toFixed(1)} L
+        </p>
+      </div>
+      <div className="bg-surface-container rounded-lg p-3">
+        <p className="text-xs text-on-surface-variant mb-1">Ø / Tag</p>
+        <p className={`font-headline font-bold text-lg ${accentClass}`}>
+          {(stats.avg / 1000).toFixed(2)} L
+        </p>
+        <p className="text-xs text-on-surface-variant">{goalLabel}: {(goalMl / 1000).toFixed(1)} L</p>
+      </div>
+      <div className="bg-surface-container rounded-lg p-3">
+        <p className="text-xs text-on-surface-variant mb-1">Max-Tag</p>
+        {stats.maxDay ? (
+          <>
+            <p className="font-headline font-bold text-lg text-on-surface">
+              {(stats.maxDay.ml / 1000).toFixed(2)} L
+            </p>
+            <p className="text-xs text-on-surface-variant">{formatDateShort(stats.maxDay.date)}</p>
+          </>
+        ) : <p className="text-on-surface-variant">—</p>}
+      </div>
+      <div className="bg-surface-container rounded-lg p-3">
+        <p className="text-xs text-on-surface-variant mb-1">Min-Tag</p>
+        {stats.minDay ? (
+          <>
+            <p className="font-headline font-bold text-lg text-on-surface">
+              {(stats.minDay.ml / 1000).toFixed(2)} L
+            </p>
+            <p className="text-xs text-on-surface-variant">{formatDateShort(stats.minDay.date)}</p>
+          </>
+        ) : <p className="text-on-surface-variant">—</p>}
+      </div>
+      <div className="bg-surface-container rounded-lg p-3">
+        <p className="text-xs text-on-surface-variant mb-1">Längste Serie</p>
+        <p className={`font-headline font-bold text-lg ${accentClass}`}>{stats.streak}</p>
+        <p className="text-xs text-on-surface-variant">Tage</p>
+      </div>
+    </div>
+  )
+}
+
+// ─── Single drink chart section ────────────────────────────────────────────
+
+interface DrinkSectionProps {
+  title: string
+  days: DrinkDayData[]
+  dataKey: 'waterMl' | 'colaZeroMl'
+  stats: DrinkStats
+  barColor: string
+  lineColor: string
+  accentClass: string
+  goalMl: number
+  goalLabel: string
+  goalLineLabel: string
+  moreIsBetter: boolean
+}
+
+export function DrinkChartSection({
+  title,
+  days,
+  dataKey,
+  stats,
+  barColor,
+  lineColor,
+  accentClass,
+  goalMl,
+  goalLabel,
+  goalLineLabel,
+  moreIsBetter,
+}: DrinkSectionProps) {
+  const rawValues = days.map((d) => d[dataKey])
+  const avgValues = rollingAvg(rawValues, 7)
+
+  const chartData = days.map((d, i) => ({
+    date: d.date,
+    daily: d[dataKey],
+    avg7d: avgValues[i],
+  }))
+
+  const goalL = mlToL(goalMl)
+
+  return (
+    <div className="space-y-4">
+      <h2 className="font-headline font-bold text-lg text-on-surface">{title}</h2>
+
+      <StatsPanel
+        stats={stats}
+        accentClass={accentClass}
+        goalMl={goalMl}
+        goalLabel={goalLabel}
+      />
+
+      <div className="bg-surface-container border border-outline-variant/10 rounded-xl p-4">
+        {days.length === 0 ? (
+          <p className="text-on-surface-variant text-sm py-8 text-center">Keine Daten im gewählten Zeitraum</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <ComposedChart data={chartData} margin={{ top: 8, right: 8, left: -12, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 10, fill: 'var(--chart-axis)' }}
+                tickFormatter={(v) => formatDateShort(v)}
+                tickLine={false}
+                axisLine={{ stroke: 'var(--chart-axis-line)' }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tick={{ fontSize: 10, fill: 'var(--chart-axis)' }}
+                tickFormatter={(v) => `${(v / 1000).toFixed(1)}`}
+                tickLine={false}
+                axisLine={false}
+                unit="L"
+              />
+              <ReferenceLine
+                y={goalMl}
+                stroke={moreIsBetter ? '#22c55e' : '#ef4444'}
+                strokeDasharray="4 3"
+                strokeWidth={1.5}
+                label={{
+                  value: `${goalL.toFixed(1)}L ${goalLineLabel}`,
+                  position: 'insideTopRight',
+                  fontSize: 10,
+                  fill: moreIsBetter ? '#22c55e' : '#ef4444',
+                }}
+              />
+              <Tooltip content={<DrinkTooltip unit="L" />} />
+              <Legend
+                wrapperStyle={{ fontSize: 11, paddingTop: 8 }}
+                formatter={(value) => value === 'daily' ? 'Täglich' : '7T-Ø'}
+              />
+              <Bar dataKey="daily" fill={barColor} radius={[2, 2, 0, 0]} maxBarSize={32} name="daily" />
+              <Line
+                dataKey="avg7d"
+                type="monotone"
+                stroke={lineColor}
+                strokeWidth={2}
+                dot={false}
+                name="avg7d"
+                connectNulls
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/drinks.ts
+++ b/src/lib/drinks.ts
@@ -22,6 +22,103 @@ export interface DrinkAvg7d {
   colaZeroMl: number
 }
 
+// ─── Analytics ────────────────────────────────────────────────────────────
+
+export interface DrinkDayData {
+  date: string   // YYYY-MM-DD
+  waterMl: number
+  colaZeroMl: number
+}
+
+export interface DrinkDayStat {
+  date: string
+  ml: number
+}
+
+export interface DrinkStats {
+  total: number
+  avg: number
+  maxDay: DrinkDayStat | null
+  minDay: DrinkDayStat | null
+  streak: number
+}
+
+export interface DrinkAnalytics {
+  days: DrinkDayData[]
+  waterStats: DrinkStats
+  colaStats: DrinkStats
+}
+
+function buildStats(
+  days: DrinkDayData[],
+  key: 'waterMl' | 'colaZeroMl',
+  threshold: number,
+  moreIsBetter: boolean,
+): DrinkStats {
+  if (days.length === 0) return { total: 0, avg: 0, maxDay: null, minDay: null, streak: 0 }
+
+  const pairs = days.map((d) => ({ date: d.date, ml: d[key] }))
+  const total = pairs.reduce((s, d) => s + d.ml, 0)
+  const avg = Math.round(total / days.length)
+
+  const sorted = [...pairs].sort((a, b) => a.ml - b.ml)
+  const minDay = sorted[0]
+  const maxDay = sorted[sorted.length - 1]
+
+  let maxStreak = 0, cur = 0
+  for (const d of pairs) {
+    const met = moreIsBetter ? d.ml >= threshold : d.ml <= threshold
+    cur = met ? cur + 1 : 0
+    if (cur > maxStreak) maxStreak = cur
+  }
+
+  return { total, avg, maxDay, minDay, streak: maxStreak }
+}
+
+export async function getDrinkAnalytics(days: number | 'all'): Promise<DrinkAnalytics> {
+  const tz = 'Europe/Zurich'
+  const todayStart = zurichDayStart()
+  const since = days === 'all'
+    ? undefined
+    : new Date(todayStart.getTime() - days * 24 * 60 * 60 * 1000)
+
+  const rows = await prisma.drinkLog.findMany({
+    where: { timestamp: { ...(since ? { gte: since } : {}), lt: todayStart } },
+    select: { type: true, volume: true, timestamp: true },
+    orderBy: { timestamp: 'asc' },
+  })
+
+  // Aggregate by Zurich calendar day
+  const dayMap = new Map<string, { water: number; cola: number }>()
+  for (const row of rows) {
+    const date = new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(row.timestamp)
+    const entry = dayMap.get(date) ?? { water: 0, cola: 0 }
+    if (row.type === 'WATER') entry.water += row.volume
+    else entry.cola += row.volume
+    dayMap.set(date, entry)
+  }
+
+  // Build ordered day list, filling zeros for missing days
+  const daysList: DrinkDayData[] = []
+  const rangeStart = since ?? (rows[0]
+    ? new Date(new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(rows[0].timestamp) + 'T00:00:00Z')
+    : todayStart)
+
+  let cur = new Date(rangeStart)
+  while (cur < todayStart) {
+    const date = new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(cur)
+    const entry = dayMap.get(date) ?? { water: 0, cola: 0 }
+    daysList.push({ date, waterMl: entry.water, colaZeroMl: entry.cola })
+    cur = new Date(cur.getTime() + 24 * 60 * 60 * 1000)
+  }
+
+  return {
+    days: daysList,
+    waterStats: buildStats(daysList, 'waterMl', WATER_DAILY_TARGET_ML, true),
+    colaStats: buildStats(daysList, 'colaZeroMl', COLA_ZERO_DAILY_LIMIT_ML, false),
+  }
+}
+
 export async function getDrinkAvg7d(): Promise<DrinkAvg7d> {
   const todayStart = zurichDayStart()
   const sevenDaysAgo = new Date(todayStart.getTime() - 7 * 24 * 60 * 60 * 1000)


### PR DESCRIPTION
Closes #173

> **Merge-Reihenfolge:** Nach PR #172 (BL-13) mergen — dieser Branch baut darauf auf.

## Summary
- Neue Admin-Seite `/admin/drinks` mit Getränke-Analytics
- Nav-Eintrag "Getränke" unter "Daten" in der Sidebar
- Konstanten `WATER_DAILY_TARGET_ML` / `COLA_ZERO_DAILY_LIMIT_ML` aus BL-13 — keine Duplikation

## Features

### Period Toggle (URL searchParams)
`7T` | `30T` (default) | `90T` | `Alles` — link-basiert, kein JavaScript nötig

### Pro Getränk
| Komponente | Detail |
|-----------|--------|
| Stats Panel | Gesamt · Ø/Tag · Max-Tag (Datum+Menge) · Min-Tag · Längste Serie |
| Bar Chart | Tägliche Gesamtmenge in L |
| Trend Line | 7-Tages-gleitender Durchschnitt (Recharts `ComposedChart`) |
| Reference Line | Grün bei Wasser-Ziel (2.5L), Rot bei Cola-Limit (660ml) |

### Streak-Logik
- Wasser: aufeinanderfolgende Tage mit ≥ 2500ml
- Cola Zero: aufeinanderfolgende Tage mit ≤ 660ml
- Tage ohne Einträge zählen als 0ml (korrekt: bricht Wasser-Streak, verlängert Cola-Streak)

### Chart-Library
Recharts `ComposedChart` — bereits im Projekt vorhanden, konsistent mit anderen Metrik-Charts

## Test plan
- [ ] `/admin/drinks` lädt und zeigt beide Sektionen
- [ ] Period-Toggle wechselt Zeitraum korrekt
- [ ] Streak zählt bei Wasser-Zieltagen korrekt hoch
- [ ] Reference Line: grün bei Wasser, rot bei Cola Zero
- [ ] TypeScript: `pnpm tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)