### PR TITLE
feat: Metriken-Sektion Startseite Phase 1 — UI-Überarbeitung (#185)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -44,7 +44,11 @@
     "metricWater": "Ø Wasser (7T)",
     "metricColaZero": "Ø Cola Zero (7T)",
     "metricDailyGoal": "Tagesziel",
-    "metricDailyLimit": "Tageslimit"
+    "metricDailyLimit": "Tageslimit",
+    "metricsSectionTitle": "Metriken & Fortschritt",
+    "metricStart": "Start",
+    "metricProgress": "vom Weg geschafft",
+    "metricImport": "Import"
   },
   "AboutPage": {
     "metaTitle": "Über das Projekt — Project 365",

--- a/messages/en.json
+++ b/messages/en.json
@@ -44,7 +44,11 @@
     "metricWater": "Avg Water (7d)",
     "metricColaZero": "Avg Cola Zero (7d)",
     "metricDailyGoal": "Daily goal",
-    "metricDailyLimit": "Daily limit"
+    "metricDailyLimit": "Daily limit",
+    "metricsSectionTitle": "Metrics & Progress",
+    "metricStart": "Start",
+    "metricProgress": "of the way there",
+    "metricImport": "Import"
   },
   "AboutPage": {
     "metaTitle": "About the Project — Project 365",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -41,7 +41,11 @@
     "metricWater": "Média Água (7d)",
     "metricColaZero": "Média Cola Zero (7d)",
     "metricDailyGoal": "Meta diária",
-    "metricDailyLimit": "Limite diário"
+    "metricDailyLimit": "Limite diário",
+    "metricsSectionTitle": "Métricas & Progresso",
+    "metricStart": "Início",
+    "metricProgress": "do caminho percorrido",
+    "metricImport": "Importado"
   },
   "AboutPage": {
     "metaTitle": "Sobre o Projeto — Project 365",

--- a/public/images/journal/tag-043-sample-ai.svg
+++ b/public/images/journal/tag-043-sample-ai.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" width="1200" height="420">
+  <defs>
+    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1919;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0e0e0e;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="circ-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ff8f70;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#fc7c7c;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="420" fill="url(#bg-grad)"/>
+
+  <!-- Surface grounding layers -->
+  <rect x="-40" y="180" width="500" height="220" rx="40" fill="#201f1f" opacity="0.5" transform="rotate(-8, 200, 290)"/>
+  <rect x="780" y="30" width="480" height="200" rx="48" fill="#262626" opacity="0.45" transform="rotate(12, 1020, 130)"/>
+
+  <!-- Large background circles -->
+  <circle cx="980" cy="320" r="180" fill="#ff8f70" opacity="0.22"/>
+  <circle cx="120" cy="80" r="140" fill="#fc7c7c" opacity="0.2"/>
+  <circle cx="600" cy="380" r="120" fill="#eaa5ff" opacity="0.2"/>
+
+  <!-- Mid-layer ellipses -->
+  <ellipse cx="700" cy="100" rx="220" ry="90" fill="#ff734c" opacity="0.28" transform="rotate(15, 700, 100)"/>
+  <ellipse cx="250" cy="320" rx="160" ry="70" fill="#fc7c7c" opacity="0.25" transform="rotate(-10, 250, 320)"/>
+
+  <!-- Rotated rectangles for dynamism -->
+  <rect x="400" y="60" width="260" height="90" rx="28" fill="#ff8f70" opacity="0.32" transform="rotate(14, 530, 105)"/>
+  <rect x="820" y="240" width="300" height="80" rx="36" fill="#eaa5ff" opacity="0.28" transform="rotate(-10, 970, 280)"/>
+  <rect x="50" y="250" width="200" height="70" rx="24" fill="#ff734c" opacity="0.3" transform="rotate(9, 150, 285)"/>
+
+  <!-- Polygons / triangles for movement energy -->
+  <polygon points="560,30 630,160 490,160" fill="#ff8f70" opacity="0.35" transform="rotate(5, 560, 95)"/>
+  <polygon points="1080,180 1160,330 1000,330" fill="#fc7c7c" opacity="0.3" transform="rotate(-6, 1080, 255)"/>
+  <polygon points="180,140 240,260 120,260" fill="#eaa5ff" opacity="0.28" transform="rotate(10, 180, 200)"/>
+
+  <!-- Small accent shapes — focal points -->
+  <circle cx="610" cy="210" r="32" fill="#ff8f70" opacity="0.52"/>
+  <circle cx="980" cy="130" r="22" fill="#eaa5ff" opacity="0.5"/>
+  <rect x="290" y="170" width="50" height="50" rx="14" fill="#fc7c7c" opacity="0.48" transform="rotate(20, 315, 195)"/>
+</svg>

--- a/public/images/journal/tag-044-sample-ai.svg
+++ b/public/images/journal/tag-044-sample-ai.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" width="1200" height="420">
+  <defs>
+    <radialGradient id="bgGrad" cx="50%" cy="50%" r="70%" fx="50%" fy="50%">
+      <stop offset="0%" stop-color="#2a2a3e"/>
+      <stop offset="100%" stop-color="#1e1e2e"/>
+    </radialGradient>
+    <radialGradient id="glowMauve" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#cba6f7" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#cba6f7" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#89b4fa" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#89b4fa" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowTeal" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#94e2d5" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#94e2d5" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="overlayGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#cba6f7" stop-opacity="0.08"/>
+      <stop offset="50%" stop-color="#89b4fa" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#94e2d5" stop-opacity="0.07"/>
+    </linearGradient>
+    <filter id="blur1" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="45"/>
+    </filter>
+    <filter id="blur2" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="30"/>
+    </filter>
+    <filter id="blur3" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="20"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="420" fill="url(#bgGrad)"/>
+
+  <!-- Deep background blobs -->
+  <ellipse cx="300" cy="210" rx="380" ry="280" fill="#cba6f7" opacity="0.12" filter="url(#blur1)"/>
+  <ellipse cx="950" cy="180" rx="320" ry="260" fill="#89b4fa" opacity="0.13" filter="url(#blur1)"/>
+  <ellipse cx="620" cy="350" rx="280" ry="180" fill="#94e2d5" opacity="0.10" filter="url(#blur1)"/>
+
+  <!-- Mid-layer circles -->
+  <circle cx="220" cy="190" r="180" fill="url(#glowMauve)" filter="url(#blur2)" opacity="0.55"/>
+  <circle cx="980" cy="230" r="160" fill="url(#glowBlue)" filter="url(#blur2)" opacity="0.5"/>
+  <circle cx="600" cy="120" r="140" fill="url(#glowTeal)" filter="url(#blur2)" opacity="0.4"/>
+
+  <!-- Soft surface shapes -->
+  <ellipse cx="150" cy="320" rx="200" ry="120" fill="#313244" opacity="0.35" filter="url(#blur3)"/>
+  <ellipse cx="1050" cy="100" rx="180" ry="110" fill="#45475a" opacity="0.3" filter="url(#blur3)"/>
+  <ellipse cx="600" cy="260" rx="260" ry="140" fill="#313244" opacity="0.25" filter="url(#blur3)"/>
+
+  <!-- Crisp accent circles (lower opacity, no blur) -->
+  <circle cx="580" cy="200" r="110" fill="none" stroke="#cba6f7" stroke-width="1.5" opacity="0.2"/>
+  <circle cx="580" cy="200" r="160" fill="none" stroke="#89b4fa" stroke-width="1" opacity="0.12"/>
+  <circle cx="230" cy="180" r="90" fill="none" stroke="#94e2d5" stroke-width="1" opacity="0.18"/>
+  <circle cx="970" cy="220" r="100" fill="none" stroke="#cba6f7" stroke-width="1.2" opacity="0.15"/>
+
+  <!-- Flowing curve arcs -->
+  <path d="M 0 280 Q 300 150 600 250 T 1200 200" fill="none" stroke="#cba6f7" stroke-width="1.5" opacity="0.18"/>
+  <path d="M 0 320 Q 400 200 700 300 T 1200 260" fill="none" stroke="#89b4fa" stroke-width="1" opacity="0.14"/>
+  <path d="M 100 420 Q 500 280 900 360 T 1200 320" fill="none" stroke="#94e2d5" stroke-width="1" opacity="0.12"/>
+
+  <!-- Subtle filled arcs for depth -->
+  <path d="M 0 350 Q 200 200 450 300 Q 650 380 800 260 Q 1000 140 1200 300 L 1200 420 L 0 420 Z" fill="#313244" opacity="0.2"/>
+  <path d="M 0 390 Q 300 300 600 370 Q 900 430 1200 360 L 1200 420 L 0 420 Z" fill="#45475a" opacity="0.15"/>
+
+  <!-- Final gradient overlay -->
+  <rect width="1200" height="420" fill="url(#overlayGrad)"/>
+</svg>

--- a/public/images/journal/tag-045-sample-ai.svg
+++ b/public/images/journal/tag-045-sample-ai.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" width="1200" height="420">
+  <defs>
+    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1919"/>
+      <stop offset="100%" stop-color="#0e0e0e"/>
+    </linearGradient>
+    <linearGradient id="accent-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8f70"/>
+      <stop offset="100%" stop-color="#ff734c"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="420" fill="url(#bg-grad)"/>
+
+  <!-- Grounding mid-layer surface shapes -->
+  <rect x="-60" y="180" width="520" height="200" rx="40" fill="#201f1f" opacity="0.5" transform="rotate(-12 200 280)"/>
+  <rect x="820" y="60" width="460" height="220" rx="48" fill="#262626" opacity="0.45" transform="rotate(10 1050 170)"/>
+
+  <!-- Large background circles for movement energy -->
+  <circle cx="960" cy="320" r="220" fill="#ff8f70" opacity="0.2"/>
+  <circle cx="180" cy="100" r="160" fill="#ff734c" opacity="0.22"/>
+
+  <!-- Upward triangle - kinetic energy, movement -->
+  <polygon points="600,30 720,260 480,260" fill="#ff8f70" opacity="0.28"/>
+
+  <!-- Diagonal energy rect -->
+  <rect x="300" y="120" width="420" height="80" rx="32" fill="#ff734c" opacity="0.3" transform="rotate(14 510 160)"/>
+
+  <!-- Large sweeping ellipse -->
+  <ellipse cx="850" cy="200" rx="280" ry="100" fill="#ff8f70" opacity="0.25" transform="rotate(-18 850 200)"/>
+
+  <!-- Secondary polygon - angular dynamism -->
+  <polygon points="100,380 280,180 360,380" fill="#eaa5ff" opacity="0.22"/>
+
+  <!-- Tilted rect, purple accent -->
+  <rect x="780" y="280" width="300" height="70" rx="28" fill="#eaa5ff" opacity="0.28" transform="rotate(16 930 315)"/>
+
+  <!-- Coral accent ellipse -->
+  <ellipse cx="420" cy="360" rx="200" ry="55" fill="#fc7c7c" opacity="0.25" transform="rotate(-8 420 360)"/>
+
+  <!-- Upward pointing triangle - forward motion -->
+  <polygon points="1080,60 1160,240 1000,240" fill="#ff734c" opacity="0.3"/>
+
+  <!-- Small accent shapes - focal points -->
+  <circle cx="600" cy="210" r="28" fill="#ff8f70" opacity="0.52"/>
+  <circle cx="220" cy="320" r="20" fill="#eaa5ff" opacity="0.48"/>
+  <rect x="1030" y="130" width="60" height="60" rx="18" fill="#fc7c7c" opacity="0.5" transform="rotate(22 1060 160)"/>
+
+  <!-- Scattered detail rect -->
+  <rect x="500" y="310" width="180" height="44" rx="24" fill="#ff8f70" opacity="0.35" transform="rotate(-10 590 332)"/>
+
+  <!-- Top right energy burst polygon -->
+  <polygon points="1150,0 1200,120 1080,60" fill="#ff8f70" opacity="0.32"/>
+
+  <!-- Lower left grounding ellipse -->
+  <ellipse cx="80" cy="400" rx="120" ry="50" fill="#ff734c" opacity="0.3" transform="rotate(-20 80 400)"/>
+</svg>

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -1,6 +1,6 @@
 import { getTranslations } from 'next-intl/server'
 import { getAllEntries } from '@/lib/journal'
-import { getLatestMetrics } from '@/lib/metrics'
+import { getLatestMetrics, getStepsHistory } from '@/lib/metrics'
 import { getProfile } from '@/lib/profile'
 import { getPriorityPillar } from '@/lib/settings'
 import {
@@ -14,14 +14,29 @@ import {
   WATER_DAILY_TARGET_ML,
   COLA_ZERO_DAILY_LIMIT_ML,
 } from '@/lib/drinks'
+import { StepsSparkline } from './StepsSparkline'
+
+// ─── Constants ────────────────────────────────────────────────────────────
+const TARGET_BODY_FAT_PCT = 15
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function formatSyncTimestamp(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(date.getDate())}.${pad(date.getMonth() + 1)}.${date.getFullYear()}, ${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function clampPct(val: number): number {
+  return Math.max(0, Math.min(100, Math.round(val)))
+}
 
 // ─── SVG Ring Chart ────────────────────────────────────────────────────────
 
 interface RingChartProps {
-  pct: number          // 0–100
-  color: string        // stroke color (hex)
-  size?: number        // viewBox size (default 88)
-  strokeWidth?: number // (default 7)
+  pct: number
+  color: string
+  size?: number
+  strokeWidth?: number
 }
 
 function RingChart({ pct, color, size = 88, strokeWidth = 7 }: RingChartProps) {
@@ -34,14 +49,7 @@ function RingChart({ pct, color, size = 88, strokeWidth = 7 }: RingChartProps) {
 
   return (
     <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} aria-hidden="true">
-      {/* Track */}
-      <circle
-        cx={cx} cy={cy} r={r}
-        fill="none"
-        stroke="#201f1f"
-        strokeWidth={strokeWidth}
-      />
-      {/* Progress */}
+      <circle cx={cx} cy={cy} r={r} fill="none" stroke="#201f1f" strokeWidth={strokeWidth} />
       <circle
         cx={cx} cy={cy} r={r}
         fill="none"
@@ -52,7 +60,6 @@ function RingChart({ pct, color, size = 88, strokeWidth = 7 }: RingChartProps) {
         strokeDashoffset={offset}
         transform={`rotate(-90 ${cx} ${cy})`}
       />
-      {/* Center label */}
       <text
         x={cx} y={cy}
         textAnchor="middle"
@@ -68,14 +75,15 @@ function RingChart({ pct, color, size = 88, strokeWidth = 7 }: RingChartProps) {
   )
 }
 
-// ─── Smoking Streak Hero Tile ──────────────────────────────────────────────
+// ─── Glow styles per pillar ────────────────────────────────────────────────
 
-// Glow styles per pillar (smoking=blue, movement=green, nutrition=orange)
 const PILLAR_GLOW: Record<string, { border: string; shadow: string }> = {
   smoking:   { border: 'border-smoking-400/50',   shadow: '0 0 20px rgba(91,145,247,0.28), 0 0 6px rgba(91,145,247,0.14)' },
   movement:  { border: 'border-movement-400/50',  shadow: '0 0 20px rgba(98,188,68,0.28),  0 0 6px rgba(98,188,68,0.14)'  },
   nutrition: { border: 'border-nutrition-400/50', shadow: '0 0 20px rgba(253,139,80,0.28), 0 0 6px rgba(253,139,80,0.14)' },
 }
+
+// ─── Smoking Streak Hero Tile ──────────────────────────────────────────────
 
 interface SmokingHeroProps {
   streak: number
@@ -98,7 +106,6 @@ function SmokingHeroTile({ streak, longestStreak, pct, labelStreak, labelDays, l
       aria-label={isPriority ? 'Priorität: Rauchstopp' : undefined}
     >
       {isPriority && <span className="sr-only">Aktueller Fokus</span>}
-      {/* Decorative background number */}
       <span
         className="pointer-events-none select-none absolute -right-4 -bottom-4 font-headline font-bold leading-none text-smoking-400/5"
         style={{ fontSize: '10rem' }}
@@ -106,27 +113,18 @@ function SmokingHeroTile({ streak, longestStreak, pct, labelStreak, labelDays, l
       >
         {streak}
       </span>
-
-      {/* Header */}
       <p className="text-xs font-label font-bold tracking-widest uppercase text-smoking-400">
         {labelStreak}
       </p>
-
-      {/* Main number */}
       <div className="flex items-baseline gap-2">
         <span className="text-7xl font-headline font-bold tracking-tighter leading-none text-smoking-300">
           {streak}
         </span>
         <span className="text-sm text-on-surface-variant">{labelDays}</span>
       </div>
-
-      {/* Progress bar */}
       <div className="space-y-1.5">
         <div className="h-1 bg-surface-container-high rounded-full overflow-hidden">
-          <div
-            className="h-full rounded-full bg-smoking-400 transition-all duration-700"
-            style={{ width: `${pct}%` }}
-          />
+          <div className="h-full rounded-full bg-smoking-400 transition-all duration-700" style={{ width: `${pct}%` }} />
         </div>
         <div className="flex items-center justify-between">
           <span className="text-xs text-on-surface-variant">
@@ -148,7 +146,7 @@ interface HabitRingProps {
   streak: number
   pct7d: number
   pct30d: number
-  color: string        // hex
+  color: string
   labelDays: string
   label7d: string
   isPriority?: boolean
@@ -169,31 +167,22 @@ function HabitRingTile({ label, streak, pct7d, pct30d, color, labelDays, label7d
       aria-label={isPriority && pillarKey ? `Priorität: ${label}` : undefined}
     >
       {isPriority && <span className="sr-only">Aktueller Fokus</span>}
-      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
-        {label}
-      </p>
-
-      {/* Ring + streak */}
+      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{label}</p>
       <div className="flex items-center gap-4">
         <RingChart pct={pct30d} color={color} size={80} strokeWidth={6} />
-
         <div className="flex flex-col gap-1">
           <div className="flex items-baseline gap-1">
-            <span className="text-3xl font-headline font-bold tracking-tighter leading-none text-on-surface">
-              {streak}
-            </span>
+            <span className="text-3xl font-headline font-bold tracking-tighter leading-none text-on-surface">{streak}</span>
             <span className="text-xs text-on-surface-variant">{labelDays}</span>
           </div>
-          <span className={`text-xs font-semibold ${trendColor}`}>
-            {label7d}: {trendSign}{trend}%
-          </span>
+          <span className={`text-xs font-semibold ${trendColor}`}>{label7d}: {trendSign}{trend}%</span>
         </div>
       </div>
     </div>
   )
 }
 
-// ─── Nutrition Ring Tile (smaller) ─────────────────────────────────────────
+// ─── Nutrition Ring Tile ───────────────────────────────────────────────────
 
 interface NutritionRingProps {
   label: string
@@ -220,71 +209,58 @@ function NutritionRingTile({ label, streak, pct7d, pct30d, color, labelDays, lab
       aria-label={isPriority ? `Priorität: ${label}` : undefined}
     >
       {isPriority && <span className="sr-only">Aktueller Fokus</span>}
-      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
-        {label}
-      </p>
-
+      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{label}</p>
       <div className="flex flex-col items-center gap-2">
         <RingChart pct={pct30d} color={color} size={72} strokeWidth={6} />
-
         <div className="text-center">
           <div className="flex items-baseline justify-center gap-1">
-            <span className="text-2xl font-headline font-bold tracking-tighter leading-none text-on-surface">
-              {streak}
-            </span>
+            <span className="text-2xl font-headline font-bold tracking-tighter leading-none text-on-surface">{streak}</span>
             <span className="text-xs text-on-surface-variant">{labelDays}</span>
           </div>
-          <p className={`text-xs font-semibold mt-0.5 ${trendColor}`}>
-            {label7d}: {trendSign}{trend}%
-          </p>
+          <p className={`text-xs font-semibold mt-0.5 ${trendColor}`}>{label7d}: {trendSign}{trend}%</p>
         </div>
       </div>
     </div>
   )
 }
 
-// ─── Weight Progress Tile ─────────────────────────────────────────────────
+// ─── Weight Progress Tile ──────────────────────────────────────────────────
 
 interface WeightTileProps {
   weight?: number
   bmi?: number
   targetWeight?: number | null
-  lastSync?: Date
+  baselineWeight?: number
+  importedAt?: Date
   labelWeight: string
   labelBmi: string
   labelTarget: string
-  labelSync: string
+  labelImport: string
+  labelStart: string
+  labelProgress: string
   labelNoData: string
 }
 
-function WeightTile({ weight, bmi, targetWeight, lastSync, labelWeight, labelBmi, labelTarget, labelSync, labelNoData }: WeightTileProps) {
+function WeightTile({ weight, bmi, targetWeight, baselineWeight, importedAt, labelWeight, labelBmi, labelTarget, labelImport, labelStart, labelProgress, labelNoData }: WeightTileProps) {
   const hasWeight = weight !== undefined
   const hasTarget = targetWeight !== null && targetWeight !== undefined
+  const hasBaseline = baselineWeight !== undefined
 
-  // Progress: assume start weight was ~110kg (or derive from target gap)
-  // We'll just show how close to target (pct = 0 = far, 100 = at/below target)
   let pct = 0
-  const startReference = 110 // approximate start weight in kg
-  if (hasWeight && hasTarget && weight! < startReference) {
-    const totalNeeded = startReference - targetWeight!
-    const achieved = startReference - weight!
-    pct = totalNeeded > 0 ? Math.min(100, Math.round((achieved / totalNeeded) * 100)) : 100
+  if (hasWeight && hasTarget && hasBaseline) {
+    const totalNeeded = baselineWeight! - targetWeight!
+    const achieved = baselineWeight! - weight!
+    if (totalNeeded > 0) pct = clampPct((achieved / totalNeeded) * 100)
   }
 
-  const syncStr = lastSync
-    ? lastSync.toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit', year: 'numeric' })
-    : null
+  const syncStr = importedAt ? formatSyncTimestamp(importedAt) : null
 
   return (
-    <div className="col-span-1 sm:col-span-2 lg:col-span-8 bg-surface-container border border-outline-variant/10 rounded-xl p-5 flex flex-col gap-4">
+    <div className="col-span-1 sm:col-span-1 lg:col-span-6 bg-surface-container border border-outline-variant/10 rounded-xl p-5 flex flex-col gap-4">
       <div className="flex items-start justify-between gap-4">
-        <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
-          {labelWeight}
-        </p>
+        <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{labelWeight}</p>
         {syncStr && (
-          <span className="text-xs text-on-surface-variant shrink-0">
-            {labelSync}: {syncStr}
-          </span>
+          <span className="text-xs text-on-surface-variant shrink-0">{labelImport}: {syncStr}</span>
         )}
       </div>
 
@@ -307,23 +283,23 @@ function WeightTile({ weight, bmi, targetWeight, lastSync, labelWeight, labelBmi
             {hasTarget && (
               <div className="text-right">
                 <span className="text-xs text-on-surface-variant">{labelTarget}</span>
-                <p className="text-2xl font-headline font-bold tracking-tighter text-primary">
-                  {targetWeight} kg
-                </p>
+                <p className="text-2xl font-headline font-bold tracking-tighter text-primary">{targetWeight} kg</p>
               </div>
             )}
           </div>
 
-          {hasTarget && (
-            <div className="space-y-1.5">
+          {hasTarget && hasBaseline && (
+            <div className="space-y-2">
+              <p className="text-xs text-on-surface-variant">
+                {labelStart}: <span className="text-on-surface font-semibold">{baselineWeight!.toFixed(1)} kg</span>
+                {' → '}
+                {labelTarget}: <span className="text-primary font-semibold">{targetWeight} kg</span>
+              </p>
               <div className="h-1.5 bg-surface-container-high rounded-full overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-primary transition-all duration-700"
-                  style={{ width: `${pct}%` }}
-                />
+                <div className="h-full rounded-full bg-primary transition-all duration-700" style={{ width: `${pct}%` }} />
               </div>
               <p className="text-xs text-on-surface-variant text-right">
-                {pct}% {labelTarget.toLowerCase()}
+                <span className="text-on-surface font-semibold">{pct}%</span> {labelProgress}
               </p>
             </div>
           )}
@@ -335,67 +311,133 @@ function WeightTile({ weight, bmi, targetWeight, lastSync, labelWeight, labelBmi
   )
 }
 
-// ─── Steps + Body Fat Stacked Tile ────────────────────────────────────────
+// ─── Body Fat Tile ─────────────────────────────────────────────────────────
 
-interface StackedMetricProps {
-  steps?: number
-  stepsGoal: number
+interface BodyFatTileProps {
   bodyFat?: number
-  labelSteps: string
+  baselineBodyFat?: number
+  importedAt?: Date
   labelBodyFat: string
-  labelAvg30d: string
+  labelTarget: string
+  labelImport: string
+  labelStart: string
+  labelProgress: string
+  labelNoData: string
 }
 
-function StackedMetricTile({ steps, stepsGoal, bodyFat, labelSteps, labelBodyFat, labelAvg30d }: StackedMetricProps) {
-  const stepsPct = steps ? Math.min(100, Math.round((steps / stepsGoal) * 100)) : 0
+function BodyFatTile({ bodyFat, baselineBodyFat, importedAt, labelBodyFat, labelTarget, labelImport, labelStart, labelProgress, labelNoData }: BodyFatTileProps) {
+  const hasBodyFat = bodyFat !== undefined
+  const hasBaseline = baselineBodyFat !== undefined
+
+  let pct = 0
+  if (hasBodyFat && hasBaseline) {
+    const totalNeeded = baselineBodyFat! - TARGET_BODY_FAT_PCT
+    const achieved = baselineBodyFat! - bodyFat!
+    if (totalNeeded > 0) pct = clampPct((achieved / totalNeeded) * 100)
+  }
+
+  const syncStr = importedAt ? formatSyncTimestamp(importedAt) : null
 
   return (
-    <div className="col-span-1 sm:col-span-2 lg:col-span-4 bg-surface-container-high border border-outline-variant/10 rounded-xl overflow-hidden flex flex-col">
-      {/* Steps half */}
-      <div className="p-4 flex flex-col gap-2 flex-1">
-        <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
-          {labelSteps}
-        </p>
-        {steps !== undefined ? (
-          <>
+    <div className="col-span-1 sm:col-span-1 lg:col-span-6 bg-surface-container border border-outline-variant/10 rounded-xl p-5 flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{labelBodyFat}</p>
+        {syncStr && (
+          <span className="text-xs text-on-surface-variant shrink-0">{labelImport}: {syncStr}</span>
+        )}
+      </div>
+
+      {hasBodyFat ? (
+        <>
+          <div className="flex items-end gap-6">
             <div className="flex items-baseline gap-1.5">
-              <span className="text-3xl font-headline font-bold tracking-tighter leading-none text-on-surface">
-                {steps.toLocaleString('de-CH')}
+              <span className="text-5xl font-headline font-bold tracking-tighter leading-none text-on-surface">
+                {bodyFat!.toFixed(1)}
               </span>
-              <span className="text-xs text-on-surface-variant">/ {stepsGoal.toLocaleString('de-CH')}</span>
+              <span className="text-sm text-on-surface-variant">%</span>
             </div>
-            <div className="h-1 bg-surface-container rounded-full overflow-hidden">
-              <div
-                className="h-full rounded-full bg-movement-400 transition-all duration-700"
-                style={{ width: `${stepsPct}%` }}
-              />
+            <div className="text-right">
+              <span className="text-xs text-on-surface-variant">{labelTarget}</span>
+              <p className="text-2xl font-headline font-bold tracking-tighter text-primary">{TARGET_BODY_FAT_PCT} %</p>
             </div>
-            <p className="text-xs text-on-surface-variant">{labelAvg30d}</p>
-          </>
-        ) : (
-          <p className="text-sm text-on-surface-variant">—</p>
-        )}
-      </div>
-
-      {/* Divider */}
-      <div className="h-px bg-outline-variant/10" />
-
-      {/* Body Fat half */}
-      <div className="p-4 flex flex-col gap-2 flex-1">
-        <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
-          {labelBodyFat}
-        </p>
-        {bodyFat !== undefined ? (
-          <div className="flex items-baseline gap-1.5">
-            <span className="text-3xl font-headline font-bold tracking-tighter leading-none text-on-surface">
-              {bodyFat.toFixed(1)}
-            </span>
-            <span className="text-xs text-on-surface-variant">%</span>
           </div>
-        ) : (
-          <p className="text-sm text-on-surface-variant">—</p>
+
+          {hasBaseline && (
+            <div className="space-y-2">
+              <p className="text-xs text-on-surface-variant">
+                {labelStart}: <span className="text-on-surface font-semibold">{baselineBodyFat!.toFixed(1)} %</span>
+                {' → '}
+                {labelTarget}: <span className="text-primary font-semibold">{TARGET_BODY_FAT_PCT} %</span>
+              </p>
+              <div className="h-1.5 bg-surface-container-high rounded-full overflow-hidden">
+                <div className="h-full rounded-full bg-primary transition-all duration-700" style={{ width: `${pct}%` }} />
+              </div>
+              <p className="text-xs text-on-surface-variant text-right">
+                <span className="text-on-surface font-semibold">{pct}%</span> {labelProgress}
+              </p>
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="text-sm text-on-surface-variant">{labelNoData}</p>
+      )}
+    </div>
+  )
+}
+
+// ─── Steps Tile (full width with sparkline) ───────────────────────────────
+
+interface StepsTileProps {
+  avgSteps?: number
+  stepsGoal: number
+  stepsHistory: Array<{ date: string; steps: number }>
+  importedAt?: Date
+  labelSteps: string
+  labelAvg30d: string
+  labelImport: string
+  labelNoData: string
+}
+
+function StepsTile({ avgSteps, stepsGoal, stepsHistory, importedAt, labelSteps, labelAvg30d, labelImport, labelNoData }: StepsTileProps) {
+  const stepsPct = avgSteps ? Math.min(100, Math.round((avgSteps / stepsGoal) * 100)) : 0
+  const syncStr = importedAt ? formatSyncTimestamp(importedAt) : null
+
+  return (
+    <div className="col-span-1 sm:col-span-2 lg:col-span-12 bg-surface-container border border-outline-variant/10 rounded-xl p-5 flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{labelSteps}</p>
+        {syncStr && (
+          <span className="text-xs text-on-surface-variant shrink-0">{labelImport}: {syncStr}</span>
         )}
       </div>
+
+      {avgSteps !== undefined ? (
+        <>
+          <div className="flex items-center gap-4">
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-4xl font-headline font-bold tracking-tighter leading-none text-on-surface">
+                {avgSteps.toLocaleString('de-CH')}
+              </span>
+              <span className="text-sm text-on-surface-variant">/ {stepsGoal.toLocaleString('de-CH')}</span>
+            </div>
+            <div className="flex-1">
+              <div className="h-1.5 bg-surface-container-high rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-movement-400 transition-all duration-700"
+                  style={{ width: `${stepsPct}%` }}
+                />
+              </div>
+              <p className="text-xs text-on-surface-variant mt-1">{labelAvg30d} · {stepsPct}%</p>
+            </div>
+          </div>
+
+          {stepsHistory.length > 1 && (
+            <StepsSparkline data={stepsHistory} goal={stepsGoal} />
+          )}
+        </>
+      ) : (
+        <p className="text-sm text-on-surface-variant">{labelNoData}</p>
+      )}
     </div>
   )
 }
@@ -406,7 +448,6 @@ interface DrinkMetricTileProps {
   label: string
   avgMl: number
   targetMl: number
-  /** true = higher is better (water); false = lower is better (cola zero) */
   moreIsBetter: boolean
   labelGoal: string
   unit?: string
@@ -419,19 +460,13 @@ function DrinkMetricTile({ label, avgMl, targetMl, moreIsBetter, labelGoal, unit
   const barColor = goalMet ? 'bg-movement-400' : moreIsBetter ? 'bg-primary' : 'bg-error'
   const valueColor = goalMet ? 'text-movement-300' : 'text-on-surface'
 
-  const display = unit === 'L'
-    ? `${(avgMl / 1000).toFixed(1)} L`
-    : `${avgMl} ml`
   const goalDisplay = unit === 'L'
     ? `${(targetMl / 1000).toFixed(1)} L`
     : `${targetMl} ml`
 
   return (
     <div className="col-span-1 sm:col-span-1 lg:col-span-6 bg-surface-container-high border border-outline-variant/10 rounded-xl p-4 flex flex-col gap-3">
-      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
-        {label}
-      </p>
-
+      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{label}</p>
       <div className="flex items-end justify-between gap-2">
         <div className="flex items-baseline gap-1.5">
           <span className={`text-3xl font-headline font-bold tracking-tighter leading-none ${valueColor}`}>
@@ -439,17 +474,11 @@ function DrinkMetricTile({ label, avgMl, targetMl, moreIsBetter, labelGoal, unit
           </span>
           <span className="text-xs text-on-surface-variant">L</span>
         </div>
-        <span className="text-xs text-on-surface-variant shrink-0">
-          {labelGoal}: {goalDisplay}
-        </span>
+        <span className="text-xs text-on-surface-variant shrink-0">{labelGoal}: {goalDisplay}</span>
       </div>
-
       <div className="space-y-1">
         <div className="h-1 bg-surface-container rounded-full overflow-hidden">
-          <div
-            className={`h-full rounded-full ${barColor} transition-all duration-700`}
-            style={{ width: `${barPct}%` }}
-          />
+          <div className={`h-full rounded-full ${barColor} transition-all duration-700`} style={{ width: `${barPct}%` }} />
         </div>
         <p className="text-xs text-on-surface-variant text-right">{barPct}%</p>
       </div>
@@ -457,7 +486,7 @@ function DrinkMetricTile({ label, avgMl, targetMl, moreIsBetter, labelGoal, unit
   )
 }
 
-// ─── Helper: compute 7-day vs 30-day success rate ─────────────────────────
+// ─── Helper: 7-day vs 30-day success rate ─────────────────────────────────
 
 function computeRates(booleans: boolean[]): { pct30d: number; pct7d: number } {
   const last30 = booleans.slice(0, 30)
@@ -467,16 +496,20 @@ function computeRates(booleans: boolean[]): { pct30d: number; pct7d: number } {
   return { pct30d, pct7d }
 }
 
-// ─── Live Status section ───────────────────────────────────────────────────
+// ─── Live Status Section ───────────────────────────────────────────────────
 
 export async function LiveStatus() {
-  const [entries, metrics, profile, drinkAvg, priorityPillar, t] = await Promise.all([
-    getAllEntries(),
-    getLatestMetrics(),
+  const [profile, t] = await Promise.all([
     getProfile(),
+    getTranslations('HomePage'),
+  ])
+
+  const [entries, metrics, drinkAvg, priorityPillar, stepsHistoryRaw] = await Promise.all([
+    getAllEntries(),
+    getLatestMetrics(profile.projectStartDate ?? undefined),
     getDrinkAvg7d(),
     getPriorityPillar(),
-    getTranslations('HomePage'),
+    getStepsHistory(30),
   ])
 
   const movementBools = entries.map((e) => isMovementFulfilled(e.habits.movement))
@@ -493,18 +526,22 @@ export async function LiveStatus() {
 
   const stepsGoal = profile.targetSteps ?? 10000
 
+  const stepsHistory = stepsHistoryRaw
+    .filter((d) => d.steps !== null)
+    .map((d) => ({ date: d.date.toISOString().slice(0, 10), steps: d.steps as number }))
+
   return (
     <section className="max-w-4xl mx-auto px-4 sm:px-6 py-8 border-b border-outline-variant/10">
 
       {/* Section label */}
       <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant mb-4">
-        {t('tagline')}
+        {t('metricsSectionTitle')}
       </p>
 
       {/* Bento grid — 12-col on lg, 2-col on sm, 1-col on mobile */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-3">
 
-        {/* Row 1 */}
+        {/* Row A — Habit streaks */}
         <SmokingHeroTile
           streak={smokingStreak.current}
           longestStreak={smokingStreak.longest}
@@ -515,7 +552,6 @@ export async function LiveStatus() {
           labelRate={t('rate30d')}
           isPriority={priorityPillar === 'smoking'}
         />
-
         <HabitRingTile
           label={t('streakMovement')}
           streak={movementStreak.current}
@@ -527,7 +563,6 @@ export async function LiveStatus() {
           isPriority={priorityPillar === 'movement'}
           pillarKey="movement"
         />
-
         <NutritionRingTile
           label={t('streakNutrition')}
           streak={nutritionStreak.current}
@@ -539,29 +574,46 @@ export async function LiveStatus() {
           isPriority={priorityPillar === 'nutrition'}
         />
 
-        {/* Row 2 */}
+        {/* Row B — Weight & Body Fat */}
         <WeightTile
           weight={metrics.latestWeight}
           bmi={metrics.latestBmi}
           targetWeight={profile.targetWeight}
-          lastSync={metrics.lastSyncDate}
+          baselineWeight={metrics.baselineWeight}
+          importedAt={metrics.weightImportedAt}
           labelWeight={t('metricWeight')}
           labelBmi={t('metricBmi')}
           labelTarget={t('metricTarget')}
-          labelSync={t('metricSync')}
+          labelImport={t('metricImport')}
+          labelStart={t('metricStart')}
+          labelProgress={t('metricProgress')}
+          labelNoData={t('metricNoData')}
+        />
+        <BodyFatTile
+          bodyFat={metrics.latestBodyFat}
+          baselineBodyFat={metrics.baselineBodyFat}
+          importedAt={metrics.bodyFatImportedAt}
+          labelBodyFat={t('metricBodyFat')}
+          labelTarget={t('metricTarget')}
+          labelImport={t('metricImport')}
+          labelStart={t('metricStart')}
+          labelProgress={t('metricProgress')}
           labelNoData={t('metricNoData')}
         />
 
-        <StackedMetricTile
-          steps={metrics.avgSteps30d}
+        {/* Row C — Steps with sparkline */}
+        <StepsTile
+          avgSteps={metrics.avgSteps30d}
           stepsGoal={stepsGoal}
-          bodyFat={metrics.latestBodyFat}
+          stepsHistory={stepsHistory}
+          importedAt={metrics.stepsImportedAt}
           labelSteps={t('metricSteps')}
-          labelBodyFat={t('metricBodyFat')}
           labelAvg30d={t('metricAvg30d')}
+          labelImport={t('metricImport')}
+          labelNoData={t('metricNoData')}
         />
 
-        {/* Row 3 — Drink metrics */}
+        {/* Row D — Drink metrics */}
         <DrinkMetricTile
           label={t('metricWater')}
           avgMl={drinkAvg.waterMl}
@@ -569,7 +621,6 @@ export async function LiveStatus() {
           moreIsBetter={true}
           labelGoal={t('metricDailyGoal')}
         />
-
         <DrinkMetricTile
           label={t('metricColaZero')}
           avgMl={drinkAvg.colaZeroMl}

--- a/src/components/home/StepsSparkline.tsx
+++ b/src/components/home/StepsSparkline.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import {
+  LineChart,
+  Line,
+  ResponsiveContainer,
+  ReferenceLine,
+  Tooltip,
+  XAxis,
+} from 'recharts'
+
+interface DataPoint {
+  date: string
+  steps: number
+}
+
+interface StepsSparklineProps {
+  data: DataPoint[]
+  goal: number
+}
+
+export function StepsSparkline({ data, goal }: StepsSparklineProps) {
+  return (
+    <ResponsiveContainer width="100%" height={64}>
+      <LineChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 4 }}>
+        <XAxis dataKey="date" hide />
+        <ReferenceLine
+          y={goal}
+          stroke="rgba(255,143,112,0.25)"
+          strokeDasharray="4 3"
+          strokeWidth={1}
+        />
+        <Tooltip
+          contentStyle={{
+            background: '#1a1919',
+            border: '1px solid rgba(72,72,71,0.4)',
+            borderRadius: 4,
+            fontSize: 11,
+            padding: '4px 8px',
+          }}
+          labelStyle={{ color: '#adaaaa', fontSize: 10, marginBottom: 2 }}
+          itemStyle={{ color: '#62bc44' }}
+          formatter={(v: number) => [v.toLocaleString('de-CH'), 'Schritte']}
+          labelFormatter={(label: string) =>
+            new Date(label).toLocaleDateString('de-CH', {
+              day: '2-digit',
+              month: '2-digit',
+              year: 'numeric',
+            })
+          }
+        />
+        <Line
+          type="monotone"
+          dataKey="steps"
+          stroke="#62bc44"
+          strokeWidth={1.5}
+          dot={false}
+          activeDot={{ r: 3, fill: '#62bc44', strokeWidth: 0 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -6,47 +6,74 @@ export interface MetricsSummary {
   latestBmi?: number
   avgSteps30d?: number
   lastSyncDate?: Date
+  weightImportedAt?: Date
+  bodyFatImportedAt?: Date
+  stepsImportedAt?: Date
+  baselineWeight?: number
+  baselineBodyFat?: number
 }
 
-export async function getLatestMetrics(): Promise<MetricsSummary> {
-  const [latest, lastSyncRow] = await Promise.all([
-    prisma.dailyMetrics.findFirst({
-      orderBy: { date: 'desc' },
-      where: {
-        OR: [
-          { weight: { not: null } },
-          { bodyFat: { not: null } },
-        ],
-      },
-    }),
-    prisma.dailyMetrics.findFirst({
-      orderBy: { date: 'desc' },
-      select: { date: true },
-    }),
-  ])
+export async function getLatestMetrics(projectStartDate?: string): Promise<MetricsSummary> {
+  const startDate = projectStartDate ? new Date(projectStartDate) : new Date('2020-01-01')
 
   const thirtyDaysAgo = new Date()
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
 
-  const stepsData = await prisma.dailyMetrics.findMany({
-    where: {
-      date: { gte: thirtyDaysAgo },
-      steps: { not: null },
-    },
-    select: { steps: true },
-  })
+  const [
+    latestWeightRow,
+    latestBodyFatRow,
+    latestStepsRow,
+    baselineWeightRow,
+    baselineBodyFatRow,
+    stepsData,
+  ] = await Promise.all([
+    prisma.dailyMetrics.findFirst({
+      orderBy: { date: 'desc' },
+      where: { weight: { not: null } },
+      select: { weight: true, bmi: true, updatedAt: true },
+    }),
+    prisma.dailyMetrics.findFirst({
+      orderBy: { date: 'desc' },
+      where: { bodyFat: { not: null } },
+      select: { bodyFat: true, updatedAt: true },
+    }),
+    prisma.dailyMetrics.findFirst({
+      orderBy: { date: 'desc' },
+      where: { steps: { not: null } },
+      select: { date: true, updatedAt: true },
+    }),
+    prisma.dailyMetrics.findFirst({
+      orderBy: { date: 'asc' },
+      where: { date: { gte: startDate }, weight: { not: null } },
+      select: { weight: true },
+    }),
+    prisma.dailyMetrics.findFirst({
+      orderBy: { date: 'asc' },
+      where: { date: { gte: startDate }, bodyFat: { not: null } },
+      select: { bodyFat: true },
+    }),
+    prisma.dailyMetrics.findMany({
+      where: { date: { gte: thirtyDaysAgo }, steps: { not: null } },
+      select: { steps: true },
+    }),
+  ])
 
   const avgSteps =
     stepsData.length > 0
-      ? Math.round(stepsData.reduce((sum, d) => sum + (d.steps ?? 0), 0) / stepsData.length)
+      ? Math.round(stepsData.reduce((s, d) => s + (d.steps ?? 0), 0) / stepsData.length)
       : undefined
 
   return {
-    latestWeight: latest?.weight ?? undefined,
-    latestBodyFat: latest?.bodyFat ?? undefined,
-    latestBmi: latest?.bmi ?? undefined,
+    latestWeight: latestWeightRow?.weight ?? undefined,
+    latestBodyFat: latestBodyFatRow?.bodyFat ?? undefined,
+    latestBmi: latestWeightRow?.bmi ?? undefined,
     avgSteps30d: avgSteps,
-    lastSyncDate: lastSyncRow?.date ?? undefined,
+    lastSyncDate: latestStepsRow?.date ?? undefined,
+    weightImportedAt: latestWeightRow?.updatedAt ?? undefined,
+    bodyFatImportedAt: latestBodyFatRow?.updatedAt ?? undefined,
+    stepsImportedAt: latestStepsRow?.updatedAt ?? undefined,
+    baselineWeight: baselineWeightRow?.weight ?? undefined,
+    baselineBodyFat: baselineBodyFatRow?.bodyFat ?? undefined,
   }
 }
 


### PR DESCRIPTION
## Summary

- Sektionstitel: „METRIKEN & FORTSCHRITT" statt „EIN ÖFFENTLICHES PROJEKT"
- Gewicht-Kachel: Baseline-Fortschrittsberechnung mit korrekter Formel `(baseline - aktuell) / (baseline - ziel) * 100`, Clamping 0–100 %
- Körperfett als eigenständige Kachel neben Gewicht (je 6 Spalten), eigene Baseline-Logik, Ziel 15 %
- Schritte über volle Breite mit 30-Tage-Sparkline (Recharts LineChart) und dezenter Ziellinie bei 10'000
- Sync-Timestamps mit Uhrzeit: `Import: DD.MM.YYYY, HH:mm`
- `getLatestMetrics()` liefert jetzt separate `importedAt`-Timestamps pro Metrik und Baseline-Werte
- Neue i18n-Keys in DE/EN/PT: `metricsSectionTitle`, `metricStart`, `metricProgress`, `metricImport`

Closes #185

## Test plan

- [ ] Sektionstitel zeigt „METRIKEN & FORTSCHRITT"
- [ ] Gewicht-Kachel zeigt Baseline, Ziel und Prozentwert (0–100 %)
- [ ] Körperfett als eigenständige Kachel mit Progress-Bar
- [ ] Schritte-Kachel über volle Breite mit Sparkline
- [ ] Timestamps mit Datum + Uhrzeit sichtbar
- [ ] Responsive auf Mobile
- [ ] Keine Regression bei Rauchstopp/Bewegung/Ernährung/Wasser/Cola Zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)