### PR TITLE
feat: sweets tracking — quick-log toggle + dashboard tile (#186)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -48,7 +48,8 @@
     "metricsSectionTitle": "Metriken & Fortschritt",
     "metricStart": "Start",
     "metricProgress": "vom Weg geschafft",
-    "metricImport": "Import"
+    "metricImport": "Import",
+    "metricSweets": "Süssigkeiten-Freie-Serie"
   },
   "AboutPage": {
     "metaTitle": "Über das Projekt — Project 365",

--- a/messages/en.json
+++ b/messages/en.json
@@ -48,7 +48,8 @@
     "metricsSectionTitle": "Metrics & Progress",
     "metricStart": "Start",
     "metricProgress": "of the way there",
-    "metricImport": "Import"
+    "metricImport": "Import",
+    "metricSweets": "Sweets-Free Streak"
   },
   "AboutPage": {
     "metaTitle": "About the Project — Project 365",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -45,7 +45,8 @@
     "metricsSectionTitle": "Métricas & Progresso",
     "metricStart": "Início",
     "metricProgress": "do caminho percorrido",
-    "metricImport": "Importado"
+    "metricImport": "Importado",
+    "metricSweets": "Dias Sem Doces"
   },
   "AboutPage": {
     "metaTitle": "Sobre o Projeto — Project 365",

--- a/prisma/migrations/20260418180249_add_sweets_consumed/migration.sql
+++ b/prisma/migrations/20260418180249_add_sweets_consumed/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JournalEntry" ADD COLUMN     "sweetsConsumed" BOOLEAN;

--- a/prisma/migrations/20260418182001_add_sweets_log/migration.sql
+++ b/prisma/migrations/20260418182001_add_sweets_log/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "SweetsLog" (
+    "id" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "consumed" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SweetsLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SweetsLog_date_key" ON "SweetsLog"("date");
+
+-- CreateIndex
+CREATE INDEX "SweetsLog_date_idx" ON "SweetsLog"("date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,9 @@ model JournalEntry {
   nutrition NutritionLevel
   smoking   SmokingStatus
 
+  // Süssigkeiten: null = nicht erfasst, false = keine, true = konsumiert
+  sweetsConsumed Boolean?
+
   // Privates Notizfeld — niemals in öffentlichen Queries zurückgeben
   privateNotes String? @db.Text
 
@@ -272,6 +275,21 @@ model DrinkLog {
 enum DrinkType {
   WATER
   COLA_ZERO
+}
+
+// =============================================
+// SÜSSIGKEITEN-LOG — tägliche Erfassung (unabhängig vom Journal-Eintrag)
+// consumed = false → keine Süssigkeiten, true → konsumiert
+// =============================================
+
+model SweetsLog {
+  id        String   @id @default(cuid())
+  date      DateTime @unique @db.Date
+  consumed  Boolean
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([date])
 }
 
 // =============================================

--- a/src/app/admin/quick-log/actions.ts
+++ b/src/app/admin/quick-log/actions.ts
@@ -28,6 +28,27 @@ export async function deleteDrink(id: string): Promise<{ error?: string }> {
   return {}
 }
 
+export async function setSweetsConsumed(value: boolean | null): Promise<{ error?: string }> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  const today = zurichDayStart()
+
+  if (value === null) {
+    await prisma.sweetsLog.deleteMany({ where: { date: today } })
+  } else {
+    await prisma.sweetsLog.upsert({
+      where: { date: today },
+      update: { consumed: value },
+      create: { date: today, consumed: value },
+    })
+  }
+
+  revalidatePath('/admin/quick-log')
+  revalidatePath('/')
+  return {}
+}
+
 export async function getTodayDrinks(): Promise<TodayDrinks> {
   const start = zurichDayStart()
 

--- a/src/app/admin/quick-log/page.tsx
+++ b/src/app/admin/quick-log/page.tsx
@@ -8,10 +8,15 @@ export const dynamic = 'force-dynamic'
 export default async function QuickLogPage() {
   const start = zurichDayStart()
 
-  const todayEntries = await prisma.drinkLog.findMany({
-    where: { timestamp: { gte: start } },
-    orderBy: { timestamp: 'desc' },
-  })
+  const [todayEntries, todaySweetsLog] = await Promise.all([
+    prisma.drinkLog.findMany({
+      where: { timestamp: { gte: start } },
+      orderBy: { timestamp: 'desc' },
+    }),
+    prisma.sweetsLog.findUnique({
+      where: { date: start },
+    }),
+  ])
 
   const water = todayEntries.filter((e) => e.type === 'WATER').length
   const colaZero = todayEntries.filter((e) => e.type === 'COLA_ZERO').length
@@ -27,7 +32,7 @@ export default async function QuickLogPage() {
     <div className="max-w-sm mx-auto space-y-8 py-4">
       <div>
         <h1 className="font-headline text-2xl font-bold text-on-surface mb-1">Quick Log</h1>
-        <p className="text-on-surface-variant text-sm">Getränke schnell erfassen</p>
+        <p className="text-on-surface-variant text-sm">Getränke und Süssigkeiten erfassen</p>
       </div>
 
       {/* Today's summary */}
@@ -46,7 +51,10 @@ export default async function QuickLogPage() {
         </div>
       </div>
 
-      <QuickLogButtons recentEntries={recentEntries} />
+      <QuickLogButtons
+        recentEntries={recentEntries}
+        sweetsConsumed={todaySweetsLog?.consumed ?? null}
+      />
     </div>
   )
 }

--- a/src/components/admin/QuickLogButtons.tsx
+++ b/src/components/admin/QuickLogButtons.tsx
@@ -2,7 +2,7 @@
 
 import { useTransition, useState } from 'react'
 import { DrinkType } from '@prisma/client'
-import { logDrink, deleteDrink } from '@/app/admin/quick-log/actions'
+import { logDrink, deleteDrink, setSweetsConsumed } from '@/app/admin/quick-log/actions'
 
 interface LogEntry {
   id: string
@@ -12,6 +12,7 @@ interface LogEntry {
 
 interface QuickLogButtonsProps {
   recentEntries: LogEntry[]
+  sweetsConsumed: boolean | null
 }
 
 interface Feedback {
@@ -19,10 +20,25 @@ interface Feedback {
   key: number
 }
 
-export function QuickLogButtons({ recentEntries }: QuickLogButtonsProps) {
+export function QuickLogButtons({ recentEntries, sweetsConsumed }: QuickLogButtonsProps) {
   const [isPending, startTransition] = useTransition()
   const [feedback, setFeedback] = useState<Feedback | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [sweetsLocal, setSweetsLocal] = useState<boolean | null>(sweetsConsumed)
+  const [sweetsError, setSweetsError] = useState<string | null>(null)
+
+  function handleSweets(value: boolean | null) {
+    setSweetsError(null)
+    const prev = sweetsLocal
+    setSweetsLocal(value)
+    startTransition(async () => {
+      const result = await setSweetsConsumed(value)
+      if (result.error) {
+        setSweetsLocal(prev)
+        setSweetsError(result.error)
+      }
+    })
+  }
 
   function handleLog(type: DrinkType) {
     const key = Date.now()
@@ -70,6 +86,48 @@ export function QuickLogButtons({ recentEntries }: QuickLogButtonsProps) {
           <span className="font-label text-xs font-bold tracking-widest uppercase text-on-surface-variant">Cola Zero</span>
           <span className="text-xs text-on-surface-variant">330 ml</span>
         </button>
+      </div>
+
+      {/* Sweets tracking */}
+      <div>
+        <p className="text-xs font-semibold text-on-surface-variant uppercase tracking-wide mb-3">Süssigkeiten heute</p>
+        <div className="grid grid-cols-3 gap-2">
+          <button
+            onClick={() => handleSweets(false)}
+            disabled={isPending}
+            className={`flex flex-col items-center justify-center gap-1.5 rounded-xl p-4 border transition-all disabled:opacity-60 active:scale-95 ${
+              sweetsLocal === false
+                ? 'bg-movement-400/20 border-movement-400/50 text-movement-300'
+                : 'bg-surface-container border-surface-container-high text-on-surface-variant'
+            }`}
+          >
+            <span className="text-2xl">✅</span>
+            <span className="font-label text-xs font-bold tracking-widest uppercase">Keine</span>
+          </button>
+          <button
+            onClick={() => handleSweets(true)}
+            disabled={isPending}
+            className={`flex flex-col items-center justify-center gap-1.5 rounded-xl p-4 border transition-all disabled:opacity-60 active:scale-95 ${
+              sweetsLocal === true
+                ? 'bg-error/20 border-error/50 text-error'
+                : 'bg-surface-container border-surface-container-high text-on-surface-variant'
+            }`}
+          >
+            <span className="text-2xl">🍫</span>
+            <span className="font-label text-xs font-bold tracking-widest uppercase">Konsumiert</span>
+          </button>
+          <button
+            onClick={() => handleSweets(null)}
+            disabled={isPending || sweetsLocal === null}
+            className="flex flex-col items-center justify-center gap-1.5 rounded-xl p-4 border bg-surface-container border-surface-container-high text-on-surface-variant transition-all disabled:opacity-40 active:scale-95"
+          >
+            <span className="text-2xl">↩</span>
+            <span className="font-label text-xs font-bold tracking-widest uppercase">Reset</span>
+          </button>
+        </div>
+        {sweetsError && (
+          <p className="text-xs text-error mt-2">{sweetsError}</p>
+        )}
       </div>
 
       {/* Recent entries (today) */}

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -5,12 +5,15 @@ import { getProfile } from '@/lib/profile'
 import { getPriorityPillar } from '@/lib/settings'
 import {
   calculateStreak,
+  calculateSweetsStreak,
+  computeSweetsRate30d,
   isMovementFulfilled,
   isNutritionFulfilled,
   isSmokingFulfilled,
 } from '@/lib/habits'
 import {
   getDrinkAvg7d,
+  getSweetsHistory,
   WATER_DAILY_TARGET_ML,
   COLA_ZERO_DAILY_LIMIT_ML,
 } from '@/lib/drinks'
@@ -442,6 +445,43 @@ function StepsTile({ avgSteps, stepsGoal, stepsHistory, importedAt, labelSteps, 
   )
 }
 
+// ─── Sweets Tile ──────────────────────────────────────────────────────────
+
+interface SweetsTileProps {
+  streak: number
+  longestStreak: number
+  rate30d: number
+  labelSweets: string
+  labelDays: string
+  labelLongest: string
+  labelRate: string
+}
+
+function SweetsTile({ streak, longestStreak, rate30d, labelSweets, labelDays, labelLongest, labelRate }: SweetsTileProps) {
+  return (
+    <div className="col-span-1 sm:col-span-1 lg:col-span-4 bg-surface-container-high border border-outline-variant/10 rounded-xl p-4 flex flex-col gap-3">
+      <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{labelSweets}</p>
+      <div className="flex items-baseline gap-2">
+        <span className="text-4xl font-headline font-bold tracking-tighter leading-none text-on-surface">{streak}</span>
+        <span className="text-sm text-on-surface-variant">{labelDays}</span>
+      </div>
+      <div className="space-y-1">
+        <div className="h-1 bg-surface-container rounded-full overflow-hidden">
+          <div className="h-full rounded-full bg-tertiary transition-all duration-700" style={{ width: `${rate30d}%` }} />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-on-surface-variant">
+            {labelRate}: <span className="text-tertiary font-semibold">{rate30d}%</span>
+          </span>
+          <span className="text-xs text-on-surface-variant">
+            {labelLongest}: <span className="text-on-surface font-semibold">{longestStreak}</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ─── Drink Metric Tile ────────────────────────────────────────────────────
 
 interface DrinkMetricTileProps {
@@ -465,7 +505,7 @@ function DrinkMetricTile({ label, avgMl, targetMl, moreIsBetter, labelGoal, unit
     : `${targetMl} ml`
 
   return (
-    <div className="col-span-1 sm:col-span-1 lg:col-span-6 bg-surface-container-high border border-outline-variant/10 rounded-xl p-4 flex flex-col gap-3">
+    <div className="col-span-1 sm:col-span-1 lg:col-span-4 bg-surface-container-high border border-outline-variant/10 rounded-xl p-4 flex flex-col gap-3">
       <p className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">{label}</p>
       <div className="flex items-end justify-between gap-2">
         <div className="flex items-baseline gap-1.5">
@@ -504,12 +544,13 @@ export async function LiveStatus() {
     getTranslations('HomePage'),
   ])
 
-  const [entries, metrics, drinkAvg, priorityPillar, stepsHistoryRaw] = await Promise.all([
+  const [entries, metrics, drinkAvg, priorityPillar, stepsHistoryRaw, sweetsHistory] = await Promise.all([
     getAllEntries(),
     getLatestMetrics(profile.projectStartDate ?? undefined),
     getDrinkAvg7d(),
     getPriorityPillar(),
     getStepsHistory(30),
+    getSweetsHistory(90),
   ])
 
   const movementBools = entries.map((e) => isMovementFulfilled(e.habits.movement))
@@ -523,6 +564,9 @@ export async function LiveStatus() {
   const movementRates  = computeRates(movementBools)
   const nutritionRates = computeRates(nutritionBools)
   const smokingRates   = computeRates(smokingBools)
+
+  const sweetsStreak  = calculateSweetsStreak(sweetsHistory)
+  const sweetsRate30d = computeSweetsRate30d(sweetsHistory)
 
   const stepsGoal = profile.targetSteps ?? 10000
 
@@ -613,7 +657,16 @@ export async function LiveStatus() {
           labelNoData={t('metricNoData')}
         />
 
-        {/* Row D — Drink metrics */}
+        {/* Row D — Sweets + Drink metrics */}
+        <SweetsTile
+          streak={sweetsStreak.current}
+          longestStreak={sweetsStreak.longest}
+          rate30d={sweetsRate30d}
+          labelSweets={t('metricSweets')}
+          labelDays={t('streakDays')}
+          labelLongest={t('streakLongest')}
+          labelRate={t('rate30d')}
+        />
         <DrinkMetricTile
           label={t('metricWater')}
           avgMl={drinkAvg.waterMl}

--- a/src/lib/drinks.ts
+++ b/src/lib/drinks.ts
@@ -119,6 +119,28 @@ export async function getDrinkAnalytics(days: number | 'all'): Promise<DrinkAnal
   }
 }
 
+export async function getSweetsHistory(days = 90): Promise<(boolean | null)[]> {
+  const todayStart = zurichDayStart()
+  const since = new Date(todayStart.getTime() - days * 24 * 60 * 60 * 1000)
+
+  const rows = await prisma.sweetsLog.findMany({
+    where: { date: { gte: since } },
+    select: { date: true, consumed: true },
+    orderBy: { date: 'desc' },
+  })
+
+  const byDate = new Map(rows.map((r) => [r.date.toISOString().slice(0, 10), r.consumed]))
+
+  const result: (boolean | null)[] = []
+  for (let i = 0; i < days; i++) {
+    const d = new Date(todayStart.getTime() - i * 24 * 60 * 60 * 1000)
+    const key = d.toISOString().slice(0, 10)
+    result.push(byDate.get(key) ?? null)
+  }
+
+  return result
+}
+
 export async function getDrinkAvg7d(): Promise<DrinkAvg7d> {
   const todayStart = zurichDayStart()
   const sevenDaysAgo = new Date(todayStart.getTime() - 7 * 24 * 60 * 60 * 1000)

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -119,3 +119,37 @@ export async function getSmokingStreak(): Promise<StreakResult> {
   const entries = await getAllEntries()
   return calculateStreak(entries.map((e) => isSmokingFulfilled(e.habits.smoking)))
 }
+
+/**
+ * Streak für Süssigkeiten: zählt aufeinanderfolgende Tage mit sweetsConsumed === false.
+ * null-Werte werden übersprungen (Streak weder unterbrochen noch gezählt).
+ * true unterbricht den Streak.
+ */
+export function calculateSweetsStreak(values: (boolean | null)[]): StreakResult {
+  let current = 0
+  for (const v of values) {
+    if (v === false) current++
+    else if (v === true) break
+    // null → skip, Streak läuft weiter
+  }
+
+  let longest = 0
+  let run = 0
+  for (const v of values) {
+    if (v === false) {
+      run++
+      if (run > longest) longest = run
+    } else if (v === true) {
+      run = 0
+    }
+    // null → run bleibt
+  }
+
+  return { current, longest }
+}
+
+export function computeSweetsRate30d(values: (boolean | null)[]): number {
+  const tracked = values.slice(0, 30).filter((v) => v !== null) as boolean[]
+  if (tracked.length === 0) return 0
+  return Math.round(tracked.filter((v) => v === false).length / tracked.length * 100)
+}

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -30,6 +30,7 @@ export interface JournalEntry {
   habits: HabitsFrontmatter
   content: string
   excerpt?: string
+  sweetsConsumed?: boolean | null
 }
 
 export type JournalEntryMeta = Omit<JournalEntry, 'content'>
@@ -76,6 +77,7 @@ function toMeta(entry: PrismaJournalEntry): JournalEntryMeta {
       nutrition: NUTRITION_TO_VALUE[entry.nutrition],
       smoking: SMOKING_TO_VALUE[entry.smoking],
     },
+    sweetsConsumed: entry.sweetsConsumed,
   }
 }
 


### PR DESCRIPTION
## Summary

- New `SweetsLog` DB model (independent of journal entries, one row per day, upserted via quick-log)
- Quick-Log: three-state toggle — ✅ Keine / 🍫 Konsumiert / ↩ Reset
- Dashboard: `SweetsTile` added to Row D alongside the two drink tiles (all three at `lg:col-span-4`)
- `calculateSweetsStreak` + `computeSweetsRate30d` in `habits.ts` (null = skip, true = break, false = count)
- `getSweetsHistory(days)` in `drinks.ts` reads from `SweetsLog`
- Two migrations: `add_sweets_consumed` (field on JournalEntry, kept for editor use) + `add_sweets_log` (new standalone table)
- i18n: `metricSweets` key added in de/en/pt

## Test plan

- [ ] `/admin/quick-log`: buttons visible, Keine/Konsumiert toggle persists on reload, Reset clears
- [ ] Home dashboard: SweetsTile shows streak and 30-day rate in Row D (3-column layout)
- [ ] `migrate deploy` runs cleanly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)