### PR TITLE
fix: localize Open Graph and Twitter metadata for all locales

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,3 +267,9 @@ Keine aktiven Issues. Nächste Schritte aus dem Backlog priorisieren.
 ### BannerImage-Wrapper
 
 `src/components/ui/BannerImage.tsx` — next/image-Wrapper für alle Banner. Setzt automatisch `unoptimized={true}` für `.svg`-Dateien, da der Next.js Image-Optimizer SVGs mit 400 ablehnt. Alle neuen Komponenten die Bannerbilder rendern müssen `BannerImage` statt `next/image` direkt verwenden.
+
+### Locale-aware Metadata
+
+Jede `[locale]/.../page.tsx` muss `generateMetadata` exportieren und intern `buildLocaleMetadata({ locale, path, title, description, ... })` aus `src/lib/site.ts` aufrufen. Der Helper setzt `title` (mit `absolute`, damit das Root-Template nicht doppelt anhängt), `description`, `openGraph` (inkl. `locale`, `alternateLocale`, `siteName`, `images`), `twitter` und `alternates` (canonical + hreflang) konsistent für DE/EN/PT.
+
+Das Root-Layout (`src/app/layout.tsx`) trägt absichtlich keine sprachspezifischen `openGraph`/`twitter`-Felder mehr — würde es das tun, würden Pages, die nur einen Teil der Felder überschreiben, deutsche Strings für die fehlenden Felder leaken (genau das war der Bug bei `/en/about`, `/en/journal`, `/en/monthly`). Default-Title und Description im Root bleiben für nicht lokalisierte Routen (Admin) bestehen.

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -3,32 +3,21 @@ import React from 'react'
 import Link from 'next/link'
 import { getTranslations } from 'next-intl/server'
 import { Icon } from '@/components/ui/Icon'
-import { SITE_URL, buildAlternates, OG_LOCALE } from '@/lib/site'
+import { buildLocaleMetadata } from '@/lib/site'
 
 interface AboutPageProps {
   params: { locale: string }
 }
 
 export async function generateMetadata({ params }: AboutPageProps): Promise<Metadata> {
-  const t = await getTranslations('AboutPage')
-  const canonicalUrl = `${SITE_URL}/${params.locale}/about`
-  const ogLocale = OG_LOCALE[params.locale] ?? OG_LOCALE.de
+  const t = await getTranslations({ locale: params.locale, namespace: 'AboutPage' })
 
-  return {
+  return buildLocaleMetadata({
+    locale: params.locale,
+    path: '/about',
     title: t('metaTitle'),
     description: t('metaDescription'),
-    alternates: {
-      ...buildAlternates(`${SITE_URL}/de/about`, `${SITE_URL}/en/about`, `${SITE_URL}/pt/about`),
-      canonical: canonicalUrl,
-    },
-    openGraph: {
-      type: 'website',
-      url: canonicalUrl,
-      title: t('metaTitle'),
-      description: t('metaDescription'),
-      locale: ogLocale,
-    },
-  }
+  })
 }
 
 const PILLARS = [

--- a/src/app/[locale]/journal/[slug]/page.tsx
+++ b/src/app/[locale]/journal/[slug]/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 import { getEntryBySlugWithTranslation } from '@/lib/journal'
 import { JournalPost } from '@/components/journal/JournalPost'
-import { SITE_NAME, SITE_URL, stripHtml, buildAlternates, OG_LOCALE } from '@/lib/site'
+import { SITE_NAME, SITE_URL, stripHtml, buildLocaleMetadata } from '@/lib/site'
 
 interface JournalPostPageProps {
   params: {
@@ -26,38 +26,17 @@ export async function generateMetadata({ params }: JournalPostPageProps): Promis
     ? (translation!.excerpt || translation!.title)
     : (entry.excerpt ?? '')
   const description = excerptSource || stripHtml(entry.content).slice(0, 160).trimEnd() + '…'
-
-  const deUrl = `${SITE_URL}/de/journal/${entry.slug}`
-  const enUrl = `${SITE_URL}/en/journal/${entry.slug}`
-  const ptUrl = `${SITE_URL}/pt/journal/${entry.slug}`
-  const canonicalUrl = `${SITE_URL}/${params.locale}/journal/${entry.slug}`
-  const ogLocale = OG_LOCALE[params.locale] ?? OG_LOCALE.de
   const ogImage = entry.banner ? entry.banner : '/og-default.png'
 
-  return {
+  return buildLocaleMetadata({
+    locale: params.locale,
+    path: `/journal/${entry.slug}`,
     title,
     description,
-    alternates: {
-      ...buildAlternates(deUrl, enUrl, ptUrl),
-      canonical: canonicalUrl,
-    },
-    openGraph: {
-      type: 'article',
-      url: canonicalUrl,
-      siteName: SITE_NAME,
-      title,
-      description,
-      locale: ogLocale,
-      images: [{ url: ogImage, width: 1600, height: 700, alt: title }],
-      publishedTime: entry.date,
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: [ogImage],
-    },
-  }
+    type: 'article',
+    images: [{ url: ogImage, width: 1600, height: 700, alt: title }],
+    publishedTime: entry.date,
+  })
 }
 
 export default async function JournalPostPage({ params }: JournalPostPageProps) {

--- a/src/app/[locale]/journal/page.tsx
+++ b/src/app/[locale]/journal/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { getAllEntriesForLocale } from '@/lib/journal'
 import { JournalFeed } from '@/components/journal/JournalFeed'
 import { Icon } from '@/components/ui/Icon'
-import { SITE_NAME, SITE_URL, buildAlternates, OG_LOCALE } from '@/lib/site'
+import { SITE_NAME, buildLocaleMetadata } from '@/lib/site'
 
 interface JournalPageProps {
   params: { locale: string }
@@ -16,32 +16,12 @@ export async function generateMetadata({ params }: JournalPageProps): Promise<Me
   const { locale } = params
   const t = await getTranslations({ locale, namespace: 'JournalPage' })
 
-  const title = `${t('title')} — ${SITE_NAME}`
-  const description = t('description')
-  const canonicalUrl = `${SITE_URL}/${locale}/journal`
-  const ogLocale = OG_LOCALE[locale] ?? OG_LOCALE.de
-
-  return {
-    title,
-    description,
-    alternates: {
-      ...buildAlternates(
-        `${SITE_URL}/de/journal`,
-        `${SITE_URL}/en/journal`,
-        `${SITE_URL}/pt/journal`,
-      ),
-      canonical: canonicalUrl,
-    },
-    openGraph: {
-      type: 'website',
-      url: canonicalUrl,
-      siteName: SITE_NAME,
-      title,
-      description,
-      locale: ogLocale,
-      images: [{ url: '/og-default.png', width: 1200, height: 630, alt: SITE_NAME }],
-    },
-  }
+  return buildLocaleMetadata({
+    locale,
+    path: '/journal',
+    title: `${t('title')} — ${SITE_NAME}`,
+    description: t('description'),
+  })
 }
 
 export default async function JournalPage({ params }: JournalPageProps) {

--- a/src/app/[locale]/monthly/[month]/page.tsx
+++ b/src/app/[locale]/monthly/[month]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation'
 import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { getMonthSummary } from '@/lib/month-summary'
-import { SITE_NAME, SITE_URL } from '@/lib/site'
+import { buildLocaleMetadata, stripHtml } from '@/lib/site'
 import type { Metadata } from 'next'
 
 const MONTH_NAMES_DE = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
@@ -39,25 +39,19 @@ export async function generateMetadata({ params }: MonthSummaryPageProps): Promi
     ? `${monthName} ${parsed.year} — Resumo Mensal`
     : `${monthName} ${parsed.year} — Monats-Zusammenfassung`
 
-  const canonicalUrl = `${SITE_URL}/${params.locale}/monthly/${params.month}`
+  const localizedContent =
+    params.locale === 'en' && summary.contentEn ? summary.contentEn :
+    params.locale === 'pt' && summary.contentPt ? summary.contentPt :
+    summary.contentDe
+  const description = stripHtml(localizedContent).slice(0, 160).trimEnd() + '…'
 
-  return {
+  return buildLocaleMetadata({
+    locale: params.locale,
+    path: `/monthly/${params.month}`,
     title,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        de: `${SITE_URL}/de/monthly/${params.month}`,
-        en: `${SITE_URL}/en/monthly/${params.month}`,
-        pt: `${SITE_URL}/pt/monthly/${params.month}`,
-      },
-    },
-    openGraph: {
-      type: 'article',
-      url: canonicalUrl,
-      siteName: SITE_NAME,
-      title,
-    },
-  }
+    description,
+    type: 'article',
+  })
 }
 
 export default async function MonthSummaryPage({ params }: MonthSummaryPageProps) {

--- a/src/app/[locale]/monthly/page.tsx
+++ b/src/app/[locale]/monthly/page.tsx
@@ -1,8 +1,10 @@
 export const dynamic = 'force-dynamic'
 
+import type { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { getAllMonthSummaries } from '@/lib/month-summary'
+import { buildLocaleMetadata } from '@/lib/site'
 
 const MONTH_NAMES_DE = ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
 const MONTH_NAMES_EN = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
@@ -13,6 +15,16 @@ function monthSlug(year: number, month: number): string {
 
 interface MonthlyOverviewPageProps {
   params: { locale: string }
+}
+
+export async function generateMetadata({ params }: MonthlyOverviewPageProps): Promise<Metadata> {
+  const t = await getTranslations({ locale: params.locale, namespace: 'MonthlySummary' })
+  return buildLocaleMetadata({
+    locale: params.locale,
+    path: '/monthly',
+    title: t('overviewHeading'),
+    description: t('overviewDescription'),
+  })
 }
 
 export default async function MonthlyOverviewPage({ params }: MonthlyOverviewPageProps) {

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -16,9 +16,8 @@ import {
   SITE_NAME,
   SITE_DESCRIPTION,
   SITE_DESCRIPTION_EN,
-  SITE_URL,
-  buildAlternates,
-  OG_LOCALE,
+  SITE_DESCRIPTION_PT,
+  buildLocaleMetadata,
 } from '@/lib/site'
 import { getLatestMonthSummary } from '@/lib/month-summary'
 
@@ -26,41 +25,25 @@ interface HomePageProps {
   params: { locale: string }
 }
 
+const HOME_TITLES: Record<string, string> = {
+  de: `${SITE_NAME} — Tägliches Journal`,
+  en: `${SITE_NAME} — Daily Journal`,
+  pt: `${SITE_NAME} — Diário`,
+}
+
+const HOME_DESCRIPTIONS: Record<string, string> = {
+  de: SITE_DESCRIPTION,
+  en: SITE_DESCRIPTION_EN,
+  pt: SITE_DESCRIPTION_PT,
+}
+
 export async function generateMetadata({ params }: HomePageProps): Promise<Metadata> {
   const { locale } = params
-  const isEn = locale === 'en'
-
-  const title = isEn
-    ? `${SITE_NAME} — Daily Journal`
-    : `${SITE_NAME} — Tägliches Journal`
-  const description = isEn ? SITE_DESCRIPTION_EN : SITE_DESCRIPTION
-  const canonicalUrl = `${SITE_URL}/${locale}`
-  const ogLocale = OG_LOCALE[locale] ?? OG_LOCALE.de
-
-  return {
-    title,
-    description,
-    alternates: {
-      ...buildAlternates(`${SITE_URL}/de`, `${SITE_URL}/en`, `${SITE_URL}/pt`),
-      canonical: canonicalUrl,
-    },
-    openGraph: {
-      type: 'website',
-      url: canonicalUrl,
-      siteName: SITE_NAME,
-      title,
-      description,
-      locale: ogLocale,
-      alternateLocale: [isEn ? OG_LOCALE.de : OG_LOCALE.en],
-      images: [{ url: '/og-default.png', width: 1200, height: 630, alt: SITE_NAME }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: ['/og-default.png'],
-    },
-  }
+  return buildLocaleMetadata({
+    locale,
+    title: HOME_TITLES[locale] ?? HOME_TITLES.de,
+    description: HOME_DESCRIPTIONS[locale] ?? HOME_DESCRIPTIONS.de,
+  })
 }
 
 const JOURNAL_HOME_COUNT = 3

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { headers } from 'next/headers'
 import '@/styles/globals.css'
 import { AuthSessionProvider } from '@/components/providers/SessionProvider'
 import { ThemeProvider } from '@/components/providers/ThemeProvider'
-import { SITE_NAME, SITE_DESCRIPTION, SITE_URL } from '@/lib/site'
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/site'
 
 const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
@@ -21,6 +21,11 @@ const manrope = Manrope({
   display: 'swap',
 })
 
+// Locale-routed pages set their own title/description/openGraph/twitter via
+// `buildLocaleMetadata` (lib/site.ts). The root layout only carries
+// language-neutral defaults so a page that forgets to set them doesn't leak
+// the wrong language into a social card. The `default` title is the fallback
+// for non-localized routes (admin) and is intentionally German.
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
@@ -28,26 +33,12 @@ export const metadata: Metadata = {
     template: `%s — ${SITE_NAME}`,
   },
   description: SITE_DESCRIPTION,
-  openGraph: {
-    type: 'website',
-    siteName: SITE_NAME,
-    title: `${SITE_NAME} — Tägliches Journal`,
-    description: SITE_DESCRIPTION,
-    images: [{ url: '/og-default.png', width: 1200, height: 630, alt: SITE_NAME }],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: `${SITE_NAME} — Tägliches Journal`,
-    description: SITE_DESCRIPTION,
-    images: ['/og-default.png'],
-  },
   icons: {
     icon: '/icon.svg',
     apple: '/apple-icon.svg',
   },
   robots: { index: true, follow: true },
   alternates: {
-    canonical: SITE_URL,
     types: { 'application/rss+xml': `${SITE_URL}/feed.xml` },
   },
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next'
+
 export const SITE_NAME = 'Project 365'
 
 export const SITE_DESCRIPTION =
@@ -5,6 +7,9 @@ export const SITE_DESCRIPTION =
 
 export const SITE_DESCRIPTION_EN =
   'A public 365-day project: Daily entries about movement, nutrition and the journey to quit smoking — with real numbers, good days and bad.'
+
+export const SITE_DESCRIPTION_PT =
+  'Um projeto público de 365 dias: entradas diárias sobre movimento, alimentação e o caminho para parar de fumar — com números reais, bons e maus dias.'
 
 // Trailing slash deliberately stripped
 export const SITE_URL = (process.env.NEXTAUTH_URL ?? 'http://localhost:3000').replace(/\/$/, '')
@@ -33,4 +38,77 @@ export const OG_LOCALE: Record<string, string> = {
   de: 'de_CH',
   en: 'en_US',
   pt: 'pt_BR',
+}
+
+export type OgImage = {
+  url: string
+  width?: number
+  height?: number
+  alt?: string
+}
+
+const DEFAULT_OG_IMAGE: OgImage = {
+  url: '/og-default.png',
+  width: 1200,
+  height: 630,
+  alt: SITE_NAME,
+}
+
+/**
+ * Single source of truth for locale-aware page metadata. Produces a Metadata
+ * block with title, description, openGraph, twitter, and alternates all set
+ * consistently. Every locale-routed page should call this so social cards and
+ * hreflang stay in sync across DE/EN/PT.
+ *
+ * `path` is the locale-agnostic route (e.g. '', '/journal', '/journal/some-slug').
+ * Passing the leading locale segment is the caller's bug — don't.
+ */
+export function buildLocaleMetadata(opts: {
+  locale: string
+  /** Route path WITHOUT the leading `/{locale}` segment. Use '' for the home page. */
+  path?: string
+  title: string
+  description: string
+  type?: 'website' | 'article'
+  images?: OgImage[]
+  publishedTime?: string
+}): Metadata {
+  const { locale, path = '', title, description, type = 'website', images, publishedTime } = opts
+  const safePath = path === '' || path.startsWith('/') ? path : `/${path}`
+  const canonicalUrl = `${SITE_URL}/${locale}${safePath}`
+  const ogLocale = OG_LOCALE[locale] ?? OG_LOCALE.de
+  const alternateLocale = Object.entries(OG_LOCALE)
+    .filter(([code]) => code !== locale)
+    .map(([, og]) => og)
+  const ogImages = images ?? [DEFAULT_OG_IMAGE]
+
+  return {
+    title: { absolute: title },
+    description,
+    alternates: {
+      ...buildAlternates(
+        `${SITE_URL}/de${safePath}`,
+        `${SITE_URL}/en${safePath}`,
+        `${SITE_URL}/pt${safePath}`,
+      ),
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      type,
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      title,
+      description,
+      locale: ogLocale,
+      alternateLocale,
+      images: ogImages,
+      ...(publishedTime ? { publishedTime } : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ogImages.map((img) => img.url),
+    },
+  }
 }


### PR DESCRIPTION
## Summary
- Centralize locale-aware metadata in `buildLocaleMetadata` (`src/lib/site.ts`) — one call now sets `title`/`description`/`openGraph`/`twitter`/`alternates` consistently for DE/EN/PT.
- Strip language-specific `openGraph`/`twitter` content from `app/layout.tsx` so a page that forgets a field can't leak German strings into a non-German social card (root cause of the bug).
- Refactor every `[locale]/.../page.tsx` to use the helper; add the missing `generateMetadata` to `[locale]/monthly/page.tsx`.
- Use `title.absolute` in the helper so the root `template: '%s — Project 365'` no longer double-appends the site name (was producing `Project 365 — Daily Journal — Project 365`).

## Bug
Sharing `https://project365.dom42.ch/en` (or `/en/about`, `/en/journal`, `/en/monthly`) on Bluesky/Twitter/etc. showed the German description, because:
- `og:` was correctly overridden per locale on most pages.
- `twitter:` was rarely set on locale pages, so it fell back to the German `twitter:title` / `twitter:description` defined in the root layout.
- `/en/about` was additionally missing `og:image`, `og:site_name`, `og:locale:alternate`.
- `/en/monthly` had no `generateMetadata` at all.

## Test plan
- [x] `pnpm type-check`, `pnpm lint`, `pnpm test` (92 passing), `pnpm build` all green.
- [x] Locally with `pnpm dev` + `curl`: `/de`, `/en`, `/pt` and the `/about`, `/journal`, `/monthly` variants all return the correct locale-specific `og:title`, `og:description`, `og:locale`, multiple `og:locale:alternate`, `twitter:title`, `twitter:description`, plus a clean `<title>` without the duplicated suffix.
- [ ] After deploy: re-share `/en` on Bluesky. The previously-cached preview will need a fresh crawl — use the Bluesky card validator, or share with a `?v=2` query string the first time, since Bluesky caches by URL.
- [ ] After deploy: spot-check one URL with `curl -A "facebookexternalhit/1.1" https://project365.dom42.ch/en | grep -E 'og:|twitter:'` to confirm `og:locale=en_US` and English `og:description`.

## Out of scope
- Locale switcher UI, content rewrites, OG-image localization (separate backlog item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)