### PR TITLE
fix: use meal score for nutrition fulfillment, show score badge

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -199,6 +199,7 @@
       "steps_trained": "10k+ & Training"
     },
     "nutrition": {
+      "scoreTitle": "Ernährungs-Score",
       "none": "Keine ges. Mahlzeit",
       "one_meal": "1 ges. Mahlzeit",
       "two_meals": "2 ges. Mahlzeiten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -199,6 +199,7 @@
       "steps_trained": "10k+ & workout"
     },
     "nutrition": {
+      "scoreTitle": "Nutrition score",
       "none": "No healthy meal",
       "one_meal": "1 healthy meal",
       "two_meals": "2 healthy meals",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -196,6 +196,7 @@
       "steps_trained": "10k+ e treino"
     },
     "nutrition": {
+      "scoreTitle": "Pontuação alimentar",
       "none": "Sem refeição saudável",
       "one_meal": "1 refeição saudável",
       "two_meals": "2 refeições saudáveis",

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
-import type { MealLogData } from '@/lib/meal-log'
+import { scoreToNutritionLevel, type MealLogData } from '@/lib/meal-log'
 import { clsx } from 'clsx'
 import { TiptapEditor } from './TiptapEditor'
 import { HabitsPicker } from './HabitsPicker'
@@ -50,7 +50,14 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
   const [content, setContent] = useState(initial?.content ?? '')
   const [excerpt, setExcerpt] = useState(initial?.excerpt ?? '')
   const [movement, setMovement] = useState<MovementLevel>(initial?.movement ?? 'STEPS_ONLY')
-  const [nutrition, setNutrition] = useState<NutritionLevel>(initial?.nutrition ?? 'TWO_MEALS')
+  // If the meal log has a score (saved before the entry was created), derive
+  // the initial enum value from it instead of falling back to the TWO_MEALS
+  // default — otherwise the user has to manually fix the picker every time.
+  // For existing entries we always trust the persisted enum value.
+  const defaultNutrition: NutritionLevel =
+    initial?.nutrition ??
+    (mealLog?.score != null ? scoreToNutritionLevel(mealLog.score) : 'TWO_MEALS')
+  const [nutrition, setNutrition] = useState<NutritionLevel>(defaultNutrition)
   const [smoking, setSmoking] = useState<SmokingStatus>(initial?.smoking ?? 'SMOKE_FREE')
   const [bannerUrl, setBannerUrl] = useState<string | undefined>(initial?.bannerUrl)
   const [tags, setTags] = useState<string>(initial?.tags?.join(', ') ?? '')
@@ -139,6 +146,7 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
           smoking={smoking}
           tags={tags}
           bannerUrl={bannerUrl}
+          mealScore={mealLog?.score}
         />
       ) : (
     <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/components/admin/EntryPreview.tsx
+++ b/src/components/admin/EntryPreview.tsx
@@ -29,8 +29,12 @@ const SMOKING_LABELS: Record<SmokingStatus, string> = {
 function isMovementOk(m: MovementLevel) {
   return m === 'STEPS_ONLY' || m === 'TRAINED_ONLY' || m === 'STEPS_TRAINED'
 }
-function isNutritionOk(n: NutritionLevel) {
-  return n === 'TWO_MEALS' || n === 'THREE_MEALS'
+/** Mirrors `lib/habits.ts:isNutritionFulfilled` on the UPPERCASE enum side. */
+function isNutritionOk(n: NutritionLevel, mealScore?: number | null) {
+  if (mealScore !== null && mealScore !== undefined) {
+    return mealScore >= 8.0
+  }
+  return n === 'THREE_MEALS'
 }
 function isSmokingOk(s: SmokingStatus) {
   return s === 'NICOTINE_REPLACEMENT' || s === 'SMOKE_FREE'
@@ -72,6 +76,9 @@ export interface EntryPreviewProps {
   smoking: SmokingStatus
   tags: string
   bannerUrl?: string
+  /** When a meal-log score is present, the nutrition badge shows the score (e.g. `9.6 / 10`)
+   * and fulfillment is computed from the score. */
+  mealScore?: number | null
 }
 
 // =============================================
@@ -87,7 +94,12 @@ export function EntryPreview({
   smoking,
   tags,
   bannerUrl,
+  mealScore,
 }: EntryPreviewProps) {
+  const hasMealScore = mealScore !== null && mealScore !== undefined
+  const nutritionLabel = hasMealScore
+    ? `${mealScore.toFixed(1)} / 10`
+    : NUTRITION_LABELS[nutrition]
   const dayNumber = date ? getDayNumber(date) : 1
 
   const formattedDate = date
@@ -156,8 +168,8 @@ export function EntryPreview({
               colorClass="bg-movement-100 bg-movement-600/20 text-movement-700 text-movement-400"
             />
             <HabitBadge
-              label={NUTRITION_LABELS[nutrition]}
-              fulfilled={isNutritionOk(nutrition)}
+              label={nutritionLabel}
+              fulfilled={isNutritionOk(nutrition, mealScore)}
               colorClass="bg-nutrition-100 bg-nutrition-600/20 text-nutrition-700 text-nutrition-400"
             />
             <HabitBadge

--- a/src/components/admin/HabitsPicker.tsx
+++ b/src/components/admin/HabitsPicker.tsx
@@ -11,12 +11,20 @@ import {
 
 // =============================================
 // Fulfillment-Status aus den Prisma-Enum-Werten
+// (Spiegelt lib/habits.ts auf der UPPERCASE-Enum-Seite. `isNutritionFulfilled`
+//  ist score-aware: Wenn ein Meal-Score vorliegt, gilt Score ≥ 8.0; sonst
+//  zählt nur THREE_MEALS — analog zur kanonischen Definition.)
 // =============================================
+
+const NUTRITION_SCORE_THRESHOLD = 8.0
 
 function isMovementFulfilled(m: MovementLevel): boolean {
   return m === 'STEPS_ONLY' || m === 'TRAINED_ONLY' || m === 'STEPS_TRAINED'
 }
-function isNutritionFulfilled(n: NutritionLevel): boolean {
+function isNutritionFulfilled(n: NutritionLevel, mealScore?: number | null): boolean {
+  if (mealScore !== null && mealScore !== undefined) {
+    return mealScore >= NUTRITION_SCORE_THRESHOLD
+  }
   return n === 'THREE_MEALS'
 }
 function isSmokingFulfilled(s: SmokingStatus): boolean {
@@ -82,12 +90,15 @@ export function HabitsPicker({
   mealScore,
 }: HabitsPickerProps) {
   const movementLabel = MOVEMENT_OPTIONS.find((o) => o.value === movement)?.label ?? movement
-  const nutritionLabel = NUTRITION_OPTIONS.find((o) => o.value === nutrition)?.label ?? nutrition
+  const hasMealScore = mealScore !== null && mealScore !== undefined
+  const nutritionLabel = hasMealScore
+    ? `${mealScore.toFixed(1)} / 10`
+    : NUTRITION_OPTIONS.find((o) => o.value === nutrition)?.label ?? nutrition
   const smokingLabel = SMOKING_OPTIONS.find((o) => o.value === smoking)?.label ?? smoking
 
   const fulfilledCount = [
     isMovementFulfilled(movement),
-    isNutritionFulfilled(nutrition),
+    isNutritionFulfilled(nutrition, mealScore),
     isSmokingFulfilled(smoking),
   ].filter(Boolean).length
 
@@ -131,8 +142,15 @@ export function HabitsPicker({
                   {mealScore.toFixed(1)}<span className="text-xs font-normal text-on-surface-variant ml-0.5">/10</span>
                 </span>
               )}
-              <span className="text-sm font-medium text-on-surface">
-                {NUTRITION_OPTIONS.find((o) => o.value === nutrition)?.label ?? nutrition}
+              <span
+                className={clsx(
+                  'text-xs font-label font-bold tracking-widest uppercase',
+                  isNutritionFulfilled(nutrition, mealScore)
+                    ? 'text-nutrition-300'
+                    : 'text-on-surface-variant',
+                )}
+              >
+                {isNutritionFulfilled(nutrition, mealScore) ? 'Ziel erreicht' : 'Ziel verfehlt'}
               </span>
             </div>
           </div>
@@ -163,7 +181,7 @@ export function HabitsPicker({
           />
           <PreviewBadge
             label={nutritionLabel}
-            fulfilled={isNutritionFulfilled(nutrition)}
+            fulfilled={isNutritionFulfilled(nutrition, mealScore)}
             colorClass="bg-nutrition-100 text-nutrition-700"
           />
           <PreviewBadge

--- a/src/components/habits/HabitsDashboard.tsx
+++ b/src/components/habits/HabitsDashboard.tsx
@@ -39,21 +39,24 @@ export async function HabitsDashboard() {
     date,
     level: entryMap.has(date) ? getMovementLevel(entryMap.get(date)!.habits.movement) : -1,
   }))
-  const nutritionDays = allDates.map((date) => ({
-    date,
-    level: entryMap.has(date) ? getNutritionLevel(entryMap.get(date)!.habits.nutrition) : -1,
-  }))
+  const nutritionDays = allDates.map((date) => {
+    const e = entryMap.get(date)
+    return {
+      date,
+      level: e ? getNutritionLevel(e.habits.nutrition, e.mealScore) : -1,
+    }
+  })
   const smokingDays = allDates.map((date) => ({
     date,
     level: entryMap.has(date) ? getSmokingLevel(entryMap.get(date)!.habits.smoking) : -1,
   }))
 
   const movementStreak = calculateStreak(entries.map((e) => isMovementFulfilled(e.habits.movement)))
-  const nutritionStreak = calculateStreak(entries.map((e) => isNutritionFulfilled(e.habits.nutrition)))
+  const nutritionStreak = calculateStreak(entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)))
   const smokingStreak = calculateStreak(entries.map((e) => isSmokingFulfilled(e.habits.smoking)))
 
   const movementFulfilled = entries.filter((e) => isMovementFulfilled(e.habits.movement)).length
-  const nutritionFulfilled = entries.filter((e) => isNutritionFulfilled(e.habits.nutrition)).length
+  const nutritionFulfilled = entries.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)).length
   const smokingFulfilled = entries.filter((e) => isSmokingFulfilled(e.habits.smoking)).length
 
   return (

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -664,7 +664,7 @@ export async function LiveStatus() {
   ])
 
   const movementBools = entries.map((e) => isMovementFulfilled(e.habits.movement))
-  const nutritionBools = entries.map((e) => isNutritionFulfilled(e.habits.nutrition))
+  const nutritionBools = entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore))
   const smokingBools   = entries.map((e) => isSmokingFulfilled(e.habits.smoking))
 
   const movementStreak = calculateStreak(movementBools)

--- a/src/components/journal/HabitBadges.tsx
+++ b/src/components/journal/HabitBadges.tsx
@@ -5,6 +5,10 @@ import { Icon } from '@/components/ui/Icon'
 
 interface HabitBadgesProps {
   habits: HabitsFrontmatter
+  /** Nutrition score from the day's MealLog (0–10), if logged. When present,
+   * the nutrition badge shows the score (e.g. `9.6 / 10`) instead of the
+   * meal-count label, and fulfillment is computed from the score. */
+  mealScore?: number | null
 }
 
 interface BadgeProps {
@@ -13,15 +17,17 @@ interface BadgeProps {
   colorClass: string
   dimClass: string
   icon: string
+  /** Optional accessible label override — used when `label` is purely numeric. */
+  title?: string
 }
 
-function HabitBadge({ label, fulfilled, colorClass, dimClass, icon }: BadgeProps) {
+function HabitBadge({ label, fulfilled, colorClass, dimClass, icon, title }: BadgeProps) {
   return (
     <span
       className={`inline-flex items-center gap-1.5 text-xs font-label font-bold tracking-widest uppercase px-2.5 py-1 rounded-full border ${
         fulfilled ? colorClass : dimClass
       }`}
-      title={label}
+      title={title ?? label}
     >
       <Icon name={icon} size={14} fill={fulfilled} />
       {label}
@@ -29,8 +35,15 @@ function HabitBadge({ label, fulfilled, colorClass, dimClass, icon }: BadgeProps
   )
 }
 
-export function HabitBadges({ habits }: HabitBadgesProps) {
+export function HabitBadges({ habits, mealScore }: HabitBadgesProps) {
   const t = useTranslations('HabitBadges')
+  const hasScore = mealScore !== null && mealScore !== undefined
+  const nutritionLabel = hasScore
+    ? `${mealScore.toFixed(1)} / 10`
+    : t(`nutrition.${habits.nutrition}` as 'nutrition.none')
+  const nutritionTitle = hasScore
+    ? `${t('nutrition.scoreTitle' as 'nutrition.scoreTitle')}: ${mealScore.toFixed(1)} / 10`
+    : nutritionLabel
 
   return (
     <div className="flex flex-wrap gap-2">
@@ -42,8 +55,9 @@ export function HabitBadges({ habits }: HabitBadgesProps) {
         dimClass="bg-surface-container border-outline-variant/20 text-on-surface-variant"
       />
       <HabitBadge
-        label={t(`nutrition.${habits.nutrition}` as 'nutrition.none')}
-        fulfilled={isNutritionFulfilled(habits.nutrition)}
+        label={nutritionLabel}
+        title={nutritionTitle}
+        fulfilled={isNutritionFulfilled(habits.nutrition, mealScore)}
         icon="restaurant"
         colorClass="bg-nutrition-600/20 text-nutrition-400 border-nutrition-600/30"
         dimClass="bg-surface-container border-outline-variant/20 text-on-surface-variant"

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -20,7 +20,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
 
   const excerpt = entry.excerpt ?? ''
   const dayNumber = getDayNumber(entry.date, startDate)
-  const perfect = isPerfectDay(entry.habits)
+  const perfect = isPerfectDay(entry.habits, entry.mealScore)
 
   function formatDate(dateStr: string): string {
     return new Date(dateStr).toLocaleDateString(locale, {
@@ -86,7 +86,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
           )}
 
           <div className="flex items-center justify-between gap-4 pt-2 border-t border-outline-variant/10">
-            <HabitBadges habits={entry.habits} />
+            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} />
             <span className="inline-flex items-center gap-1 text-xs font-label font-bold tracking-widest uppercase text-primary shrink-0 group-hover:gap-1.5 transition-all duration-150">
               {t('readMore')}
               <Icon name="arrow_forward" size={12} />

--- a/src/components/journal/JournalCardCompact.tsx
+++ b/src/components/journal/JournalCardCompact.tsx
@@ -21,7 +21,7 @@ export async function JournalCardCompact({ entry }: JournalCardCompactProps) {
   const dayNumber = getDayNumber(entry.date, startDate)
 
   const movementOk = isMovementFulfilled(entry.habits.movement)
-  const nutritionOk = isNutritionFulfilled(entry.habits.nutrition)
+  const nutritionOk = isNutritionFulfilled(entry.habits.nutrition, entry.mealScore)
   const smokingOk = isSmokingFulfilled(entry.habits.smoking)
   const allOk = movementOk && nutritionOk && smokingOk
 

--- a/src/components/journal/JournalCardHome.tsx
+++ b/src/components/journal/JournalCardHome.tsx
@@ -17,7 +17,7 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
   ])
 
   const dayNumber = getDayNumber(entry.date, startDate)
-  const perfect = isPerfectDay(entry.habits)
+  const perfect = isPerfectDay(entry.habits, entry.mealScore)
 
   const formattedDate = new Date(entry.date).toLocaleDateString(locale, {
     day: 'numeric',

--- a/src/components/journal/JournalPost.tsx
+++ b/src/components/journal/JournalPost.tsx
@@ -85,7 +85,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
       )}
 
       <div className="flex flex-col gap-3 mb-8">
-        <HabitBadges habits={entry.habits} />
+        <HabitBadges habits={entry.habits} mealScore={entry.mealScore} />
         {entry.tags && entry.tags.length > 0 && (
           <ul className="flex flex-wrap gap-2">
             {entry.tags.map((tag) => (

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -30,17 +30,44 @@ describe('isMovementFulfilled', () => {
 })
 
 describe('isNutritionFulfilled', () => {
-  it('returns false for none', () => {
+  // Without meal score → enum fallback (only three_meals counts).
+  it('returns false for none (no score)', () => {
     expect(isNutritionFulfilled('none')).toBe(false)
   })
-  it('returns false for one_meal', () => {
+  it('returns false for one_meal (no score)', () => {
     expect(isNutritionFulfilled('one_meal')).toBe(false)
   })
-  it('returns false for two_meals', () => {
+  it('returns false for two_meals (no score)', () => {
     expect(isNutritionFulfilled('two_meals')).toBe(false)
   })
-  it('returns true for three_meals', () => {
+  it('returns true for three_meals (no score)', () => {
     expect(isNutritionFulfilled('three_meals')).toBe(true)
+  })
+  it('treats null mealScore as "no score" (enum fallback)', () => {
+    expect(isNutritionFulfilled('three_meals', null)).toBe(true)
+    expect(isNutritionFulfilled('two_meals', null)).toBe(false)
+  })
+
+  // With meal score → score takes priority over the enum.
+  it('returns true when mealScore ≥ 8.0 (boundary)', () => {
+    expect(isNutritionFulfilled('none', 8.0)).toBe(true)
+  })
+  it('returns true when mealScore is well above threshold', () => {
+    expect(isNutritionFulfilled('none', 9.6)).toBe(true)
+  })
+  it('returns false when mealScore is just below threshold', () => {
+    expect(isNutritionFulfilled('three_meals', 7.9)).toBe(false)
+  })
+  it('returns false when mealScore is 0', () => {
+    expect(isNutritionFulfilled('three_meals', 0)).toBe(false)
+  })
+  it('score overrides enum (high enum, low score)', () => {
+    // Stale enum should not save a low-score day.
+    expect(isNutritionFulfilled('three_meals', 5.5)).toBe(false)
+  })
+  it('score overrides enum (low enum, high score)', () => {
+    // Stale enum should not block a high-score day.
+    expect(isNutritionFulfilled('two_meals', 9.0)).toBe(true)
   })
 })
 

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -2,17 +2,31 @@ import { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
 import { getAllEntries, type MovementValue, type NutritionValue, type SmokingValue } from './journal'
 
 // =============================================
-// Streak-Definitionen (Issue #87):
+// Streak-Definitionen (Issue #87, score-aware):
 //   Bewegung  ≥ STEPS_ONLY oder TRAINED_ONLY → steps_only | trained_only | steps_trained
-//   Ernährung = THREE_MEALS                  → three_meals
+//   Ernährung   mealScore ≥ 8.0  (sonst Enum-Fallback: three_meals)
 //   Rauchstopp ≠ SMOKED                      → nicotine_replacement | smoke_free
 // =============================================
+
+/** Score threshold for "nutrition goal met" — kept in sync with `scoreToNutritionLevel` (THREE_MEALS). */
+export const NUTRITION_SCORE_THRESHOLD = 8.0
 
 export function isMovementFulfilled(movement: MovementValue): boolean {
   return movement === 'steps_only' || movement === 'trained_only' || movement === 'steps_trained'
 }
 
-export function isNutritionFulfilled(nutrition: NutritionValue): boolean {
+/**
+ * Nutrition goal met for the day. When a meal-log score is present (preferred,
+ * authoritative), score ≥ 8.0 = fulfilled. Without a score we fall back to the
+ * enum threshold so historical entries that pre-date the meal-log still count.
+ */
+export function isNutritionFulfilled(
+  nutrition: NutritionValue,
+  mealScore?: number | null,
+): boolean {
+  if (mealScore !== null && mealScore !== undefined) {
+    return mealScore >= NUTRITION_SCORE_THRESHOLD
+  }
   return nutrition === 'three_meals'
 }
 
@@ -92,7 +106,13 @@ export function getMovementLevel(m: MovementValue): number {
   return 0
 }
 
-export function getNutritionLevel(n: NutritionValue): number {
+export function getNutritionLevel(n: NutritionValue, mealScore?: number | null): number {
+  if (mealScore !== null && mealScore !== undefined) {
+    if (mealScore >= 8.0) return 3
+    if (mealScore >= 5.0) return 2
+    if (mealScore >= 2.0) return 1
+    return 0
+  }
   if (n === 'three_meals') return 3
   if (n === 'two_meals') return 2
   if (n === 'one_meal') return 1
@@ -112,7 +132,7 @@ export async function getMovementStreak(): Promise<StreakResult> {
 
 export async function getNutritionStreak(): Promise<StreakResult> {
   const entries = await getAllEntries()
-  return calculateStreak(entries.map((e) => isNutritionFulfilled(e.habits.nutrition)))
+  return calculateStreak(entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)))
 }
 
 export async function getSmokingStreak(): Promise<StreakResult> {

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -31,6 +31,14 @@ export interface JournalEntry {
   content: string
   excerpt?: string
   sweetsConsumed?: boolean | null
+  /**
+   * Nutrition score (0–10) from the day's MealLog, when one exists. The enum
+   * `habits.nutrition` mirrors this via `scoreToNutritionLevel` (auto-synced
+   * by `saveMealLogAction`), but the raw score is the canonical fulfillment
+   * input — score ≥ 8.0 counts as the nutrition goal met. Falls back to the
+   * enum threshold (`three_meals`) only for entries without a meal log.
+   */
+  mealScore?: number | null
 }
 
 export type JournalEntryMeta = Omit<JournalEntry, 'content'>
@@ -63,9 +71,12 @@ function toDateString(date: Date): string {
   return date.toISOString().slice(0, 10)
 }
 
-export function isPerfectDay(habits: HabitsFrontmatter): boolean {
+export function isPerfectDay(habits: HabitsFrontmatter, mealScore?: number | null): boolean {
   const movementGood = habits.movement === 'steps_only' || habits.movement === 'trained_only' || habits.movement === 'steps_trained'
-  const nutritionGood = habits.nutrition === 'three_meals'
+  const nutritionGood =
+    mealScore !== null && mealScore !== undefined
+      ? mealScore >= 8.0
+      : habits.nutrition === 'three_meals'
   const smokingGood = habits.smoking === 'nicotine_replacement' || habits.smoking === 'smoke_free'
   return movementGood && nutritionGood && smokingGood
 }
@@ -99,12 +110,34 @@ function toFull(entry: PrismaJournalEntry): JournalEntry {
 // DB-Queries (ersetzen Filesystem-Reads)
 // =============================================
 
+/**
+ * Fetch meal-log scores for a list of entry dates and return a `date → score`
+ * lookup map (date string `YYYY-MM-DD`). Entries without a logged meal map
+ * to nothing — callers should treat absence as "no score, fall back to enum".
+ */
+async function getMealScoreMapForDates(dates: Date[]): Promise<Map<string, number>> {
+  if (dates.length === 0) return new Map()
+  const rows = await prisma.mealLog.findMany({
+    where: { date: { in: dates }, score: { not: null } },
+    select: { date: true, score: true },
+  })
+  return new Map(
+    rows
+      .filter((r): r is { date: Date; score: number } => r.score !== null)
+      .map((r) => [toDateString(r.date), r.score]),
+  )
+}
+
 export async function getAllEntries(): Promise<JournalEntryMeta[]> {
   const entries = await prisma.journalEntry.findMany({
     where: { published: true },
     orderBy: { date: 'desc' },
   })
-  return entries.map(toMeta)
+  const scores = await getMealScoreMapForDates(entries.map((e) => e.date))
+  return entries.map((entry) => ({
+    ...toMeta(entry),
+    mealScore: scores.get(toDateString(entry.date)) ?? null,
+  }))
 }
 
 export async function getAllEntriesForLocale(locale: string): Promise<JournalEntryMeta[]> {
@@ -115,9 +148,13 @@ export async function getAllEntriesForLocale(locale: string): Promise<JournalEnt
     orderBy: { date: 'desc' },
     include: { translations: { where: { locale } } },
   })
+  const scores = await getMealScoreMapForDates(entries.map((e) => e.date))
 
   return entries.map((entry) => {
-    const meta = toMeta(entry)
+    const meta: JournalEntryMeta = {
+      ...toMeta(entry),
+      mealScore: scores.get(toDateString(entry.date)) ?? null,
+    }
     const translation = entry.translations[0] ?? null
     if (translation) {
       meta.title = translation.title
@@ -130,7 +167,8 @@ export async function getAllEntriesForLocale(locale: string): Promise<JournalEnt
 export async function getEntryBySlug(slug: string): Promise<JournalEntry | null> {
   const entry = await prisma.journalEntry.findUnique({ where: { slug } })
   if (!entry || !entry.published) return null
-  return toFull(entry)
+  const scores = await getMealScoreMapForDates([entry.date])
+  return { ...toFull(entry), mealScore: scores.get(toDateString(entry.date)) ?? null }
 }
 
 export async function getEntryBySlugWithTranslation(
@@ -143,7 +181,11 @@ export async function getEntryBySlugWithTranslation(
   })
   if (!row || !row.published) return null
 
-  const entry = toFull(row)
+  const scores = await getMealScoreMapForDates([row.date])
+  const entry: JournalEntry = {
+    ...toFull(row),
+    mealScore: scores.get(toDateString(row.date)) ?? null,
+  }
   const t = row.translations[0] ?? null
   const translation = t
     ? { title: t.title, content: t.content, excerpt: t.excerpt ?? '' }


### PR DESCRIPTION
## Bug
On the home Live-Status grid the **Ernährung** streak showed `0 Tage` even though the last few days had meal scores well above 8.0. On the public journal cards the badge read `2 GES. MAHLZEITEN` (gray, not fulfilled) for an entry whose meal-log score was `9.6 / 10`.

Two root causes:
1. **Stale enum + strict predicate.** Nutrition fulfillment was computed from the persisted `NutritionLevel` enum only (`three_meals` ⇒ ✅). When the meal log was saved before the entry was created, `EntryForm` initialized with the `TWO_MEALS` default, so the entry got persisted as `TWO_MEALS` despite the high score, and every fulfillment check downstream returned `false`.
2. **Three competing predicate definitions.** `lib/habits.ts` (`three_meals` only), admin `HabitsPicker` (`THREE_MEALS` only), admin `EntryPreview` (`TWO_MEALS` or `THREE_MEALS`) — none of them score-aware.

## Fix
Centralize on a single score-aware predicate in `lib/habits.ts`:
```ts
isNutritionFulfilled(nutrition, mealScore?) =
  mealScore != null ? mealScore >= 8.0 : nutrition === 'three_meals'
```
The score is authoritative when present (mirrors `scoreToNutritionLevel`), the enum threshold is the fallback so historical entries without a meal log still count. Same treatment for `getNutritionLevel` (heat-map) and `isPerfectDay`.

`JournalEntryMeta` now carries `mealScore?: number | null`, fetched in one batch DB lookup per query (`getMealScoreMapForDates`) joined by date. Threaded through every consumer: `HabitsDashboard`, `LiveStatus`, `JournalCard`, `JournalCardCompact`, `JournalCardHome`, `JournalPost`, `HabitBadges`.

## UX changes
- **Public card badge** `2 GES. MAHLZEITEN` → `9.6 / 10` (only when a meal log exists; falls back to the meal-count label otherwise). Tooltip says "Ernährungs-Score / Nutrition score / Pontuação alimentar".
- **Admin live preview & picker preview** show the same score badge.
- **Admin locked picker card** subtitle changes from `2 Mahlzeiten` to `Ziel erreicht` / `Ziel verfehlt` (the score is already shown big above).

## Adjacent bug also fixed
`EntryForm` defaulted `nutrition` to `TWO_MEALS` even when the meal log was already saved with a score that should map to `THREE_MEALS`. Now it derives the initial value from `scoreToNutritionLevel(mealLog.score)` when no `initial` is present.

## Test plan
- [x] `pnpm type-check`, `pnpm lint`, `pnpm build` green.
- [x] `pnpm test` — 99 passing (was 92). 7 new tests cover boundary conditions for `isNutritionFulfilled`: 8.0 exact, 7.9, 0, null mealScore, score overrides stale enum both directions.
- [ ] After deploy, on the home Live-Status grid: **Ernährung** streak should now reflect score ≥ 8.0 days. The user said yesterday + today are > 8.0, expect at least 2 days.
- [ ] Open `Ernährung an oberster Stelle` entry: badge reads `9.6 / 10` (or actual score), nutrition pillar shown as fulfilled (colored, not gray).
- [ ] Admin entry editor for that entry: "X/3 erfüllt" updates to 3/3 when nutrition counts; locked card shows "Ziel erreicht".

🤖 Generated with [Claude Code](https://claude.com/claude-code)