### PR TITLE
feat: per-meal score dashboard + align habit tile sizing

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -51,6 +51,12 @@
     "metricImport": "Import",
     "metricSweets": "Süssigkeiten-Freie-Serie",
     "metricNutritionScore": "Ernährungs-Score",
+    "metricMealAverages": "Ø Score pro Mahlzeit (30T)",
+    "mealBreakfast": "Frühstück",
+    "mealSnackMorning": "Snack Vormittag",
+    "mealLunch": "Mittagessen",
+    "mealSnackAfternoon": "Snack Nachmittag",
+    "mealDinner": "Abendessen",
     "monthlySummaryHeading": "Monats-Rückblick",
     "monthlySummaryReadMore": "Vollständige Zusammenfassung lesen",
     "monthlySummaryViewAll": "Alle Monats-Rückblicke"

--- a/messages/en.json
+++ b/messages/en.json
@@ -51,6 +51,12 @@
     "metricImport": "Import",
     "metricSweets": "Sweets-Free Streak",
     "metricNutritionScore": "Nutrition Score",
+    "metricMealAverages": "Avg score per meal (30d)",
+    "mealBreakfast": "Breakfast",
+    "mealSnackMorning": "Morning snack",
+    "mealLunch": "Lunch",
+    "mealSnackAfternoon": "Afternoon snack",
+    "mealDinner": "Dinner",
     "monthlySummaryHeading": "Monthly Retrospective",
     "monthlySummaryReadMore": "Read full summary",
     "monthlySummaryViewAll": "All monthly retrospectives"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -48,6 +48,12 @@
     "metricImport": "Importado",
     "metricSweets": "Dias Sem Doces",
     "metricNutritionScore": "Pontuação Nutricional",
+    "metricMealAverages": "Pontuação média por refeição (30d)",
+    "mealBreakfast": "Café da manhã",
+    "mealSnackMorning": "Lanche da manhã",
+    "mealLunch": "Almoço",
+    "mealSnackAfternoon": "Lanche da tarde",
+    "mealDinner": "Jantar",
     "monthlySummaryHeading": "Retrospectiva Mensal",
     "monthlySummaryReadMore": "Ler resumo completo",
     "monthlySummaryViewAll": "Todas as retrospectivas mensais"

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -18,7 +18,13 @@ import {
   COLA_ZERO_DAILY_LIMIT_ML,
   type DrinkDayData,
 } from '@/lib/drinks'
-import { getMealScoreHistory, type MealScoreDay } from '@/lib/meal-log'
+import {
+  getMealScoreHistory,
+  getMealAverages,
+  type MealScoreDay,
+  type MealAverage,
+  type MealSlotKey,
+} from '@/lib/meal-log'
 import { StepsSparkline } from './StepsSparkline'
 import { DrinkSparkline } from './DrinkSparkline'
 
@@ -181,36 +187,36 @@ function HabitStreakTile({
 
   return (
     <div
-      className={`relative col-span-1 sm:col-span-1 lg:col-span-4 bg-surface-container-high rounded-xl p-4 overflow-hidden flex flex-col gap-3 transition-shadow ${glow ? `border ${glow.border}` : 'border border-outline-variant/10'}`}
+      className={`relative col-span-1 sm:col-span-1 lg:col-span-4 bg-surface-variant/40 backdrop-blur-xl rounded-xl p-5 overflow-hidden flex flex-col gap-4 transition-shadow ${glow ? `border ${glow.border}` : 'border border-outline-variant/15'}`}
       style={glow ? { boxShadow: glow.shadow } : undefined}
       role={isPriority ? 'region' : undefined}
       aria-label={isPriority && pillarKey ? `Priorität: ${label}` : undefined}
     >
       {isPriority && <span className="sr-only">Aktueller Fokus</span>}
       <span
-        className={`pointer-events-none select-none absolute -right-3 -bottom-3 font-headline font-bold leading-none opacity-[0.04]`}
-        style={{ fontSize: '8rem', color: 'currentColor' }}
+        className={`pointer-events-none select-none absolute -right-4 -bottom-4 font-headline font-bold leading-none ${colorText} opacity-[0.05]`}
+        style={{ fontSize: '10rem' }}
         aria-hidden="true"
       >
         {streak}
       </span>
       <p className={`text-xs font-label font-bold tracking-widest uppercase ${colorText}`}>{label}</p>
       <div className="flex items-baseline gap-2">
-        <span className={`text-5xl font-headline font-bold tracking-tighter leading-none ${colorText} opacity-90`}>
+        <span className={`text-7xl font-headline font-bold tracking-tighter leading-none ${colorText}`}>
           {streak}
         </span>
         <span className="text-sm text-on-surface-variant">{labelDays}</span>
       </div>
       <div className="space-y-1.5">
-        <div className="h-1 bg-surface-container rounded-full overflow-hidden">
+        <div className="h-1 bg-surface-container-high rounded-full overflow-hidden">
           <div className={`h-full rounded-full ${colorClass} transition-all duration-700`} style={{ width: `${Math.min(100, pct30d)}%` }} />
         </div>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <span className="text-xs text-on-surface-variant">
             {labelRate}: <span className={`${colorText} font-semibold`}>{pct30d}%</span>
-            <span className={`ml-2 font-semibold ${trendColor}`}>({labelTrend}: {trendSign}{trend}%)</span>
+            <span className={`ml-1.5 font-semibold ${trendColor}`}>({labelTrend}: {trendSign}{trend}%)</span>
           </span>
-          <span className="text-xs text-on-surface-variant">
+          <span className="text-xs text-on-surface-variant whitespace-nowrap">
             {labelLongest}: <span className="text-on-surface font-semibold">{longestStreak}</span>
           </span>
         </div>
@@ -573,7 +579,7 @@ function NutritionScoreTile({ history, labelNutrition, labelNoData }: NutritionS
   const recent = history.slice(-BAR_COUNT)
 
   return (
-    <div className="col-span-1 sm:col-span-2 lg:col-span-12 bg-surface-container border border-outline-variant/10 rounded-xl p-5 flex flex-col gap-4">
+    <div className="col-span-1 sm:col-span-2 lg:col-span-6 bg-surface-container border border-outline-variant/10 rounded-xl p-5 flex flex-col gap-4">
       {/* Header row */}
       <div className="flex items-center justify-between gap-4">
         <span className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
@@ -635,6 +641,84 @@ function NutritionScoreTile({ history, labelNutrition, labelNoData }: NutritionS
   )
 }
 
+// ─── MealAveragesTile ──────────────────────────────────────────────────────
+
+interface MealAveragesTileProps {
+  averages: MealAverage[]
+  labelTitle: string
+  labelTrend: string
+  labelNoData: string
+  mealLabels: Record<MealSlotKey, string>
+}
+
+function MealAveragesTile({
+  averages, labelTitle, labelTrend, labelNoData, mealLabels,
+}: MealAveragesTileProps) {
+  const hasAny = averages.some((a) => a.avg30 !== null)
+
+  function barColor(s: number) {
+    if (s >= 8.0) return 'bg-green-500'
+    if (s >= 5.0) return 'bg-yellow-500'
+    return 'bg-red-500'
+  }
+  function textColor(s: number) {
+    if (s >= 8.0) return 'text-green-400'
+    if (s >= 5.0) return 'text-yellow-400'
+    return 'text-red-400'
+  }
+
+  return (
+    <div className="col-span-1 sm:col-span-2 lg:col-span-6 bg-surface-container border border-outline-variant/10 rounded-xl p-5 flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
+          {labelTitle}
+        </span>
+        {!hasAny && <span className="text-xs text-on-surface-variant">{labelNoData}</span>}
+      </div>
+
+      {hasAny && (
+        <div className="flex flex-col gap-2.5">
+          {averages.map((m) => {
+            const avg = m.avg30
+            const trend = m.trend
+            const trendAbs = trend !== null ? Math.abs(trend) : 0
+            const showTrend = trend !== null && trendAbs >= 0.05
+            const trendArrow = trend === null ? '' : trend > 0 ? '↑' : trend < 0 ? '↓' : '→'
+            const trendSign = trend !== null && trend > 0 ? '+' : ''
+            const trendColor = trend === null
+              ? 'text-on-surface-variant'
+              : trend > 0 ? 'text-movement-400' : 'text-error'
+            return (
+              <div key={m.key} className="flex items-center gap-3">
+                <span className="w-32 shrink-0 text-xs font-label font-semibold uppercase tracking-wider text-on-surface-variant truncate">
+                  {mealLabels[m.key]}
+                </span>
+                <div className="flex-1 h-2 bg-surface-container-high rounded-full overflow-hidden">
+                  {avg !== null && (
+                    <div
+                      className={`h-full rounded-full transition-all duration-700 ${barColor(avg)}`}
+                      style={{ width: `${(avg / 10) * 100}%` }}
+                    />
+                  )}
+                </div>
+                <span className={`w-10 shrink-0 text-right text-sm font-headline font-bold tabular-nums ${avg !== null ? textColor(avg) : 'text-on-surface-variant'}`}>
+                  {avg !== null ? avg.toFixed(1) : '—'}
+                </span>
+                <span
+                  className={`w-14 shrink-0 text-right text-xs font-semibold tabular-nums ${trendColor}`}
+                  title={labelTrend}
+                >
+                  {showTrend ? `${trendArrow} ${trendSign}${trend!.toFixed(1)}` : ''}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ─── Helper: 7-day vs 30-day success rate ─────────────────────────────────
 
 function computeRates(booleans: boolean[]): { pct30d: number; pct7d: number } {
@@ -653,7 +737,7 @@ export async function LiveStatus() {
     getTranslations('HomePage'),
   ])
 
-  const [entries, metrics, drinkAnalytics, priorityPillar, stepsHistoryRaw, sweetsHistory, mealScoreHistory] = await Promise.all([
+  const [entries, metrics, drinkAnalytics, priorityPillar, stepsHistoryRaw, sweetsHistory, mealScoreHistory, mealAverages] = await Promise.all([
     getAllEntries(),
     getLatestMetrics(profile.projectStartDate ?? undefined),
     getDrinkAnalytics(7),
@@ -661,7 +745,16 @@ export async function LiveStatus() {
     getStepsHistory(30),
     getSweetsHistory(90),
     getMealScoreHistory(30),
+    getMealAverages(30),
   ])
+
+  const mealLabels: Record<MealSlotKey, string> = {
+    breakfast:      t('mealBreakfast'),
+    snackMorning:   t('mealSnackMorning'),
+    lunch:          t('mealLunch'),
+    snackAfternoon: t('mealSnackAfternoon'),
+    dinner:         t('mealDinner'),
+  }
 
   const movementBools = entries.map((e) => isMovementFulfilled(e.habits.movement))
   const nutritionBools = entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore))
@@ -737,11 +830,18 @@ export async function LiveStatus() {
           pillarKey="nutrition"
         />
 
-        {/* Row B — Nutrition score (full width) */}
+        {/* Row B — Nutrition score + per-meal averages (each half width) */}
         <NutritionScoreTile
           history={mealScoreHistory}
           labelNutrition={t('metricNutritionScore')}
           labelNoData={t('metricNoData')}
+        />
+        <MealAveragesTile
+          averages={mealAverages}
+          labelTitle={t('metricMealAverages')}
+          labelTrend={t('trend7d')}
+          labelNoData={t('metricNoData')}
+          mealLabels={mealLabels}
         />
 
         {/* Row C — Weight & Body Fat */}

--- a/src/lib/meal-log.ts
+++ b/src/lib/meal-log.ts
@@ -77,3 +77,64 @@ export async function getMealScoreHistory(days = 30): Promise<MealScoreDay[]> {
   return rows.map((r) => ({ date: r.date.toISOString().slice(0, 10), score: r.score }))
 }
 
+// =============================================
+// Per-meal averages (5 main meals, excluding bonus snack)
+// =============================================
+
+export type MealSlotKey = 'breakfast' | 'snackMorning' | 'lunch' | 'snackAfternoon' | 'dinner'
+
+export const MAIN_MEAL_KEYS: readonly MealSlotKey[] = [
+  'breakfast',
+  'snackMorning',
+  'lunch',
+  'snackAfternoon',
+  'dinner',
+] as const
+
+export interface MealAverage {
+  key: MealSlotKey
+  avg30: number | null   // 30-day average, 0–10 (null if no logs)
+  avg7: number | null    // last-7-day average, 0–10 (null if no logs)
+  trend: number | null   // avg7 − avg30 (null if either missing)
+  count30: number        // number of days with a non-null value in window
+}
+
+/**
+ * Returns the per-meal average score (0–10) over the trailing window,
+ * plus the trailing 7-day average and trend (avg7 − avg30) for each main meal.
+ * Days where a given meal slot is null are excluded from that meal's average.
+ */
+export async function getMealAverages(days = 30): Promise<MealAverage[]> {
+  const today = new Date(`${zurichDateStr()}T00:00:00.000Z`)
+  const from30 = new Date(today.getTime() - (days - 1) * 24 * 60 * 60 * 1000)
+  const from7 = new Date(today.getTime() - 6 * 24 * 60 * 60 * 1000)
+
+  const rows = await prisma.mealLog.findMany({
+    where: { date: { gte: from30, lte: today } },
+    orderBy: { date: 'asc' },
+    select: {
+      date: true,
+      breakfast: true,
+      snackMorning: true,
+      lunch: true,
+      snackAfternoon: true,
+      dinner: true,
+    },
+  })
+
+  return MAIN_MEAL_KEYS.map((key) => {
+    const all: number[] = []
+    const last7: number[] = []
+    for (const r of rows) {
+      const v = r[key]
+      if (v === null || v === undefined) continue
+      all.push(v)
+      if (r.date >= from7) last7.push(v)
+    }
+    const avg30 = all.length > 0 ? all.reduce((s, n) => s + n, 0) / all.length : null
+    const avg7 = last7.length > 0 ? last7.reduce((s, n) => s + n, 0) / last7.length : null
+    const trend = avg30 !== null && avg7 !== null ? avg7 - avg30 : null
+    return { key, avg30, avg7, trend, count30: all.length }
+  })
+}
+


### PR DESCRIPTION
## Summary
- Adds a new dashboard tile next to the **Ernährungs-Score** showing the 30-day average score per main meal (5 slots without bonus snack), with a 7-day vs 30-day trend per meal — helps identify the weakest meal slot.
- Aligns the three habit hero tiles (Rauchstopp, Bewegung, Ernährung) to share identical sizing, padding, glassmorphism background and `text-7xl` streak number. Previously Bewegung/Ernährung rendered noticeably smaller than Rauchstopp.

## Changes
- `src/lib/meal-log.ts` — new `getMealAverages(days)` returning per-meal `avg30`, `avg7`, `trend` (excludes null entries from each meal's average)
- `src/components/home/LiveStatus.tsx` — new `MealAveragesTile` (lg:col-span-6) + `NutritionScoreTile` reduced from full to half width; `HabitStreakTile` styling unified with `SmokingHeroTile`
- `messages/{de,en,pt}.json` — new keys: `metricMealAverages`, `mealBreakfast`, `mealSnackMorning`, `mealLunch`, `mealSnackAfternoon`, `mealDinner`

## Test plan
- [ ] CI green (lint, type-check, tests, build)
- [ ] Home page renders the new tile next to Ernährungs-Score on lg, stacked on sm/mobile
- [ ] All three habit hero tiles visually match (same number size, padding, background)
- [ ] DE/EN/PT labels render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)