### PR TITLE
feat: show 7-day rolling average for weight and body fat

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -49,6 +49,8 @@
     "metricStart": "Start",
     "metricProgress": "vom Weg geschafft",
     "metricImport": "Import",
+    "metricAvg7d": "Ø 7 Tage",
+    "metricToday": "Heute",
     "metricSweets": "Süssigkeiten-Freie-Serie",
     "metricNutritionScore": "Ernährungs-Score",
     "metricMealAverages": "Ø Score pro Mahlzeit (30T)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -49,6 +49,8 @@
     "metricStart": "Start",
     "metricProgress": "of the way there",
     "metricImport": "Import",
+    "metricAvg7d": "7-day avg",
+    "metricToday": "Today",
     "metricSweets": "Sweets-Free Streak",
     "metricNutritionScore": "Nutrition Score",
     "metricMealAverages": "Avg score per meal (30d)",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -46,6 +46,8 @@
     "metricStart": "Início",
     "metricProgress": "do caminho percorrido",
     "metricImport": "Importado",
+    "metricAvg7d": "Méd. 7 dias",
+    "metricToday": "Hoje",
     "metricSweets": "Dias Sem Doces",
     "metricNutritionScore": "Pontuação Nutricional",
     "metricMealAverages": "Pontuação média por refeição (30d)",

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -227,9 +227,9 @@ function HabitStreakTile({
 
 // ─── Trend Badge ──────────────────────────────────────────────────────────
 
-function TrendBadge({ current, baseline, unit }: { current: number; baseline: number; unit: string }) {
+function TrendBadge({ current, baseline, unit, threshold = 0.05 }: { current: number; baseline: number; unit: string; threshold?: number }) {
   const delta = current - baseline
-  if (Math.abs(delta) < 0.05) return null
+  if (Math.abs(delta) < threshold) return null
   const isGood = delta < 0
   const sign = delta < 0 ? '−' : '+'
   const arrow = delta < 0 ? '↓' : '↑'
@@ -246,6 +246,8 @@ function TrendBadge({ current, baseline, unit }: { current: number; baseline: nu
 
 interface WeightTileProps {
   weight?: number
+  weightAvg7d?: number
+  weightAvg7dPrev?: number
   bmi?: number
   targetWeight?: number | null
   baselineWeight?: number
@@ -256,18 +258,22 @@ interface WeightTileProps {
   labelImport: string
   labelStart: string
   labelProgress: string
+  labelAvg7d: string
+  labelToday: string
   labelNoData: string
 }
 
-function WeightTile({ weight, bmi, targetWeight, baselineWeight, importedAt, labelWeight, labelBmi, labelTarget, labelImport, labelStart, labelProgress, labelNoData }: WeightTileProps) {
-  const hasWeight = weight !== undefined
+function WeightTile({ weight, weightAvg7d, weightAvg7dPrev, bmi, targetWeight, baselineWeight, importedAt, labelWeight, labelBmi, labelTarget, labelImport, labelStart, labelProgress, labelAvg7d, labelToday, labelNoData }: WeightTileProps) {
+  const display = weightAvg7d ?? weight
+  const hasDisplay = display !== undefined
   const hasTarget = targetWeight !== null && targetWeight !== undefined
   const hasBaseline = baselineWeight !== undefined
+  const showingAvg = weightAvg7d !== undefined
 
   let pct = 0
-  if (hasWeight && hasTarget && hasBaseline) {
+  if (hasDisplay && hasTarget && hasBaseline) {
     const totalNeeded = baselineWeight! - targetWeight!
-    const achieved = baselineWeight! - weight!
+    const achieved = baselineWeight! - display!
     if (totalNeeded > 0) pct = clampPct((achieved / totalNeeded) * 100)
   }
 
@@ -282,19 +288,33 @@ function WeightTile({ weight, bmi, targetWeight, baselineWeight, importedAt, lab
         )}
       </div>
 
-      {hasWeight ? (
+      {hasDisplay ? (
         <>
           <div className="flex items-end gap-6">
             <div>
               <div className="flex items-baseline gap-1.5">
                 <span className="text-5xl font-headline font-bold tracking-tighter leading-none text-on-surface">
-                  {weight!.toFixed(1)}
+                  {display!.toFixed(1)}
                 </span>
                 <span className="text-sm text-on-surface-variant">kg</span>
-                {hasBaseline && <TrendBadge current={weight!} baseline={baselineWeight!} unit=" kg" />}
+                {showingAvg && weightAvg7dPrev !== undefined && (
+                  <TrendBadge current={weightAvg7d!} baseline={weightAvg7dPrev} unit=" kg" threshold={0.1} />
+                )}
               </div>
-              {bmi && (
-                <p className="text-xs text-on-surface-variant mt-1">
+              <p className="text-xs text-on-surface-variant mt-1">
+                {showingAvg ? (
+                  <>
+                    <span className="font-semibold text-on-surface">{labelAvg7d}</span>
+                    {weight !== undefined && (
+                      <> · {labelToday}: <span className="text-on-surface font-semibold">{weight.toFixed(1)} kg</span></>
+                    )}
+                  </>
+                ) : (
+                  bmi && <>{labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span></>
+                )}
+              </p>
+              {showingAvg && bmi && (
+                <p className="text-xs text-on-surface-variant mt-0.5">
                   {labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span>
                 </p>
               )}
@@ -334,6 +354,8 @@ function WeightTile({ weight, bmi, targetWeight, baselineWeight, importedAt, lab
 
 interface BodyFatTileProps {
   bodyFat?: number
+  bodyFatAvg7d?: number
+  bodyFatAvg7dPrev?: number
   baselineBodyFat?: number
   importedAt?: Date
   labelBodyFat: string
@@ -341,17 +363,21 @@ interface BodyFatTileProps {
   labelImport: string
   labelStart: string
   labelProgress: string
+  labelAvg7d: string
+  labelToday: string
   labelNoData: string
 }
 
-function BodyFatTile({ bodyFat, baselineBodyFat, importedAt, labelBodyFat, labelTarget, labelImport, labelStart, labelProgress, labelNoData }: BodyFatTileProps) {
-  const hasBodyFat = bodyFat !== undefined
+function BodyFatTile({ bodyFat, bodyFatAvg7d, bodyFatAvg7dPrev, baselineBodyFat, importedAt, labelBodyFat, labelTarget, labelImport, labelStart, labelProgress, labelAvg7d, labelToday, labelNoData }: BodyFatTileProps) {
+  const display = bodyFatAvg7d ?? bodyFat
+  const hasDisplay = display !== undefined
   const hasBaseline = baselineBodyFat !== undefined
+  const showingAvg = bodyFatAvg7d !== undefined
 
   let pct = 0
-  if (hasBodyFat && hasBaseline) {
+  if (hasDisplay && hasBaseline) {
     const totalNeeded = baselineBodyFat! - TARGET_BODY_FAT_PCT
-    const achieved = baselineBodyFat! - bodyFat!
+    const achieved = baselineBodyFat! - display!
     if (totalNeeded > 0) pct = clampPct((achieved / totalNeeded) * 100)
   }
 
@@ -366,15 +392,27 @@ function BodyFatTile({ bodyFat, baselineBodyFat, importedAt, labelBodyFat, label
         )}
       </div>
 
-      {hasBodyFat ? (
+      {hasDisplay ? (
         <>
           <div className="flex items-end gap-6">
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-5xl font-headline font-bold tracking-tighter leading-none text-on-surface">
-                {bodyFat!.toFixed(1)}
-              </span>
-              <span className="text-sm text-on-surface-variant">%</span>
-              {hasBaseline && <TrendBadge current={bodyFat!} baseline={baselineBodyFat!} unit="%" />}
+            <div>
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-5xl font-headline font-bold tracking-tighter leading-none text-on-surface">
+                  {display!.toFixed(1)}
+                </span>
+                <span className="text-sm text-on-surface-variant">%</span>
+                {showingAvg && bodyFatAvg7dPrev !== undefined && (
+                  <TrendBadge current={bodyFatAvg7d!} baseline={bodyFatAvg7dPrev} unit="%" threshold={0.1} />
+                )}
+              </div>
+              {showingAvg && (
+                <p className="text-xs text-on-surface-variant mt-1">
+                  <span className="font-semibold text-on-surface">{labelAvg7d}</span>
+                  {bodyFat !== undefined && (
+                    <> · {labelToday}: <span className="text-on-surface font-semibold">{bodyFat.toFixed(1)} %</span></>
+                  )}
+                </p>
+              )}
             </div>
             <div className="text-right">
               <span className="text-xs text-on-surface-variant">{labelTarget}</span>
@@ -847,6 +885,8 @@ export async function LiveStatus() {
         {/* Row C — Weight & Body Fat */}
         <WeightTile
           weight={metrics.latestWeight}
+          weightAvg7d={metrics.weightAvg7d}
+          weightAvg7dPrev={metrics.weightAvg7dPrev}
           bmi={metrics.latestBmi}
           targetWeight={profile.targetWeight}
           baselineWeight={metrics.baselineWeight}
@@ -857,10 +897,14 @@ export async function LiveStatus() {
           labelImport={t('metricImport')}
           labelStart={t('metricStart')}
           labelProgress={t('metricProgress')}
+          labelAvg7d={t('metricAvg7d')}
+          labelToday={t('metricToday')}
           labelNoData={t('metricNoData')}
         />
         <BodyFatTile
           bodyFat={metrics.latestBodyFat}
+          bodyFatAvg7d={metrics.bodyFatAvg7d}
+          bodyFatAvg7dPrev={metrics.bodyFatAvg7dPrev}
           baselineBodyFat={metrics.baselineBodyFat}
           importedAt={metrics.bodyFatImportedAt}
           labelBodyFat={t('metricBodyFat')}
@@ -868,6 +912,8 @@ export async function LiveStatus() {
           labelImport={t('metricImport')}
           labelStart={t('metricStart')}
           labelProgress={t('metricProgress')}
+          labelAvg7d={t('metricAvg7d')}
+          labelToday={t('metricToday')}
           labelNoData={t('metricNoData')}
         />
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -4,6 +4,10 @@ export interface MetricsSummary {
   latestWeight?: number
   latestBodyFat?: number
   latestBmi?: number
+  weightAvg7d?: number
+  weightAvg7dPrev?: number
+  bodyFatAvg7d?: number
+  bodyFatAvg7dPrev?: number
   avgSteps30d?: number
   lastSyncDate?: Date
   weightImportedAt?: Date
@@ -13,11 +17,29 @@ export interface MetricsSummary {
   baselineBodyFat?: number
 }
 
+function average(values: number[]): number | undefined {
+  if (values.length === 0) return undefined
+  return values.reduce((s, v) => s + v, 0) / values.length
+}
+
+function startOfDayUTC(d: Date): Date {
+  const x = new Date(d)
+  x.setUTCHours(0, 0, 0, 0)
+  return x
+}
+
 export async function getLatestMetrics(projectStartDate?: string): Promise<MetricsSummary> {
   const startDate = projectStartDate ? new Date(projectStartDate) : new Date('2020-01-01')
 
   const thirtyDaysAgo = new Date()
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+  // 14-day window for rolling weight/body-fat averages (current 7d + prior 7d)
+  const today = startOfDayUTC(new Date())
+  const fourteenDaysAgo = new Date(today)
+  fourteenDaysAgo.setUTCDate(fourteenDaysAgo.getUTCDate() - 13)
+  const sevenDaysAgo = new Date(today)
+  sevenDaysAgo.setUTCDate(sevenDaysAgo.getUTCDate() - 6)
 
   const [
     latestWeightRow,
@@ -26,6 +48,8 @@ export async function getLatestMetrics(projectStartDate?: string): Promise<Metri
     baselineWeightRow,
     baselineBodyFatRow,
     stepsData,
+    recentWeightRows,
+    recentBodyFatRows,
   ] = await Promise.all([
     prisma.dailyMetrics.findFirst({
       orderBy: { date: 'desc' },
@@ -56,6 +80,14 @@ export async function getLatestMetrics(projectStartDate?: string): Promise<Metri
       where: { date: { gte: thirtyDaysAgo }, steps: { not: null } },
       select: { steps: true },
     }),
+    prisma.dailyMetrics.findMany({
+      where: { date: { gte: fourteenDaysAgo }, weight: { not: null } },
+      select: { date: true, weight: true },
+    }),
+    prisma.dailyMetrics.findMany({
+      where: { date: { gte: fourteenDaysAgo }, bodyFat: { not: null } },
+      select: { date: true, bodyFat: true },
+    }),
   ])
 
   // Fall back to absolute first record when projectStartDate is set to a future
@@ -82,10 +114,27 @@ export async function getLatestMetrics(projectStartDate?: string): Promise<Metri
       ? Math.round(stepsData.reduce((s, d) => s + (d.steps ?? 0), 0) / stepsData.length)
       : undefined
 
+  const weightCurrent = recentWeightRows
+    .filter((r) => r.date >= sevenDaysAgo)
+    .map((r) => r.weight as number)
+  const weightPrior = recentWeightRows
+    .filter((r) => r.date < sevenDaysAgo)
+    .map((r) => r.weight as number)
+  const bodyFatCurrent = recentBodyFatRows
+    .filter((r) => r.date >= sevenDaysAgo)
+    .map((r) => r.bodyFat as number)
+  const bodyFatPrior = recentBodyFatRows
+    .filter((r) => r.date < sevenDaysAgo)
+    .map((r) => r.bodyFat as number)
+
   return {
     latestWeight: latestWeightRow?.weight ?? undefined,
     latestBodyFat: latestBodyFatRow?.bodyFat ?? undefined,
     latestBmi: latestWeightRow?.bmi ?? undefined,
+    weightAvg7d: average(weightCurrent),
+    weightAvg7dPrev: average(weightPrior),
+    bodyFatAvg7d: average(bodyFatCurrent),
+    bodyFatAvg7dPrev: average(bodyFatPrior),
     avgSteps30d: avgSteps,
     lastSyncDate: latestStepsRow?.date ?? undefined,
     weightImportedAt: latestWeightRow?.updatedAt ?? undefined,


### PR DESCRIPTION
## Summary
- Weight and body-fat home tiles now display the rolling 7-day average as the primary value, with today's reading shown as a small secondary line
- Trend arrow now compares current 7-day average vs. prior 7-day average (instead of vs. baseline) — daily Fitbit noise no longer dominates the trend
- Progress bar (% vom Weg geschafft) uses the smoothed average instead of today's swing
- Falls back gracefully to the latest reading when there's no data in the last 7 days

## Test plan
- [ ] Visual check on `/de` home page: Gewicht/Körperfett tiles show smoothed value + "Heute: …"
- [ ] Trend arrow direction matches week-over-week change
- [ ] Tile renders correctly with no data and with sparse data
- [ ] EN and PT locales render new labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)