### PR TITLE
fix: align weight and body-fat tile heights

### DIFF
--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -308,16 +308,14 @@ function WeightTile({ weight, weightAvg7d, weightAvg7dPrev, bmi, targetWeight, b
                     {weight !== undefined && (
                       <> · {labelToday}: <span className="text-on-surface font-semibold">{weight.toFixed(1)} kg</span></>
                     )}
+                    {bmi && (
+                      <> · {labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span></>
+                    )}
                   </>
                 ) : (
                   bmi && <>{labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span></>
                 )}
               </p>
-              {showingAvg && bmi && (
-                <p className="text-xs text-on-surface-variant mt-0.5">
-                  {labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span>
-                </p>
-              )}
             </div>
             {hasTarget && (
               <div className="text-right">


### PR DESCRIPTION
## Summary
- Inline BMI with "Ø 7 Tage · Heute …" so the weight tile no longer renders one row taller than the body-fat tile sitting next to it

## Test plan
- [ ] Both tiles end at the same vertical height on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)