### PR TITLE
fix: drop background pill from trend badge

### DIFF
--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -308,16 +308,14 @@ function WeightTile({ weight, weightAvg7d, weightAvg7dPrev, bmi, targetWeight, b
                     {weight !== undefined && (
                       <> · {labelToday}: <span className="text-on-surface font-semibold">{weight.toFixed(1)} kg</span></>
                     )}
+                    {bmi && (
+                      <> · {labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span></>
+                    )}
                   </>
                 ) : (
                   bmi && <>{labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span></>
                 )}
               </p>
-              {showingAvg && bmi && (
-                <p className="text-xs text-on-surface-variant mt-0.5">
-                  {labelBmi}: <span className="text-on-surface font-semibold">{bmi}</span>
-                </p>
-              )}
             </div>
             {hasTarget && (
               <div className="text-right">

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -234,8 +234,8 @@ function TrendBadge({ current, baseline, unit, threshold = 0.05 }: { current: nu
   const sign = delta < 0 ? '−' : '+'
   const arrow = delta < 0 ? '↓' : '↑'
   return (
-    <span className={`inline-flex items-center gap-0.5 text-xs font-semibold px-1.5 py-0.5 rounded ${
-      isGood ? 'text-movement-400 bg-movement-900/20' : 'text-secondary bg-secondary/10'
+    <span className={`inline-flex items-center gap-0.5 text-xs font-semibold ${
+      isGood ? 'text-movement-400' : 'text-secondary'
     }`}>
       {arrow} {sign}{Math.abs(delta).toFixed(1)}{unit}
     </span>


### PR DESCRIPTION
## Summary
- TrendBadge now renders as plain colored text without the tinted background pill — the red/green boxes had different visual weight and made the tiles feel asymmetric

## Test plan
- [ ] Weight tile shows "↑ +0.4 kg" in plain orange text, no box
- [ ] Body fat tile shows "↓ -0.7 %" in plain green text, no box

🤖 Generated with [Claude Code](https://claude.com/claude-code)