### PR TITLE
feat: add filler journal entries (Tagesnotiz)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -181,7 +181,8 @@
   "JournalCard": {
     "day": "Tag {number}",
     "readMore": "Weiterlesen →",
-    "perfectDay": "Perfekter Tag"
+    "perfectDay": "Perfekter Tag",
+    "fillerBadge": "Tagesnotiz"
   },
   "SearchModal": {
     "ariaLabel": "Suchen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -181,7 +181,8 @@
   "JournalCard": {
     "day": "Day {number}",
     "readMore": "Read more →",
-    "perfectDay": "Perfect Day"
+    "perfectDay": "Perfect Day",
+    "fillerBadge": "Daily note"
   },
   "SearchModal": {
     "ariaLabel": "Search",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -178,7 +178,8 @@
   "JournalCard": {
     "day": "Dia {number}",
     "readMore": "Ler mais →",
-    "perfectDay": "Dia Perfeito"
+    "perfectDay": "Dia Perfeito",
+    "fillerBadge": "Nota do dia"
   },
   "SearchModal": {
     "ariaLabel": "Pesquisar",

--- a/prisma/migrations/20260510170000_add_entry_type/migration.sql
+++ b/prisma/migrations/20260510170000_add_entry_type/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "EntryType" AS ENUM ('FULL', 'FILLER');
+
+-- AlterTable
+ALTER TABLE "JournalEntry" ADD COLUMN "entryType" "EntryType" NOT NULL DEFAULT 'FULL';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,10 @@ model JournalEntry {
   date      DateTime @db.Date
   published Boolean  @default(true)
 
+  // FULL = klassischer Blog-Eintrag mit Text. FILLER = Tagesnotiz ohne Text;
+  // im Feed kompakter dargestellt, Detailview ist nicht erreichbar.
+  entryType EntryType @default(FULL)
+
   // Die drei Säulen — direkt eingebettet
   movement  MovementLevel
   nutrition NutritionLevel
@@ -84,6 +88,11 @@ enum SmokingStatus {
   SMOKED
   NICOTINE_REPLACEMENT
   SMOKE_FREE
+}
+
+enum EntryType {
+  FULL
+  FILLER
 }
 
 // =============================================

--- a/src/app/[locale]/journal/[slug]/page.tsx
+++ b/src/app/[locale]/journal/[slug]/page.tsx
@@ -16,7 +16,7 @@ interface JournalPostPageProps {
 
 export async function generateMetadata({ params }: JournalPostPageProps): Promise<Metadata> {
   const result = await getEntryBySlugWithTranslation(params.slug, params.locale)
-  if (!result) return {}
+  if (!result || result.entry.entryType === 'filler') return {}
 
   const { entry, translation } = result
   const useTranslation = params.locale !== 'de' && translation !== null
@@ -45,6 +45,7 @@ export default async function JournalPostPage({ params }: JournalPostPageProps) 
     headers(),
   ])
   if (!result) notFound()
+  if (result.entry.entryType === 'filler') notFound()
 
   const nonce = headersList.get('x-nonce') ?? undefined
   const { entry, translation } = result

--- a/src/app/admin/entries/[id]/edit/page.tsx
+++ b/src/app/admin/entries/[id]/edit/page.tsx
@@ -22,6 +22,7 @@ export default async function EditEntryPage({ params }: EditEntryPageProps) {
     content: entry.content,
     excerpt: entry.excerpt ?? '',
     bannerUrl: entry.bannerUrl ?? undefined,
+    entryType: entry.entryType,
     movement: entry.movement,
     nutrition: entry.nutrition,
     smoking: entry.smoking,

--- a/src/app/admin/entries/actions.ts
+++ b/src/app/admin/entries/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { translateEntry as translateEntryViaAI } from '@/lib/translate'
-import { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
+import { MovementLevel, NutritionLevel, SmokingStatus, EntryType } from '@prisma/client'
 
 export interface EntryFormData {
   title: string
@@ -13,6 +13,7 @@ export interface EntryFormData {
   content: string
   excerpt: string
   bannerUrl?: string
+  entryType: EntryType
   movement: MovementLevel
   nutrition: NutritionLevel
   smoking: SmokingStatus
@@ -41,7 +42,10 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
   if (!data.title.trim()) return { error: 'Titel ist erforderlich' }
   if (!data.slug.trim()) return { error: 'Slug ist erforderlich' }
   if (!data.date) return { error: 'Datum ist erforderlich' }
-  if (!data.content || data.content === '<p></p>') return { error: 'Inhalt ist erforderlich' }
+  const isFiller = data.entryType === 'FILLER'
+  if (!isFiller && (!data.content || data.content === '<p></p>')) {
+    return { error: 'Inhalt ist erforderlich' }
+  }
 
   const existing = await prisma.journalEntry.findUnique({ where: { slug: data.slug } })
   if (existing) return { error: `Slug „${data.slug}" ist bereits vergeben` }
@@ -52,9 +56,12 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
         title: data.title.trim(),
         slug: data.slug.trim(),
         date: new Date(data.date),
-        content: data.content,
-        excerpt: data.excerpt.trim() || extractExcerpt(data.content),
+        content: isFiller ? '' : data.content,
+        excerpt: isFiller
+          ? data.excerpt.trim() || null
+          : data.excerpt.trim() || extractExcerpt(data.content),
         bannerUrl: data.bannerUrl ?? null,
+        entryType: data.entryType,
         movement: data.movement,
         nutrition: data.nutrition,
         smoking: data.smoking,
@@ -80,7 +87,10 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
   if (!session) return { error: 'Nicht autorisiert' }
 
   if (!data.title.trim()) return { error: 'Titel ist erforderlich' }
-  if (!data.content || data.content === '<p></p>') return { error: 'Inhalt ist erforderlich' }
+  const isFiller = data.entryType === 'FILLER'
+  if (!isFiller && (!data.content || data.content === '<p></p>')) {
+    return { error: 'Inhalt ist erforderlich' }
+  }
 
   try {
     const entry = await prisma.journalEntry.update({
@@ -88,9 +98,12 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
       data: {
         title: data.title.trim(),
         date: new Date(data.date),
-        content: data.content,
-        excerpt: data.excerpt.trim() || extractExcerpt(data.content),
+        content: isFiller ? '' : data.content,
+        excerpt: isFiller
+          ? data.excerpt.trim() || null
+          : data.excerpt.trim() || extractExcerpt(data.content),
         bannerUrl: data.bannerUrl ?? null,
+        entryType: data.entryType,
         movement: data.movement,
         nutrition: data.nutrition,
         smoking: data.smoking,
@@ -138,6 +151,9 @@ export async function translateEntry(id: string, locale: 'en' | 'pt' = 'en'): Pr
 
   const entry = await prisma.journalEntry.findUnique({ where: { id } })
   if (!entry) return { error: 'Eintrag nicht gefunden' }
+  if (entry.entryType === 'FILLER') {
+    return { error: 'Tagesnotizen werden nicht übersetzt' }
+  }
 
   try {
     const translated = await translateEntryViaAI({

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -26,6 +26,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
         title: true,
         date: true,
         published: true,
+        entryType: true,
         updatedAt: true,
         movement: true,
         nutrition: true,
@@ -82,6 +83,11 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
                     <span className="font-headline font-semibold text-on-surface truncate">
                       {entry.title}
                     </span>
+                    {entry.entryType === 'FILLER' && (
+                      <span className="text-xs px-1.5 py-0.5 bg-surface-container-high text-on-surface-variant rounded shrink-0">
+                        Tagesnotiz
+                      </span>
+                    )}
                     {!entry.published && (
                       <span className="text-xs px-1.5 py-0.5 bg-surface-container text-on-surface-variant rounded shrink-0">
                         Entwurf
@@ -92,19 +98,23 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0">
-                  <TranslateButton
-                    id={entry.id}
-                    entryUpdatedAt={entry.updatedAt}
-                    enTranslation={enTranslation}
-                    ptTranslation={ptTranslation}
-                  />
-                  <Link
-                    href={`/journal/${entry.slug}`}
-                    target="_blank"
-                    className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
-                  >
-                    Ansehen ↗
-                  </Link>
+                  {entry.entryType !== 'FILLER' && (
+                    <>
+                      <TranslateButton
+                        id={entry.id}
+                        entryUpdatedAt={entry.updatedAt}
+                        enTranslation={enTranslation}
+                        ptTranslation={ptTranslation}
+                      />
+                      <Link
+                        href={`/journal/${entry.slug}`}
+                        target="_blank"
+                        className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
+                      >
+                        Ansehen ↗
+                      </Link>
+                    </>
+                  )}
                   <Link
                     href={`/admin/entries/${entry.id}/edit`}
                     className="text-xs px-3 py-1.5 border border-surface-container-high rounded-lg text-on-surface-variant text-on-surface-variant hover:border-outline hover:border-on-surface-variant hover:text-on-surface transition-colors"

--- a/src/app/admin/translations/page.tsx
+++ b/src/app/admin/translations/page.tsx
@@ -54,6 +54,7 @@ function formatDate(date: Date): string {
 export default async function TranslationsPage() {
   const [entries, startDate] = await Promise.all([
     prisma.journalEntry.findMany({
+      where: { entryType: 'FULL' },
       orderBy: { date: 'desc' },
       select: {
         id: true,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -25,6 +25,7 @@ export async function GET(request: NextRequest) {
     prisma.journalEntry.findMany({
       where: {
         published: true,
+        entryType: 'FULL',
         OR: [
           { title: { contains: q, mode: 'insensitive' } },
           { excerpt: { contains: q, mode: 'insensitive' } },

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -16,6 +16,7 @@ export async function GET() {
   const entries = await getAllEntries()
 
   const items = entries
+    .filter((entry) => entry.entryType !== 'filler')
     .map((entry) => {
       const url = `${SITE_URL}/journal/${entry.slug}`
       const pubDate = new Date(entry.date).toUTCString()

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,7 @@ import { SITE_URL } from '@/lib/site'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const entries = await prisma.journalEntry.findMany({
-    where: { published: true },
+    where: { published: true, entryType: 'FULL' },
     orderBy: { date: 'desc' },
     select: {
       slug: true,

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
-import { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
+import { MovementLevel, NutritionLevel, SmokingStatus, EntryType } from '@prisma/client'
 import { scoreToNutritionLevel, type MealLogData } from '@/lib/meal-log'
 import { clsx } from 'clsx'
 import { TiptapEditor } from './TiptapEditor'
@@ -47,8 +47,10 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
   const [title, setTitle] = useState(initial?.title ?? '')
   const [date, setDate] = useState(initial?.date ?? today)
   const [slug, setSlug] = useState(initial?.slug ?? slugFromDate(today))
+  const [entryType, setEntryType] = useState<EntryType>(initial?.entryType ?? 'FULL')
   const [content, setContent] = useState(initial?.content ?? '')
   const [excerpt, setExcerpt] = useState(initial?.excerpt ?? '')
+  const isFiller = entryType === 'FILLER'
   const [movement, setMovement] = useState<MovementLevel>(initial?.movement ?? 'STEPS_ONLY')
   // If the meal log has a score (saved before the entry was created), derive
   // the initial enum value from it instead of falling back to the TWO_MEALS
@@ -82,9 +84,10 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
       title,
       slug,
       date,
-      content,
+      content: isFiller ? '' : content,
       excerpt,
       bannerUrl,
+      entryType,
       movement,
       nutrition,
       smoking,
@@ -102,41 +105,43 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
         return
       }
 
-      router.push(result.slug ? `/journal/${result.slug}` : '/admin/entries')
+      router.push(result.slug && !isFiller ? `/journal/${result.slug}` : '/admin/entries')
     })
   }
 
   return (
     <div className="space-y-4">
-      {/* Editor / Vorschau Toggle */}
-      <div className="flex items-center gap-1 bg-surface-container-low rounded-lg p-1 w-fit">
-        <button
-          type="button"
-          onClick={() => setIsPreview(false)}
-          className={clsx(
-            'px-3 py-1 rounded-md text-sm font-medium transition-colors',
-            !isPreview
-              ? 'bg-surface-container text-on-surface shadow-sm'
-              : 'text-on-surface-variant hover:text-on-surface'
-          )}
-        >
-          Bearbeiten
-        </button>
-        <button
-          type="button"
-          onClick={() => setIsPreview(true)}
-          className={clsx(
-            'px-3 py-1 rounded-md text-sm font-medium transition-colors',
-            isPreview
-              ? 'bg-surface-container text-on-surface shadow-sm'
-              : 'text-on-surface-variant hover:text-on-surface'
-          )}
-        >
-          Vorschau
-        </button>
-      </div>
+      {/* Editor / Vorschau Toggle — nur für vollständige Einträge sinnvoll */}
+      {!isFiller && (
+        <div className="flex items-center gap-1 bg-surface-container-low rounded-lg p-1 w-fit">
+          <button
+            type="button"
+            onClick={() => setIsPreview(false)}
+            className={clsx(
+              'px-3 py-1 rounded-md text-sm font-medium transition-colors',
+              !isPreview
+                ? 'bg-surface-container text-on-surface shadow-sm'
+                : 'text-on-surface-variant hover:text-on-surface'
+            )}
+          >
+            Bearbeiten
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsPreview(true)}
+            className={clsx(
+              'px-3 py-1 rounded-md text-sm font-medium transition-colors',
+              isPreview
+                ? 'bg-surface-container text-on-surface shadow-sm'
+                : 'text-on-surface-variant hover:text-on-surface'
+            )}
+          >
+            Vorschau
+          </button>
+        </div>
+      )}
 
-      {isPreview ? (
+      {isPreview && !isFiller ? (
         <EntryPreview
           title={title}
           date={date}
@@ -237,33 +242,73 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
         />
       </div>
 
+      {/* Eintrag-Typ */}
+      <div>
+        <label className="block text-xs font-medium text-on-surface-variant mb-1.5">Eintrag-Typ</label>
+        <div className="inline-flex items-center gap-1 bg-surface-container-low rounded-lg p-1">
+          <button
+            type="button"
+            onClick={() => setEntryType('FULL')}
+            className={clsx(
+              'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+              !isFiller
+                ? 'bg-surface-container text-on-surface shadow-sm'
+                : 'text-on-surface-variant hover:text-on-surface'
+            )}
+          >
+            Vollständiger Eintrag
+          </button>
+          <button
+            type="button"
+            onClick={() => setEntryType('FILLER')}
+            className={clsx(
+              'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+              isFiller
+                ? 'bg-surface-container text-on-surface shadow-sm'
+                : 'text-on-surface-variant hover:text-on-surface'
+            )}
+          >
+            Tagesnotiz
+          </button>
+        </div>
+        {isFiller && (
+          <p className="text-xs text-on-surface-variant mt-1.5">
+            Tagesnotiz: kein Blogtext, kein Detailview, nicht übersetzt. Nur Banner, Säulen und Metadaten.
+          </p>
+        )}
+      </div>
+
       {/* Banner-Bild */}
       <BannerUpload value={bannerUrl} onChange={setBannerUrl} slug={slug} title={title} excerpt={excerpt} />
 
-      {/* Tiptap Editor */}
-      <div>
-        <label className="block text-xs font-medium text-on-surface-variant mb-1">Inhalt</label>
-        <TiptapEditor
-          content={content}
-          onChange={setContent}
-          placeholder="Schreibe deinen heutigen Eintrag..."
-        />
-      </div>
+      {!isFiller && (
+        <>
+          {/* Tiptap Editor */}
+          <div>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Inhalt</label>
+            <TiptapEditor
+              content={content}
+              onChange={setContent}
+              placeholder="Schreibe deinen heutigen Eintrag..."
+            />
+          </div>
 
-      {/* Excerpt */}
-      <div>
-        <label className="block text-xs font-medium text-on-surface-variant mb-1">
-          Kurzbeschreibung{' '}
-          <span className="text-on-surface-variant font-normal">(optional — für SEO, RSS, Suche &amp; Feed-Vorschau; wird sonst automatisch generiert)</span>
-        </label>
-        <textarea
-          value={excerpt}
-          onChange={(e) => setExcerpt(e.target.value)}
-          rows={2}
-          placeholder="1–2 Sätze, die den Eintrag zusammenfassen..."
-          className="w-full border border-surface-container-high rounded-lg px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container resize-none"
-        />
-      </div>
+          {/* Excerpt */}
+          <div>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">
+              Kurzbeschreibung{' '}
+              <span className="text-on-surface-variant font-normal">(optional — für SEO, RSS, Suche &amp; Feed-Vorschau; wird sonst automatisch generiert)</span>
+            </label>
+            <textarea
+              value={excerpt}
+              onChange={(e) => setExcerpt(e.target.value)}
+              rows={2}
+              placeholder="1–2 Sätze, die den Eintrag zusammenfassen..."
+              className="w-full border border-surface-container-high rounded-lg px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container resize-none"
+            />
+          </div>
+        </>
+      )}
 
       {/* Private Notizen */}
       <div className="rounded-xl border border-dashed border-outline-variant bg-surface-container-low p-4 space-y-2">

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -21,6 +21,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
   const excerpt = entry.excerpt ?? ''
   const dayNumber = getDayNumber(entry.date, startDate)
   const perfect = isPerfectDay(entry.habits, entry.mealScore)
+  const isFiller = entry.entryType === 'filler'
 
   function formatDate(dateStr: string): string {
     return new Date(dateStr).toLocaleDateString(locale, {
@@ -30,12 +31,69 @@ export async function JournalCard({ entry }: JournalCardProps) {
     })
   }
 
+  const articleClass = `group backdrop-blur-xl rounded-xl overflow-hidden transition-colors duration-150 ${
+    perfect
+      ? 'bg-primary/5 border border-primary/40 hover:bg-primary/10 shadow-[0_0_24px_rgba(255,143,112,0.08)]'
+      : 'bg-surface-variant/40 border border-outline-variant/15 hover:bg-surface-variant/60'
+  }`
+
+  if (isFiller) {
+    return (
+      <article className={articleClass}>
+        {entry.banner ? (
+          <div className="relative w-full aspect-[16/7] bg-surface-container overflow-hidden">
+            <BannerImage
+              src={entry.banner}
+              alt={entry.title}
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 800px"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-background/70 to-transparent" />
+          </div>
+        ) : (
+          <div className="relative px-6 pt-5 pb-0 overflow-hidden select-none bg-surface-container-low" aria-hidden="true">
+            <span
+              className="block font-headline font-bold leading-none text-surface-container-highest"
+              style={{ fontSize: 'clamp(4.5rem, 18vw, 7.5rem)' }}
+            >
+              {String(dayNumber).padStart(2, '0')}
+            </span>
+          </div>
+        )}
+
+        <div className="px-5 py-4 space-y-3">
+          <div className="flex items-center gap-2.5 flex-wrap">
+            <span className="font-label font-bold text-xs tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2.5 py-0.5">
+              {t('day', { number: dayNumber })}
+            </span>
+            <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-on-surface-variant bg-surface-container-high border border-outline-variant/20 rounded px-2 py-0.5">
+              {t('fillerBadge')}
+            </span>
+            {perfect && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2 py-0.5">
+                ✦ {t('perfectDay')}
+              </span>
+            )}
+            <span className="text-outline-variant/60 select-none" aria-hidden="true">·</span>
+            <time className="text-xs font-label text-on-surface-variant" dateTime={entry.date}>
+              {formatDate(entry.date)}
+            </time>
+          </div>
+
+          <h2 className="font-headline text-xl sm:text-2xl font-bold leading-snug text-on-surface">
+            {entry.title}
+          </h2>
+
+          <div className="pt-2 border-t border-outline-variant/10">
+            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} />
+          </div>
+        </div>
+      </article>
+    )
+  }
+
   return (
-    <article className={`group backdrop-blur-xl rounded-xl overflow-hidden transition-colors duration-150 ${
-      perfect
-        ? 'bg-primary/5 border border-primary/40 hover:bg-primary/10 shadow-[0_0_24px_rgba(255,143,112,0.08)]'
-        : 'bg-surface-variant/40 border border-outline-variant/15 hover:bg-surface-variant/60'
-    }`}>
+    <article className={articleClass}>
       <Link href={`/journal/${entry.slug}`} className="block">
 
         {entry.banner ? (

--- a/src/components/journal/JournalCardHome.tsx
+++ b/src/components/journal/JournalCardHome.tsx
@@ -18,6 +18,7 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
 
   const dayNumber = getDayNumber(entry.date, startDate)
   const perfect = isPerfectDay(entry.habits, entry.mealScore)
+  const isFiller = entry.entryType === 'filler'
 
   const formattedDate = new Date(entry.date).toLocaleDateString(locale, {
     day: 'numeric',
@@ -25,12 +26,50 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
     year: 'numeric',
   })
 
+  const articleClass = `group flex flex-col backdrop-blur-xl rounded-xl overflow-hidden transition-colors duration-150 ${
+    perfect
+      ? 'bg-primary/5 border border-primary/40 hover:bg-primary/10 shadow-[0_0_24px_rgba(255,143,112,0.08)]'
+      : 'bg-surface-variant/40 border border-outline-variant/15 hover:bg-surface-variant/60'
+  }`
+
+  if (isFiller) {
+    return (
+      <article className={articleClass}>
+        <div className="flex flex-col flex-1 p-5 gap-3">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-on-surface-variant bg-surface-container-high border border-outline-variant/20 rounded px-2 py-0.5 mr-1">
+              {t('fillerBadge')}
+            </span>
+            {perfect && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2 py-0.5">
+                ✦ {t('perfectDay')}
+              </span>
+            )}
+            <span className="text-xs font-label font-bold tracking-widest uppercase text-outline">
+              {t('day', { number: dayNumber })}
+            </span>
+            <span className="text-outline-variant/60" aria-hidden="true">·</span>
+            <time className="text-xs font-label tracking-widest uppercase text-outline" dateTime={entry.date}>
+              {formattedDate}
+            </time>
+          </div>
+
+          <h2 className="text-2xl font-headline font-bold text-on-surface line-clamp-2">
+            {entry.title}
+          </h2>
+
+          <div className="flex-1" />
+        </div>
+
+        <div className="px-5 pb-4 pt-3 border-t border-outline-variant/10">
+          <ReactionBarCompact slug={entry.slug} />
+        </div>
+      </article>
+    )
+  }
+
   return (
-    <article className={`group flex flex-col backdrop-blur-xl rounded-xl overflow-hidden transition-colors duration-150 ${
-      perfect
-        ? 'bg-primary/5 border border-primary/40 hover:bg-primary/10 shadow-[0_0_24px_rgba(255,143,112,0.08)]'
-        : 'bg-surface-variant/40 border border-outline-variant/15 hover:bg-surface-variant/60'
-    }`}>
+    <article className={articleClass}>
       <Link href={`/journal/${entry.slug}`} className="flex flex-col flex-1 p-5 gap-3">
 
         {/* Date + Day number */}

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -1,4 +1,4 @@
-import { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
+import { MovementLevel, NutritionLevel, SmokingStatus, EntryType } from '@prisma/client'
 import type { JournalEntry as PrismaJournalEntry } from '@prisma/client'
 import { prisma } from './db'
 
@@ -13,6 +13,7 @@ const PROJECT_START = new Date('2026-03-26')
 export type MovementValue = 'minimal' | 'steps_only' | 'trained_only' | 'steps_trained'
 export type NutritionValue = 'none' | 'one_meal' | 'two_meals' | 'three_meals'
 export type SmokingValue = 'smoked' | 'nicotine_replacement' | 'smoke_free'
+export type EntryTypeValue = 'full' | 'filler'
 
 export interface HabitsFrontmatter {
   movement: MovementValue
@@ -30,6 +31,7 @@ export interface JournalEntry {
   habits: HabitsFrontmatter
   content: string
   excerpt?: string
+  entryType: EntryTypeValue
   sweetsConsumed?: boolean | null
   /**
    * Nutrition score (0–10) from the day's MealLog, when one exists. The enum
@@ -67,6 +69,11 @@ const SMOKING_TO_VALUE: Record<SmokingStatus, SmokingValue> = {
   SMOKE_FREE: 'smoke_free',
 }
 
+const ENTRY_TYPE_TO_VALUE: Record<EntryType, EntryTypeValue> = {
+  FULL: 'full',
+  FILLER: 'filler',
+}
+
 function toDateString(date: Date): string {
   return date.toISOString().slice(0, 10)
 }
@@ -90,6 +97,7 @@ function toMeta(entry: PrismaJournalEntry): JournalEntryMeta {
     banner: entry.bannerUrl ?? undefined,
     tags: entry.tags.length > 0 ? entry.tags : undefined,
     excerpt: entry.excerpt ?? undefined,
+    entryType: ENTRY_TYPE_TO_VALUE[entry.entryType],
     habits: {
       movement: MOVEMENT_TO_VALUE[entry.movement],
       nutrition: NUTRITION_TO_VALUE[entry.nutrition],


### PR DESCRIPTION
## Summary
- Adds an `EntryType` enum (`FULL` | `FILLER`) to JournalEntry, default `FULL` (existing entries unaffected)
- Filler entries carry habits, banner, mealScore and metadata but no body text — they keep the daily series complete without forcing a blog post
- Feed cards render fillers in a compact, non-clickable variant with a "Tagesnotiz" badge
- Detail route returns 404 for fillers; sitemap, RSS feed, search and translation flow exclude them
- Admin form: new "Eintrag-Typ" toggle hides Tiptap editor, excerpt and preview tab when set to Tagesnotiz; admin list shows the badge and hides translate/view actions

## Follow-up (separate PRs)
- PR-B: AI daily quote (`dailyQuote` field, Claude server action, render on filler card)
- PR-C: AI banner generation reused for fillers, with habits/metrics as input instead of body text

## Test plan
- [ ] Migration applies cleanly
- [ ] Existing entries still render and are accessible
- [ ] Create a new entry as `FILLER` — title + banner + habits required, no Tiptap, no excerpt
- [ ] Filler appears in feed with badge, no link, no read-more
- [ ] `/de/journal/<filler-slug>` returns 404
- [ ] Filler not listed in `/feed.xml`, sitemap, search, or translations admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)