### PR TITLE
feat: add AI-generated daily quote for entries

### DIFF
--- a/prisma/migrations/20260510180000_add_daily_quote/migration.sql
+++ b/prisma/migrations/20260510180000_add_daily_quote/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JournalEntry" ADD COLUMN "dailyQuote" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,10 @@ model JournalEntry {
   // im Feed kompakter dargestellt, Detailview ist nicht erreichbar.
   entryType EntryType @default(FULL)
 
+  // Optionales AI-generiertes Tageszitat. Wird primär auf Filler-Karten
+  // prominent angezeigt; bei vollständigen Einträgen rein dekorativ.
+  dailyQuote String? @db.Text
+
   // Die drei Säulen — direkt eingebettet
   movement  MovementLevel
   nutrition NutritionLevel

--- a/src/app/admin/entries/[id]/edit/page.tsx
+++ b/src/app/admin/entries/[id]/edit/page.tsx
@@ -29,6 +29,7 @@ export default async function EditEntryPage({ params }: EditEntryPageProps) {
     tags: entry.tags,
     published: entry.published,
     privateNotes: entry.privateNotes ?? '',
+    dailyQuote: entry.dailyQuote ?? '',
   }
 
   return (

--- a/src/app/admin/entries/actions.ts
+++ b/src/app/admin/entries/actions.ts
@@ -4,6 +4,9 @@ import { revalidatePath } from 'next/cache'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { translateEntry as translateEntryViaAI } from '@/lib/translate'
+import { generateDailyQuote as generateDailyQuoteAI, type DailyQuoteContext } from '@/lib/daily-quote'
+import { getDayNumber } from '@/lib/journal'
+import { getProjectStartDate } from '@/lib/project-config'
 import { MovementLevel, NutritionLevel, SmokingStatus, EntryType } from '@prisma/client'
 
 export interface EntryFormData {
@@ -20,6 +23,7 @@ export interface EntryFormData {
   tags: string[]
   published: boolean
   privateNotes?: string
+  dailyQuote?: string
 }
 
 export interface ActionResult {
@@ -68,6 +72,7 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
         tags: data.tags,
         published: data.published,
         privateNotes: data.privateNotes?.trim() || null,
+        dailyQuote: data.dailyQuote?.trim() || null,
       },
     })
 
@@ -110,6 +115,7 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
         tags: data.tags,
         published: data.published,
         privateNotes: data.privateNotes?.trim() || null,
+        dailyQuote: data.dailyQuote?.trim() || null,
       },
     })
 
@@ -138,6 +144,78 @@ export async function deleteEntry(id: string): Promise<ActionResult> {
   } catch (e) {
     console.error('deleteEntry:', e)
     return { error: 'Fehler beim Löschen' }
+  }
+}
+
+export interface QuoteContextInput {
+  date: string // YYYY-MM-DD
+  movement: MovementLevel
+  nutrition: NutritionLevel
+  smoking: SmokingStatus
+}
+
+export interface QuoteResult {
+  quote?: string
+  error?: string
+}
+
+const MOVEMENT_LABELS: Record<MovementLevel, string> = {
+  MINIMAL: 'unter 10k Schritten, kein Training',
+  STEPS_ONLY: '10k+ Schritte, kein Training',
+  TRAINED_ONLY: 'Training absolviert, unter 10k Schritte',
+  STEPS_TRAINED: '10k+ Schritte und Training',
+}
+
+const NUTRITION_LABELS: Record<NutritionLevel, string> = {
+  NONE: 'keine Mahlzeit erfasst',
+  ONE_MEAL: '1 Mahlzeit',
+  TWO_MEALS: '2 Mahlzeiten',
+  THREE_MEALS: '3 Mahlzeiten',
+}
+
+const SMOKING_LABELS: Record<SmokingStatus, string> = {
+  SMOKED: 'geraucht',
+  NICOTINE_REPLACEMENT: 'Nikotinersatz statt Zigarette',
+  SMOKE_FREE: 'rauchfrei ohne Hilfsmittel',
+}
+
+export async function generateQuoteForEntry(input: QuoteContextInput): Promise<QuoteResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return { error: 'ANTHROPIC_API_KEY nicht konfiguriert' }
+  }
+
+  try {
+    const date = new Date(input.date)
+    const [metrics, mealLog, startDate] = await Promise.all([
+      prisma.dailyMetrics.findUnique({
+        where: { date },
+        select: { steps: true, weight: true, bodyFat: true },
+      }),
+      prisma.mealLog.findUnique({ where: { date }, select: { score: true } }),
+      getProjectStartDate(),
+    ])
+
+    const ctx: DailyQuoteContext = {
+      date: input.date,
+      dayNumber: getDayNumber(input.date, startDate),
+      movement: MOVEMENT_LABELS[input.movement],
+      nutrition: NUTRITION_LABELS[input.nutrition],
+      smoking: SMOKING_LABELS[input.smoking],
+      steps: metrics?.steps,
+      weightKg: metrics?.weight,
+      bodyFatPct: metrics?.bodyFat,
+      mealScore: mealLog?.score,
+    }
+
+    const quote = await generateDailyQuoteAI(ctx)
+    return { quote }
+  } catch (e) {
+    console.error('generateQuoteForEntry:', e)
+    const message = e instanceof Error ? e.message : 'Generierung fehlgeschlagen'
+    return { error: message }
   }
 }
 

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -9,7 +9,7 @@ import { TiptapEditor } from './TiptapEditor'
 import { HabitsPicker } from './HabitsPicker'
 import { BannerUpload } from './BannerUpload'
 import { EntryPreview } from './EntryPreview'
-import { createEntry, updateEntry, type EntryFormData } from '@/app/admin/entries/actions'
+import { createEntry, updateEntry, generateQuoteForEntry, type EntryFormData } from '@/app/admin/entries/actions'
 
 // =============================================
 // Helper
@@ -65,8 +65,23 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
   const [tags, setTags] = useState<string>(initial?.tags?.join(', ') ?? '')
   const [published, setPublished] = useState(initial?.published ?? true)
   const [privateNotes, setPrivateNotes] = useState(initial?.privateNotes ?? '')
+  const [dailyQuote, setDailyQuote] = useState(initial?.dailyQuote ?? '')
+  const [quoteLoading, setQuoteLoading] = useState(false)
+  const [quoteError, setQuoteError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isPreview, setIsPreview] = useState(false)
+
+  async function handleGenerateQuote() {
+    setQuoteLoading(true)
+    setQuoteError(null)
+    const result = await generateQuoteForEntry({ date, movement, nutrition, smoking })
+    setQuoteLoading(false)
+    if (result.error) {
+      setQuoteError(result.error)
+      return
+    }
+    if (result.quote) setDailyQuote(result.quote)
+  }
 
   // Auto-generate slug from date when creating
   function handleDateChange(value: string) {
@@ -94,6 +109,7 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
       tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
       published,
       privateNotes,
+      dailyQuote,
     }
 
     startTransition(async () => {
@@ -280,6 +296,35 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
 
       {/* Banner-Bild */}
       <BannerUpload value={bannerUrl} onChange={setBannerUrl} slug={slug} title={title} excerpt={excerpt} />
+
+      {/* Tageszitat */}
+      <div className="rounded-xl border border-outline-variant/30 bg-surface-container-low p-4 space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <label className="flex items-center gap-1.5 text-xs font-medium text-on-surface-variant">
+            <span className="material-symbols-outlined text-base" style={{ fontVariationSettings: "'FILL' 0" }}>format_quote</span>
+            Tageszitat
+            <span className="font-normal ml-1">— optional, bei Tagesnotizen prominent angezeigt</span>
+          </label>
+          <button
+            type="button"
+            onClick={handleGenerateQuote}
+            disabled={quoteLoading}
+            className="text-xs px-3 py-1.5 border border-outline-variant/40 rounded-lg text-on-surface-variant hover:border-on-surface-variant hover:text-on-surface disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {quoteLoading ? 'Generiere…' : (dailyQuote ? 'Neu generieren' : 'Mit AI generieren')}
+          </button>
+        </div>
+        <textarea
+          value={dailyQuote}
+          onChange={(e) => setDailyQuote(e.target.value)}
+          rows={2}
+          placeholder="Ein kurzer Satz — frei formulierbar oder per AI generieren …"
+          className="w-full border border-outline-variant/30 rounded-lg px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-outline-variant bg-surface-container resize-none"
+        />
+        {quoteError && (
+          <p className="text-xs text-error">{quoteError}</p>
+        )}
+      </div>
 
       {!isFiller && (
         <>

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -84,6 +84,12 @@ export async function JournalCard({ entry }: JournalCardProps) {
             {entry.title}
           </h2>
 
+          {entry.dailyQuote && (
+            <blockquote className="border-l-2 border-primary/40 pl-3 py-1 text-sm font-headline italic text-on-surface-variant leading-relaxed">
+              {entry.dailyQuote}
+            </blockquote>
+          )}
+
           <div className="pt-2 border-t border-outline-variant/10">
             <HabitBadges habits={entry.habits} mealScore={entry.mealScore} />
           </div>

--- a/src/components/journal/JournalCardHome.tsx
+++ b/src/components/journal/JournalCardHome.tsx
@@ -58,7 +58,13 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
             {entry.title}
           </h2>
 
-          <div className="flex-1" />
+          {entry.dailyQuote ? (
+            <blockquote className="flex-1 border-l-2 border-primary/40 pl-3 py-1 text-sm font-headline italic text-on-surface-variant leading-relaxed line-clamp-4">
+              {entry.dailyQuote}
+            </blockquote>
+          ) : (
+            <div className="flex-1" />
+          )}
         </div>
 
         <div className="px-5 pb-4 pt-3 border-t border-outline-variant/10">

--- a/src/lib/daily-quote.ts
+++ b/src/lib/daily-quote.ts
@@ -1,0 +1,73 @@
+import Anthropic, { APIError } from '@anthropic-ai/sdk'
+
+const client = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+})
+
+export interface DailyQuoteContext {
+  date: string // YYYY-MM-DD
+  dayNumber?: number
+  movement: string // German label
+  nutrition: string
+  smoking: string
+  steps?: number | null
+  weightKg?: number | null
+  bodyFatPct?: number | null
+  mealScore?: number | null
+  movementStreak?: number
+  smokingStreak?: number
+  nutritionStreak?: number
+}
+
+const SYSTEM_PROMPT = `Du formulierst kurze, persönliche Tageszitate für ein deutschsprachiges Habit-Journal in der Ich-Form.
+
+Stilregeln:
+- Ein einzelner Satz, maximal 18 Wörter
+- Persönlich und reflektiert, kein motivierendes Pathos, keine Klischees
+- Beziehe dich auf konkrete Details des Tages (z. B. Schritte, Säulen, Streak), wenn vorhanden
+- Keine Anführungszeichen, keine Emojis, kein Datum, kein Absender
+- Antwort enthält ausschliesslich den Satz selbst, sonst nichts`
+
+function buildUserMessage(ctx: DailyQuoteContext): string {
+  const lines = [
+    `Datum: ${ctx.date}${ctx.dayNumber ? ` (Tag ${ctx.dayNumber})` : ''}`,
+    `Bewegung: ${ctx.movement}`,
+    `Ernährung: ${ctx.nutrition}`,
+    `Rauchstopp: ${ctx.smoking}`,
+  ]
+  if (ctx.steps != null) lines.push(`Schritte: ${ctx.steps.toLocaleString('de-CH')}`)
+  if (ctx.weightKg != null) lines.push(`Gewicht: ${ctx.weightKg.toFixed(1)} kg`)
+  if (ctx.bodyFatPct != null) lines.push(`Körperfett: ${ctx.bodyFatPct.toFixed(1)} %`)
+  if (ctx.mealScore != null) lines.push(`Ernährungs-Score: ${ctx.mealScore.toFixed(1)} / 10`)
+  if (ctx.movementStreak != null) lines.push(`Bewegungs-Streak: ${ctx.movementStreak} Tage`)
+  if (ctx.smokingStreak != null) lines.push(`Rauchstopp-Streak: ${ctx.smokingStreak} Tage`)
+  if (ctx.nutritionStreak != null) lines.push(`Ernährungs-Streak: ${ctx.nutritionStreak} Tage`)
+  return lines.join('\n')
+}
+
+export async function generateDailyQuote(ctx: DailyQuoteContext): Promise<string> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY nicht konfiguriert')
+  }
+
+  try {
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 200,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: buildUserMessage(ctx) }],
+    })
+
+    const block = message.content[0]
+    if (!block || block.type !== 'text') {
+      throw new Error('Unerwartete API-Antwort')
+    }
+
+    return block.text.trim().replace(/^["„»]+|["«"»]+$/g, '').trim()
+  } catch (e) {
+    if (e instanceof APIError) {
+      throw new Error(`Claude API Fehler: ${e.message}`)
+    }
+    throw e
+  }
+}

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -32,6 +32,7 @@ export interface JournalEntry {
   content: string
   excerpt?: string
   entryType: EntryTypeValue
+  dailyQuote?: string | null
   sweetsConsumed?: boolean | null
   /**
    * Nutrition score (0–10) from the day's MealLog, when one exists. The enum
@@ -98,6 +99,7 @@ function toMeta(entry: PrismaJournalEntry): JournalEntryMeta {
     tags: entry.tags.length > 0 ? entry.tags : undefined,
     excerpt: entry.excerpt ?? undefined,
     entryType: ENTRY_TYPE_TO_VALUE[entry.entryType],
+    dailyQuote: entry.dailyQuote ?? null,
     habits: {
       movement: MOVEMENT_TO_VALUE[entry.movement],
       nutrition: NUTRITION_TO_VALUE[entry.nutrition],


### PR DESCRIPTION
## Summary
- New optional `dailyQuote` field on `JournalEntry` (Text, nullable)
- New server action `generateQuoteForEntry` calls Claude Sonnet 4.6 with the day's habits + DailyMetrics + meal score and returns a single short German first-person sentence
- Admin form adds a "Tageszitat" block under the banner with a generate / regenerate button; the result is freely editable before saving
- Filler cards (home + journal feed) render the quote as a prominent italic blockquote; full entries carry it too if set
- New `lib/daily-quote.ts` mirrors the translate.ts SDK pattern

## Test plan
- [ ] Migration applies cleanly
- [ ] Existing entries unaffected (quote = null)
- [ ] Open a filler in admin → click "Mit AI generieren" → quote appears, is editable, persists on save
- [ ] Filler card shows the quote as a blockquote
- [ ] No quote → cards render unchanged
- [ ] Generation error (e.g. missing API key) shows inline error in admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)