### PR TITLE
feat: AI banner from habits and metrics for filler entries

### DIFF
--- a/src/app/api/admin/generate-banner/route.ts
+++ b/src/app/api/admin/generate-banner/route.ts
@@ -2,7 +2,36 @@ import { writeFile, mkdir } from 'fs/promises'
 import path from 'path'
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
-import { generateBannerImage } from '@/lib/banner-generate'
+import {
+  generateBannerImage,
+  generateBannerFromMetrics,
+  type MetricsBannerContext,
+} from '@/lib/banner-generate'
+import { prisma } from '@/lib/db'
+import { getDayNumber } from '@/lib/journal'
+import { getProjectStartDate } from '@/lib/project-config'
+
+interface TextRequest {
+  mode?: 'text'
+  title?: string
+  excerpt?: string
+  slug?: string
+}
+
+interface MetricsRequest {
+  mode: 'metrics'
+  slug?: string
+  date: string // YYYY-MM-DD
+  movement: MetricsBannerContext['movement']
+  nutrition: MetricsBannerContext['nutrition']
+  smoking: MetricsBannerContext['smoking']
+}
+
+type RequestBody = TextRequest | MetricsRequest
+
+function isMetrics(body: RequestBody): body is MetricsRequest {
+  return body.mode === 'metrics'
+}
 
 export async function POST(request: NextRequest) {
   const session = await requireAdmin()
@@ -10,23 +39,43 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 })
   }
 
-  let body: { title?: string; excerpt?: string; slug?: string }
+  let body: RequestBody
   try {
-    body = (await request.json()) as { title?: string; excerpt?: string; slug?: string }
+    body = (await request.json()) as RequestBody
   } catch {
     return NextResponse.json({ error: 'Ungültige Anfrage' }, { status: 400 })
   }
 
-  const { title, excerpt, slug } = body
-
-  if (!title?.trim()) {
-    return NextResponse.json({ error: 'Titel fehlt — bitte zuerst einen Titel eingeben' }, { status: 400 })
-  }
-
   try {
-    const imageBuffer = await generateBannerImage(title.trim(), excerpt?.trim() ?? '')
+    let imageBuffer: Buffer
 
-    const rawSlug = (slug ?? '').replace(/[^a-z0-9_-]/gi, '-').slice(0, 100)
+    if (isMetrics(body)) {
+      if (!body.date) {
+        return NextResponse.json({ error: 'Datum fehlt' }, { status: 400 })
+      }
+      const date = new Date(body.date)
+      const [metrics, mealLog, startDate] = await Promise.all([
+        prisma.dailyMetrics.findUnique({ where: { date }, select: { steps: true } }),
+        prisma.mealLog.findUnique({ where: { date }, select: { score: true } }),
+        getProjectStartDate(),
+      ])
+
+      imageBuffer = await generateBannerFromMetrics({
+        dayNumber: getDayNumber(body.date, startDate),
+        movement: body.movement,
+        nutrition: body.nutrition,
+        smoking: body.smoking,
+        steps: metrics?.steps,
+        mealScore: mealLog?.score,
+      })
+    } else {
+      if (!body.title?.trim()) {
+        return NextResponse.json({ error: 'Titel fehlt — bitte zuerst einen Titel eingeben' }, { status: 400 })
+      }
+      imageBuffer = await generateBannerImage(body.title.trim(), body.excerpt?.trim() ?? '')
+    }
+
+    const rawSlug = (body.slug ?? '').replace(/[^a-z0-9_-]/gi, '-').slice(0, 100)
     const filename = `${rawSlug || Date.now()}-ai.png`
 
     const uploadDir = path.join(process.cwd(), 'public', 'images', 'journal')

--- a/src/components/admin/BannerUpload.tsx
+++ b/src/components/admin/BannerUpload.tsx
@@ -2,15 +2,27 @@
 
 import { useRef, useState } from 'react'
 
+export interface BannerMetricsContext {
+  date: string
+  movement: 'MINIMAL' | 'STEPS_ONLY' | 'TRAINED_ONLY' | 'STEPS_TRAINED'
+  nutrition: 'NONE' | 'ONE_MEAL' | 'TWO_MEALS' | 'THREE_MEALS'
+  smoking: 'SMOKED' | 'NICOTINE_REPLACEMENT' | 'SMOKE_FREE'
+}
+
 interface BannerUploadProps {
   value: string | undefined
   onChange: (url: string | undefined) => void
   slug: string
   title?: string
   excerpt?: string
+  /**
+   * When set, AI generation uses habits + metrics for that date instead of
+   * the title/excerpt. Used for filler entries where there is no body text.
+   */
+  metricsContext?: BannerMetricsContext
 }
 
-export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUploadProps) {
+export function BannerUpload({ value, onChange, slug, title, excerpt, metricsContext }: BannerUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
   const [generating, setGenerating] = useState(false)
@@ -55,11 +67,22 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
     setError(null)
     setGenerating(true)
 
+    const payload = metricsContext
+      ? {
+          mode: 'metrics' as const,
+          slug,
+          date: metricsContext.date,
+          movement: metricsContext.movement,
+          nutrition: metricsContext.nutrition,
+          smoking: metricsContext.smoking,
+        }
+      : { title, excerpt, slug }
+
     try {
       const res = await fetch('/api/admin/generate-banner', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, excerpt, slug }),
+        body: JSON.stringify(payload),
       })
 
       const data = (await res.json()) as { url?: string; error?: string }
@@ -188,7 +211,9 @@ export function BannerUpload({ value, onChange, slug, title, excerpt }: BannerUp
                   />
                 </svg>
                 <span className="text-sm text-tertiary/80 font-medium">AI generieren</span>
-                <span className="text-xs text-on-surface-variant">aus Titel &amp; Inhalt</span>
+                <span className="text-xs text-on-surface-variant">
+                  {metricsContext ? 'aus Säulen & Metriken' : 'aus Titel & Inhalt'}
+                </span>
               </>
             )}
           </button>

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -294,8 +294,15 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
         )}
       </div>
 
-      {/* Banner-Bild */}
-      <BannerUpload value={bannerUrl} onChange={setBannerUrl} slug={slug} title={title} excerpt={excerpt} />
+      {/* Banner-Bild — Filler nutzt Säulen + Metriken statt Titel/Inhalt für AI */}
+      <BannerUpload
+        value={bannerUrl}
+        onChange={setBannerUrl}
+        slug={slug}
+        title={title}
+        excerpt={excerpt}
+        metricsContext={isFiller ? { date, movement, nutrition, smoking } : undefined}
+      />
 
       {/* Tageszitat */}
       <div className="rounded-xl border border-outline-variant/30 bg-surface-container-low p-4 space-y-2">

--- a/src/lib/banner-generate.ts
+++ b/src/lib/banner-generate.ts
@@ -7,6 +7,65 @@ function getClient(): OpenAI {
   return new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
 }
 
+export interface MetricsBannerContext {
+  dayNumber?: number
+  movement: 'MINIMAL' | 'STEPS_ONLY' | 'TRAINED_ONLY' | 'STEPS_TRAINED'
+  nutrition: 'NONE' | 'ONE_MEAL' | 'TWO_MEALS' | 'THREE_MEALS'
+  smoking: 'SMOKED' | 'NICOTINE_REPLACEMENT' | 'SMOKE_FREE'
+  mealScore?: number | null
+  steps?: number | null
+}
+
+function moodForMovement(level: MetricsBannerContext['movement'], steps?: number | null): string {
+  if (level === 'STEPS_TRAINED') return 'kinetic momentum, sustained motion, energy'
+  if (level === 'TRAINED_ONLY') return 'focused exertion, controlled intensity'
+  if (level === 'STEPS_ONLY') return 'steady rhythm, walking forward, persistence'
+  return steps != null && steps > 5000 ? 'low movement, drag, weight' : 'stillness, dormancy, quiet'
+}
+
+function moodForNutrition(level: MetricsBannerContext['nutrition'], score?: number | null): string {
+  if (score != null) {
+    if (score >= 8) return 'nourished warmth, balance, fullness'
+    if (score >= 5) return 'mixed signals, partial nourishment'
+    return 'depletion, scarcity, hollow'
+  }
+  if (level === 'THREE_MEALS') return 'nourished warmth, balance'
+  if (level === 'TWO_MEALS') return 'measured sustenance'
+  if (level === 'ONE_MEAL') return 'sparse nourishment'
+  return 'hunger, void, scarcity'
+}
+
+function moodForSmoking(level: MetricsBannerContext['smoking']): string {
+  if (level === 'SMOKE_FREE') return 'clear breath, openness, freedom'
+  if (level === 'NICOTINE_REPLACEMENT') return 'controlled willpower, focus, restraint'
+  return 'gravity, return, lingering weight'
+}
+
+function buildMetricsPrompt(ctx: MetricsBannerContext): string {
+  const moods = [
+    moodForMovement(ctx.movement, ctx.steps),
+    moodForNutrition(ctx.nutrition, ctx.mealScore),
+    moodForSmoking(ctx.smoking),
+  ]
+
+  return `Create a wide cinematic abstract banner image for ${
+    ctx.dayNumber ? `day ${ctx.dayNumber} of ` : ''
+  }a personal habit-tracking journey.
+
+Mood signals for today: ${moods.join('; ')}.
+
+Style requirements:
+- Dark, moody atmosphere with deep blacks and dark grays as the base
+- Warm accent lighting in orange (#ff8f70) and coral tones
+- Cinematic wide-format composition (horizontal, landscape orientation)
+- Pure abstract — no figures, no objects, no text, no letters, no symbols
+- Dramatic light, shadow, gradients, atmospheric haze, painterly textures
+- Minimal, introspective, reminiscent of dark editorial photography and abstract digital art
+- Inspired by: cinematic stills, light studies, atmospheric paintings
+
+Translate the mood signals into pure atmosphere — let light, color and texture express the emotional weight of those signals without depicting anything literal.`
+}
+
 function buildPrompt(title: string, excerpt: string): string {
   return `Create a wide cinematic banner image for a personal journal entry.
 
@@ -26,10 +85,10 @@ Style requirements:
 The image should feel personal, introspective, and visually match the emotional tone of the journal entry.`
 }
 
-export async function generateBannerImage(title: string, excerpt: string): Promise<Buffer> {
+async function generateFromPrompt(prompt: string): Promise<Buffer> {
   const response = await getClient().images.generate({
     model: 'dall-e-3',
-    prompt: buildPrompt(title, excerpt),
+    prompt,
     n: 1,
     size: '1792x1024',
     quality: 'standard',
@@ -40,6 +99,14 @@ export async function generateBannerImage(title: string, excerpt: string): Promi
   if (!b64) throw new Error('DALL-E hat kein Bild zurückgegeben')
 
   return Buffer.from(b64, 'base64')
+}
+
+export async function generateBannerImage(title: string, excerpt: string): Promise<Buffer> {
+  return generateFromPrompt(buildPrompt(title, excerpt))
+}
+
+export async function generateBannerFromMetrics(ctx: MetricsBannerContext): Promise<Buffer> {
+  return generateFromPrompt(buildMetricsPrompt(ctx))
 }
 
 // Legacy SVG-Generator — wird nicht mehr verwendet, bleibt für Fallback


### PR DESCRIPTION
## Summary
- Adds a `metrics` mode to `/api/admin/generate-banner` that takes `{ date, movement, nutrition, smoking }`, looks up steps + meal score for that date, and feeds the day's mood signals to DALL-E instead of the entry title/excerpt
- Filler entries pass `metricsContext` to `BannerUpload`, which switches the request shape and updates the helper text from "aus Titel & Inhalt" to "aus Säulen & Metriken"
- Visual aesthetic stays identical: dark base, warm orange/coral accents, abstract — only the prompt source changes
- Full entries unchanged

## Test plan
- [ ] Switch entry to "Tagesnotiz" in admin → banner placeholder shows "aus Säulen & Metriken"
- [ ] Click AI generate → DALL-E returns an abstract image, no figures or text
- [ ] Repeat with different habits → image mood reflects the change
- [ ] Full entry still generates from title/excerpt as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)