### PR TITLE
feat: auto-generate filler title and hide tags

### DIFF
--- a/src/app/admin/entries/actions.ts
+++ b/src/app/admin/entries/actions.ts
@@ -31,6 +31,15 @@ export interface ActionResult {
   slug?: string
 }
 
+function fillerTitleForDate(dateStr: string): string {
+  const formatted = new Date(dateStr).toLocaleDateString('de-CH', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+  return `Tagesnotiz – ${formatted}`
+}
+
 function extractExcerpt(html: string, maxLength = 160): string {
   const text = html
     .replace(/<[^>]+>/g, ' ')
@@ -43,12 +52,12 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
   const session = await requireAdmin()
   if (!session) return { error: 'Nicht autorisiert' }
 
-  if (!data.title.trim()) return { error: 'Titel ist erforderlich' }
   if (!data.slug.trim()) return { error: 'Slug ist erforderlich' }
   if (!data.date) return { error: 'Datum ist erforderlich' }
   const isFiller = data.entryType === 'FILLER'
-  if (!isFiller && (!data.content || data.content === '<p></p>')) {
-    return { error: 'Inhalt ist erforderlich' }
+  if (!isFiller) {
+    if (!data.title.trim()) return { error: 'Titel ist erforderlich' }
+    if (!data.content || data.content === '<p></p>') return { error: 'Inhalt ist erforderlich' }
   }
 
   const existing = await prisma.journalEntry.findUnique({ where: { slug: data.slug } })
@@ -57,7 +66,7 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
   try {
     await prisma.journalEntry.create({
       data: {
-        title: data.title.trim(),
+        title: isFiller ? fillerTitleForDate(data.date) : data.title.trim(),
         slug: data.slug.trim(),
         date: new Date(data.date),
         content: isFiller ? '' : data.content,
@@ -69,7 +78,7 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
         movement: data.movement,
         nutrition: data.nutrition,
         smoking: data.smoking,
-        tags: data.tags,
+        tags: isFiller ? [] : data.tags,
         published: data.published,
         privateNotes: data.privateNotes?.trim() || null,
         dailyQuote: data.dailyQuote?.trim() || null,
@@ -91,17 +100,17 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
   const session = await requireAdmin()
   if (!session) return { error: 'Nicht autorisiert' }
 
-  if (!data.title.trim()) return { error: 'Titel ist erforderlich' }
   const isFiller = data.entryType === 'FILLER'
-  if (!isFiller && (!data.content || data.content === '<p></p>')) {
-    return { error: 'Inhalt ist erforderlich' }
+  if (!isFiller) {
+    if (!data.title.trim()) return { error: 'Titel ist erforderlich' }
+    if (!data.content || data.content === '<p></p>') return { error: 'Inhalt ist erforderlich' }
   }
 
   try {
     const entry = await prisma.journalEntry.update({
       where: { id },
       data: {
-        title: data.title.trim(),
+        title: isFiller ? fillerTitleForDate(data.date) : data.title.trim(),
         date: new Date(data.date),
         content: isFiller ? '' : data.content,
         excerpt: isFiller
@@ -112,7 +121,7 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
         movement: data.movement,
         nutrition: data.nutrition,
         smoking: data.smoking,
-        tags: data.tags,
+        tags: isFiller ? [] : data.tags,
         published: data.published,
         privateNotes: data.privateNotes?.trim() || null,
         dailyQuote: data.dailyQuote?.trim() || null,

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -177,17 +177,19 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
         </div>
       )}
 
-      {/* Titel */}
-      <div>
-        <input
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Titel des Eintrags"
-          required
-          className="w-full font-headline text-2xl font-bold bg-transparent border-0 border-b-2 border-surface-container-high focus:border-nutrition-500 focus:outline-none pb-2 text-on-surface placeholder:text-outline transition-colors"
-        />
-      </div>
+      {/* Titel — bei Tagesnotizen automatisch gesetzt, daher versteckt */}
+      {!isFiller && (
+        <div>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Titel des Eintrags"
+            required
+            className="w-full font-headline text-2xl font-bold bg-transparent border-0 border-b-2 border-surface-container-high focus:border-nutrition-500 focus:outline-none pb-2 text-on-surface placeholder:text-outline transition-colors"
+          />
+        </div>
+      )}
 
       {/* Datum + Slug + Veröffentlicht */}
       <div className="flex flex-wrap items-end gap-4">
@@ -244,19 +246,21 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
         </div>
       </div>
 
-      {/* Tags */}
-      <div>
-        <label className="block text-xs font-medium text-on-surface-variant mb-1">
-          Tags <span className="text-on-surface-variant font-normal">(kommagetrennt, optional)</span>
-        </label>
-        <input
-          type="text"
-          value={tags}
-          onChange={(e) => setTags(e.target.value)}
-          placeholder="motivation, training, ernährung"
-          className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
-        />
-      </div>
+      {/* Tags — bei Tagesnotizen ausgeblendet */}
+      {!isFiller && (
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">
+            Tags <span className="text-on-surface-variant font-normal">(kommagetrennt, optional)</span>
+          </label>
+          <input
+            type="text"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="motivation, training, ernährung"
+            className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
+          />
+        </div>
+      )}
 
       {/* Eintrag-Typ */}
       <div>

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -80,12 +80,8 @@ export async function JournalCard({ entry }: JournalCardProps) {
             </time>
           </div>
 
-          <h2 className="font-headline text-xl sm:text-2xl font-bold leading-snug text-on-surface">
-            {entry.title}
-          </h2>
-
           {entry.dailyQuote && (
-            <blockquote className="border-l-2 border-primary/40 pl-3 py-1 text-sm font-headline italic text-on-surface-variant leading-relaxed">
+            <blockquote className="border-l-2 border-primary/40 pl-3 py-1 text-base font-headline italic text-on-surface leading-relaxed">
               {entry.dailyQuote}
             </blockquote>
           )}

--- a/src/components/journal/JournalCardHome.tsx
+++ b/src/components/journal/JournalCardHome.tsx
@@ -54,12 +54,8 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
             </time>
           </div>
 
-          <h2 className="text-2xl font-headline font-bold text-on-surface line-clamp-2">
-            {entry.title}
-          </h2>
-
           {entry.dailyQuote ? (
-            <blockquote className="flex-1 border-l-2 border-primary/40 pl-3 py-1 text-sm font-headline italic text-on-surface-variant leading-relaxed line-clamp-4">
+            <blockquote className="flex-1 border-l-2 border-primary/40 pl-3 py-1 text-base font-headline italic text-on-surface leading-relaxed line-clamp-5">
               {entry.dailyQuote}
             </blockquote>
           ) : (


### PR DESCRIPTION
## Summary
- Title input and tags input are hidden in the admin form when entry type is Tagesnotiz
- Server actions auto-set title to `Tagesnotiz – DD.MM.YYYY` and force tags to `[]` for fillers; required-field checks for title and content are skipped for fillers
- Filler feed cards drop the redundant `<h2>` — the daily quote is now the primary text element

## Test plan
- [ ] Switch to Tagesnotiz: title and tags fields disappear
- [ ] Save with no title → succeeds; record has auto title and empty tags
- [ ] Filler card shows badge + date + quote (no h2)
- [ ] Switching back to Vollständiger Eintrag re-shows fields and re-requires title

🤖 Generated with [Claude Code](https://claude.com/claude-code)