### PR TITLE
feat: translate daily quote to EN and PT

### DIFF
--- a/prisma/migrations/20260510190000_translation_daily_quote/migration.sql
+++ b/prisma/migrations/20260510190000_translation_daily_quote/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Translation" ADD COLUMN "dailyQuote" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,15 +61,16 @@ model JournalEntry {
 // =============================================
 
 model Translation {
-  id        String       @id @default(cuid())
-  entryId   String
-  locale    String       @default("en")
-  title     String
-  content   String       @db.Text
-  excerpt   String?
-  entry     JournalEntry @relation(fields: [entryId], references: [id], onDelete: Cascade)
-  createdAt DateTime     @default(now())
-  updatedAt DateTime     @updatedAt
+  id         String       @id @default(cuid())
+  entryId    String
+  locale     String       @default("en")
+  title      String
+  content    String       @db.Text
+  excerpt    String?
+  dailyQuote String?      @db.Text
+  entry      JournalEntry @relation(fields: [entryId], references: [id], onDelete: Cascade)
+  createdAt  DateTime     @default(now())
+  updatedAt  DateTime     @updatedAt
 
   @@unique([entryId, locale])
 }

--- a/src/app/admin/entries/actions.ts
+++ b/src/app/admin/entries/actions.ts
@@ -238,36 +238,51 @@ export async function translateEntry(id: string, locale: 'en' | 'pt' = 'en'): Pr
 
   const entry = await prisma.journalEntry.findUnique({ where: { id } })
   if (!entry) return { error: 'Eintrag nicht gefunden' }
-  if (entry.entryType === 'FILLER') {
-    return { error: 'Tagesnotizen werden nicht übersetzt' }
+
+  const isFiller = entry.entryType === 'FILLER'
+  if (isFiller && !entry.dailyQuote) {
+    return { error: 'Tagesnotiz hat kein Zitat zum Übersetzen' }
   }
 
   try {
-    const translated = await translateEntryViaAI({
-      title: entry.title,
-      content: entry.content,
-      excerpt: entry.excerpt,
-    }, locale)
+    const translated = await translateEntryViaAI(
+      isFiller
+        ? { dailyQuote: entry.dailyQuote }
+        : {
+            title: entry.title,
+            content: entry.content,
+            excerpt: entry.excerpt,
+            dailyQuote: entry.dailyQuote,
+          },
+      locale,
+    )
 
+    // Translation rows require title + content (NOT NULL). For fillers we
+    // persist the German auto-title and an empty content body — neither is
+    // ever surfaced because filler detail pages 404.
     await prisma.translation.upsert({
       where: { entryId_locale: { entryId: id, locale } },
       create: {
         entryId: id,
         locale,
-        title: translated.title,
-        content: translated.content,
-        excerpt: translated.excerpt,
+        title: translated.title ?? entry.title,
+        content: translated.content ?? '',
+        excerpt: translated.excerpt ?? null,
+        dailyQuote: translated.dailyQuote ?? null,
       },
       update: {
-        title: translated.title,
-        content: translated.content,
-        excerpt: translated.excerpt,
+        title: translated.title ?? entry.title,
+        content: translated.content ?? '',
+        excerpt: translated.excerpt ?? null,
+        dailyQuote: translated.dailyQuote ?? null,
         updatedAt: new Date(),
       },
     })
 
     revalidatePath('/admin/entries')
     revalidatePath(`/${locale}/journal/${entry.slug}`)
+    revalidatePath(`/${locale}`)
+    revalidatePath(`/${locale}/journal`)
 
     return {}
   } catch (e) {

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -27,6 +27,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
         date: true,
         published: true,
         entryType: true,
+        dailyQuote: true,
         updatedAt: true,
         movement: true,
         nutrition: true,
@@ -98,22 +99,22 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0">
+                  {(entry.entryType !== 'FILLER' || entry.dailyQuote) && (
+                    <TranslateButton
+                      id={entry.id}
+                      entryUpdatedAt={entry.updatedAt}
+                      enTranslation={enTranslation}
+                      ptTranslation={ptTranslation}
+                    />
+                  )}
                   {entry.entryType !== 'FILLER' && (
-                    <>
-                      <TranslateButton
-                        id={entry.id}
-                        entryUpdatedAt={entry.updatedAt}
-                        enTranslation={enTranslation}
-                        ptTranslation={ptTranslation}
-                      />
-                      <Link
-                        href={`/journal/${entry.slug}`}
-                        target="_blank"
-                        className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
-                      >
-                        Ansehen ↗
-                      </Link>
-                    </>
+                    <Link
+                      href={`/journal/${entry.slug}`}
+                      target="_blank"
+                      className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
+                    >
+                      Ansehen ↗
+                    </Link>
                   )}
                   <Link
                     href={`/admin/entries/${entry.id}/edit`}

--- a/src/app/admin/translations/page.tsx
+++ b/src/app/admin/translations/page.tsx
@@ -54,7 +54,12 @@ function formatDate(date: Date): string {
 export default async function TranslationsPage() {
   const [entries, startDate] = await Promise.all([
     prisma.journalEntry.findMany({
-      where: { entryType: 'FULL' },
+      where: {
+        OR: [
+          { entryType: 'FULL' },
+          { entryType: 'FILLER', dailyQuote: { not: null } },
+        ],
+      },
       orderBy: { date: 'desc' },
       select: {
         id: true,

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -169,6 +169,7 @@ export async function getAllEntriesForLocale(locale: string): Promise<JournalEnt
     if (translation) {
       meta.title = translation.title
       if (translation.excerpt) meta.excerpt = translation.excerpt
+      if (translation.dailyQuote) meta.dailyQuote = translation.dailyQuote
     }
     return meta
   })

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -5,15 +5,17 @@ const client = new Anthropic({
 })
 
 export interface TranslationInput {
-  title: string
-  content: string // HTML
+  title?: string
+  content?: string // HTML
   excerpt?: string | null
+  dailyQuote?: string | null
 }
 
 export interface TranslationOutput {
-  title: string
-  content: string // HTML, tags preserved
-  excerpt: string
+  title?: string
+  content?: string // HTML, tags preserved
+  excerpt?: string
+  dailyQuote?: string
 }
 
 const SYSTEM_PROMPT_EN = `You are a professional German-to-English translator specializing in personal blog and diary entries.
@@ -21,73 +23,36 @@ const SYSTEM_PROMPT_EN = `You are a professional German-to-English translator sp
 Your task:
 - Translate the JSON object you receive from German to English
 - Preserve the authentic, first-person voice and personal tone
+- Translate ONLY the fields that are present in the input. Possible fields: "title", "content", "excerpt", "dailyQuote"
 - The "content" field contains HTML — preserve ALL HTML tags exactly as-is, only translate the visible text between tags
+- The "dailyQuote" field is a single short reflective sentence in first person — keep it short, natural, and ideally one sentence
 - Keep numbers, dates, units (kg, km, etc.) and proper nouns unchanged
-- Return ONLY a valid JSON object with keys "title", "content", and "excerpt" — no other text, no markdown, no code fences`
+- Return ONLY a valid JSON object containing exactly the same keys as the input — no other text, no markdown, no code fences`
 
 const SYSTEM_PROMPT_PT = `You are a professional German-to-Brazilian Portuguese translator specializing in personal blog and diary entries.
 
 Your task:
 - Translate the JSON object you receive from German to Brazilian Portuguese (pt-BR)
 - Preserve the authentic, first-person voice and personal tone
+- Translate ONLY the fields that are present in the input. Possible fields: "title", "content", "excerpt", "dailyQuote"
 - The "content" field contains HTML — preserve ALL HTML tags exactly as-is, only translate the visible text between tags
+- The "dailyQuote" field is a single short reflective sentence in first person — keep it short, natural, and ideally one sentence
 - Keep numbers, dates, units (kg, km, etc.) and proper nouns unchanged
 - Use Brazilian Portuguese (Brazil) conventions, not European Portuguese
-- Return ONLY a valid JSON object with keys "title", "content", and "excerpt" — no other text, no markdown, no code fences`
+- Return ONLY a valid JSON object containing exactly the same keys as the input — no other text, no markdown, no code fences`
 
-/** @deprecated Use translateEntry with locale parameter */
-export async function translateEntryToEnglish(input: TranslationInput): Promise<TranslationOutput> {
-  const payload = {
-    title: input.title,
-    content: input.content,
-    excerpt: input.excerpt ?? '',
-  }
-
-  try {
-    const message = await client.messages.create({
-      model: 'claude-sonnet-4-6',
-      max_tokens: 8192,
-      system: SYSTEM_PROMPT_EN,
-      messages: [
-        {
-          role: 'user',
-          content: JSON.stringify(payload),
-        },
-      ],
-    })
-
-    const raw = message.content[0]
-    if (raw.type !== 'text') throw new Error('Unexpected response type from Claude')
-
-    // Strip possible markdown code fences in case the model adds them
-    const jsonText = raw.text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim()
-
-    const parsed = JSON.parse(jsonText) as TranslationOutput
-
-    if (!parsed.title || !parsed.content) {
-      throw new Error('Invalid translation response: missing required fields')
-    }
-
-    return {
-      title: parsed.title,
-      content: parsed.content,
-      excerpt: parsed.excerpt || '',
-    }
-  } catch (e) {
-    if (e instanceof APIError) {
-      // Surface the Anthropic error message directly (e.g. "credit balance too low")
-      throw new Error(e.message)
-    }
-    throw e
-  }
+function buildPayload(input: TranslationInput): Record<string, string> {
+  const payload: Record<string, string> = {}
+  if (input.title) payload.title = input.title
+  if (input.content) payload.content = input.content
+  if (input.excerpt) payload.excerpt = input.excerpt
+  if (input.dailyQuote) payload.dailyQuote = input.dailyQuote
+  return payload
 }
 
 async function callClaude(systemPrompt: string, input: TranslationInput): Promise<TranslationOutput> {
-  const payload = {
-    title: input.title,
-    content: input.content,
-    excerpt: input.excerpt ?? '',
-  }
+  const payload = buildPayload(input)
+  if (Object.keys(payload).length === 0) return {}
 
   try {
     const message = await client.messages.create({
@@ -103,26 +68,22 @@ async function callClaude(systemPrompt: string, input: TranslationInput): Promis
     const jsonText = raw.text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim()
     const parsed = JSON.parse(jsonText) as TranslationOutput
 
-    if (!parsed.title || !parsed.content) {
-      throw new Error('Invalid translation response: missing required fields')
+    return {
+      title: parsed.title,
+      content: parsed.content,
+      excerpt: parsed.excerpt,
+      dailyQuote: parsed.dailyQuote,
     }
-
-    return { title: parsed.title, content: parsed.content, excerpt: parsed.excerpt || '' }
   } catch (e) {
     if (e instanceof APIError) throw new Error(e.message)
     throw e
   }
 }
 
-export async function translateEntryToPortuguese(input: TranslationInput): Promise<TranslationOutput> {
-  return callClaude(SYSTEM_PROMPT_PT, input)
-}
-
-/** Translate a journal entry to the given locale. */
+/** Translate a journal entry (or just its quote, for fillers) to the given locale. */
 export async function translateEntry(
   input: TranslationInput,
   locale: 'en' | 'pt',
 ): Promise<TranslationOutput> {
-  if (locale === 'pt') return translateEntryToPortuguese(input)
-  return translateEntryToEnglish(input)
+  return callClaude(locale === 'pt' ? SYSTEM_PROMPT_PT : SYSTEM_PROMPT_EN, input)
 }


### PR DESCRIPTION
## Summary
- Adds a `dailyQuote` column on the `Translation` model
- `lib/translate.ts` rewritten to translate only the fields present in the input — fillers send `{ dailyQuote }`, full entries send `{ title, content, excerpt, dailyQuote }`
- Translate action no longer rejects fillers; it requires a quote to be present
- `getAllEntriesForLocale` maps the translated quote onto `JournalEntryMeta.dailyQuote` so feed cards render the localized text
- Admin entries list shows the Translate button for fillers with a quote; the translations admin page lists them too

## Test plan
- [ ] Migration applies cleanly
- [ ] Create a filler with a German quote → translate to EN → card on `/en` shows English quote
- [ ] Same for PT
- [ ] Translate a full entry with both content and quote → both are translated
- [ ] Filler without a quote: translate button hidden, action returns "kein Zitat zum Übersetzen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)