### PR TITLE
feat: post entries to social media via Postiz

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,12 @@ ANTHROPIC_API_KEY=""
 # https://platform.openai.com/api-keys
 OPENAI_API_KEY=""
 
+# --- Postiz (selbst-gehostetes Social-Media Posting) ---
+# Self-hosted Postiz instance, z.B. https://postiz.dom42.ch/api/public/v1
+# API-Key: Postiz Settings → API Keys → Generate
+POSTIZ_API_URL=""
+POSTIZ_API_KEY=""
+
 # --- Analytics (Privacy-first, selbst gehostet) ---
 # Schützt /api/internal/* Routen
 INTERNAL_SECRET=""

--- a/src/app/admin/entries/social-actions.ts
+++ b/src/app/admin/entries/social-actions.ts
@@ -1,0 +1,73 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { SITE_URL } from '@/lib/site'
+import {
+  listIntegrations,
+  createPost,
+  type PostizIntegration,
+} from '@/lib/postiz'
+export interface ChannelsResult {
+  integrations?: PostizIntegration[]
+  error?: string
+}
+
+export async function listSocialChannels(): Promise<ChannelsResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  try {
+    const integrations = await listIntegrations()
+    return { integrations: integrations.filter((i) => !i.disabled) }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'Fehler beim Laden der Channels' }
+  }
+}
+
+export interface PublishInput {
+  entryId: string
+  integrationIds: string[]
+  caption: string
+}
+
+export interface PublishResult {
+  ok?: boolean
+  error?: string
+}
+
+export async function publishEntryToSocial(input: PublishInput): Promise<PublishResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  if (!input.caption.trim()) return { error: 'Text ist leer' }
+  if (input.integrationIds.length === 0) return { error: 'Mindestens ein Channel auswählen' }
+
+  const entry = await prisma.journalEntry.findUnique({
+    where: { id: input.entryId },
+    select: { bannerUrl: true },
+  })
+  if (!entry) return { error: 'Eintrag nicht gefunden' }
+
+  // Banner: relative URLs müssen für Postiz absolut sein, damit /upload-from-url
+  // sie fetchen kann. Externe URLs werden direkt durchgereicht.
+  let imageUrl: string | undefined
+  if (entry.bannerUrl) {
+    imageUrl = entry.bannerUrl.startsWith('http')
+      ? entry.bannerUrl
+      : `${SITE_URL}${entry.bannerUrl}`
+  }
+
+  try {
+    await createPost({
+      integrationIds: input.integrationIds,
+      content: input.caption,
+      imageUrl,
+      type: 'now',
+    })
+    return { ok: true }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'Posting fehlgeschlagen' }
+  }
+}
+

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -10,6 +10,8 @@ import { HabitsPicker } from './HabitsPicker'
 import { BannerUpload } from './BannerUpload'
 import { EntryPreview } from './EntryPreview'
 import { createEntry, updateEntry, generateQuoteForEntry, type EntryFormData } from '@/app/admin/entries/actions'
+import { defaultCaption } from '@/lib/social-caption'
+import { SocialPostDialog } from './SocialPostDialog'
 
 // =============================================
 // Helper
@@ -70,6 +72,7 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
   const [quoteError, setQuoteError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isPreview, setIsPreview] = useState(false)
+  const [showSocialDialog, setShowSocialDialog] = useState(false)
 
   async function handleGenerateQuote() {
     setQuoteLoading(true)
@@ -403,18 +406,43 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
         >
           ← Abbrechen
         </button>
-        <button
-          type="submit"
-          disabled={isPending}
-          className="px-6 py-2.5 bg-nutrition-600 text-white rounded-xl text-sm font-medium hover:bg-nutrition-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {isPending
-            ? 'Speichern...'
-            : mode === 'create'
-            ? 'Eintrag erstellen'
-            : 'Änderungen speichern'}
-        </button>
+        <div className="flex items-center gap-2">
+          {mode === 'edit' && entryId && (
+            <button
+              type="button"
+              onClick={() => setShowSocialDialog(true)}
+              className="px-4 py-2.5 border border-outline-variant/40 text-on-surface rounded-xl text-sm font-medium hover:border-on-surface-variant transition-colors"
+            >
+              An Social Media senden
+            </button>
+          )}
+          <button
+            type="submit"
+            disabled={isPending}
+            className="px-6 py-2.5 bg-nutrition-600 text-white rounded-xl text-sm font-medium hover:bg-nutrition-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isPending
+              ? 'Speichern...'
+              : mode === 'create'
+              ? 'Eintrag erstellen'
+              : 'Änderungen speichern'}
+          </button>
+        </div>
       </div>
+
+      {showSocialDialog && entryId && (
+        <SocialPostDialog
+          entryId={entryId}
+          defaultCaption={defaultCaption({
+            title,
+            slug,
+            excerpt: excerpt || null,
+            dailyQuote: dailyQuote || null,
+            entryType,
+          })}
+          onClose={() => setShowSocialDialog(false)}
+        />
+      )}
     </form>
       )}
     </div>

--- a/src/components/admin/SocialPostDialog.tsx
+++ b/src/components/admin/SocialPostDialog.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useEffect, useState, useTransition } from 'react'
+import { clsx } from 'clsx'
+import { listSocialChannels, publishEntryToSocial } from '@/app/admin/entries/social-actions'
+
+interface PostizIntegration {
+  id: string
+  name: string
+  identifier: string
+  picture?: string
+  profile?: string
+}
+
+interface Props {
+  entryId: string
+  defaultCaption: string
+  onClose: () => void
+}
+
+const PLATFORM_LABELS: Record<string, string> = {
+  bluesky: 'Bluesky',
+  instagram: 'Instagram',
+  threads: 'Threads',
+  twitter: 'X / Twitter',
+  mastodon: 'Mastodon',
+  linkedin: 'LinkedIn',
+  facebook: 'Facebook',
+}
+
+function platformLabel(identifier: string): string {
+  return PLATFORM_LABELS[identifier] ?? identifier
+}
+
+export function SocialPostDialog({ entryId, defaultCaption, onClose }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [integrations, setIntegrations] = useState<PostizIntegration[]>([])
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [caption, setCaption] = useState(defaultCaption)
+  const [feedback, setFeedback] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    let cancelled = false
+    listSocialChannels().then((result) => {
+      if (cancelled) return
+      if (result.error) {
+        setLoadError(result.error)
+      } else if (result.integrations) {
+        setIntegrations(result.integrations)
+        setSelected(new Set(result.integrations.map((i) => i.id)))
+      }
+      setLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function handleSend() {
+    setFeedback(null)
+    startTransition(async () => {
+      const result = await publishEntryToSocial({
+        entryId,
+        integrationIds: Array.from(selected),
+        caption,
+      })
+      if (result.error) {
+        setFeedback({ kind: 'error', text: result.error })
+      } else {
+        setFeedback({ kind: 'ok', text: 'Erfolgreich gepostet' })
+      }
+    })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="w-full max-w-lg rounded-xl bg-surface-container border border-outline-variant/20 p-5 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between">
+          <h2 className="font-headline text-lg font-bold text-on-surface">An Social Media senden</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-on-surface-variant hover:text-on-surface text-sm"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Channels */}
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1.5">Channels</label>
+          {loading ? (
+            <p className="text-sm text-on-surface-variant">Lade Channels …</p>
+          ) : loadError ? (
+            <p className="text-sm text-error">{loadError}</p>
+          ) : integrations.length === 0 ? (
+            <p className="text-sm text-on-surface-variant">
+              Keine Channels in Postiz verbunden. Verbinde zuerst ein Konto in der Postiz-UI.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {integrations.map((i) => (
+                <label
+                  key={i.id}
+                  className={clsx(
+                    'flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer transition-colors',
+                    selected.has(i.id)
+                      ? 'border-primary/40 bg-primary/5'
+                      : 'border-outline-variant/20 hover:border-outline-variant/40',
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(i.id)}
+                    onChange={() => toggle(i.id)}
+                    className="accent-primary"
+                  />
+                  <span className="text-sm text-on-surface">
+                    {platformLabel(i.identifier)}
+                    {i.profile && (
+                      <span className="text-on-surface-variant font-normal"> · {i.profile}</span>
+                    )}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Caption */}
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1.5">Text</label>
+          <textarea
+            value={caption}
+            onChange={(e) => setCaption(e.target.value)}
+            rows={6}
+            className="w-full border border-outline-variant/30 rounded-lg px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-outline-variant bg-surface-container-low resize-none"
+          />
+          <p className="mt-1 text-xs text-on-surface-variant">
+            {caption.length} Zeichen · Bluesky-Limit: 300
+          </p>
+        </div>
+
+        {feedback && (
+          <p
+            className={clsx(
+              'text-sm rounded-lg px-3 py-2',
+              feedback.kind === 'ok'
+                ? 'bg-movement-900/20 text-movement-300'
+                : 'bg-secondary/10 text-secondary',
+            )}
+          >
+            {feedback.text}
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-2 border-t border-outline-variant/15">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-on-surface-variant hover:text-on-surface px-3 py-2"
+          >
+            {feedback?.kind === 'ok' ? 'Schliessen' : 'Abbrechen'}
+          </button>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={isPending || selected.size === 0 || !caption.trim() || feedback?.kind === 'ok'}
+            className="px-4 py-2 bg-primary text-surface-container rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isPending ? 'Sende …' : 'Jetzt posten'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/postiz.ts
+++ b/src/lib/postiz.ts
@@ -1,0 +1,101 @@
+/**
+ * Thin wrapper around the self-hosted Postiz public API.
+ * Docs: https://docs.postiz.com/public-api
+ *
+ * Requires POSTIZ_API_URL and POSTIZ_API_KEY in the environment. The URL
+ * should include the public base path, e.g. `https://postiz.dom42.ch/api/public/v1`.
+ */
+
+export interface PostizIntegration {
+  id: string
+  name: string
+  identifier: string // e.g. 'bluesky', 'instagram', 'threads'
+  picture?: string
+  disabled?: boolean
+  profile?: string
+}
+
+export interface UploadedMedia {
+  id: string
+  path: string
+}
+
+export interface CreatePostInput {
+  /** Channel IDs from listIntegrations(). Each id becomes a separate post block. */
+  integrationIds: string[]
+  /** Caption text — same for all selected channels. */
+  content: string
+  /** Optional public image URL. Postiz fetches it via /upload-from-url. */
+  imageUrl?: string
+  /**
+   * Schedule mode. 'now' publishes immediately. 'schedule' requires a future
+   * `date`. 'draft' stores without publishing. Default: 'now'.
+   */
+  type?: 'now' | 'schedule' | 'draft'
+  /** ISO timestamp; required for `schedule`. Defaults to now. */
+  date?: string
+}
+
+function getConfig() {
+  const url = process.env.POSTIZ_API_URL?.replace(/\/$/, '')
+  const key = process.env.POSTIZ_API_KEY
+  if (!url) throw new Error('POSTIZ_API_URL nicht konfiguriert')
+  if (!key) throw new Error('POSTIZ_API_KEY nicht konfiguriert')
+  return { url, key }
+}
+
+async function postizFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const { url, key } = getConfig()
+  const headers = new Headers(init.headers)
+  headers.set('Authorization', key)
+  if (!headers.has('Content-Type') && init.body && typeof init.body === 'string') {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  const res = await fetch(`${url}${path}`, { ...init, headers, cache: 'no-store' })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Postiz ${res.status}: ${text || res.statusText}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export function listIntegrations(): Promise<PostizIntegration[]> {
+  return postizFetch<PostizIntegration[]>('/integrations')
+}
+
+export function uploadImageFromUrl(url: string): Promise<UploadedMedia> {
+  return postizFetch<UploadedMedia>('/upload-from-url', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  })
+}
+
+export async function createPost(input: CreatePostInput): Promise<unknown> {
+  if (input.integrationIds.length === 0) {
+    throw new Error('Mindestens ein Channel muss ausgewählt sein')
+  }
+
+  const image = input.imageUrl
+    ? [await uploadImageFromUrl(input.imageUrl)]
+    : []
+
+  const date = input.date ?? new Date().toISOString()
+
+  const payload = {
+    type: input.type ?? 'now',
+    shortLink: false,
+    date,
+    tags: [],
+    posts: input.integrationIds.map((id) => ({
+      integration: { id },
+      value: [{ content: input.content, image }],
+      settings: {},
+    })),
+  }
+
+  return postizFetch('/posts', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}

--- a/src/lib/social-caption.ts
+++ b/src/lib/social-caption.ts
@@ -1,0 +1,26 @@
+import { SITE_URL } from './site'
+
+export interface CaptionContext {
+  title: string
+  slug: string
+  excerpt: string | null
+  dailyQuote: string | null
+  entryType: 'FULL' | 'FILLER'
+}
+
+/**
+ * Build a sensible default caption from a JournalEntry. Full entries get
+ * title + excerpt + permalink; fillers get the daily quote alone.
+ * The user edits the result before publishing.
+ */
+export function defaultCaption(ctx: CaptionContext): string {
+  if (ctx.entryType === 'FILLER') {
+    if (ctx.dailyQuote) return `${ctx.dailyQuote.trim()}\n\n#project365`
+    return `Tagesnotiz · #project365`
+  }
+  const url = `${SITE_URL}/de/journal/${ctx.slug}`
+  const lines: string[] = [ctx.title.trim()]
+  if (ctx.excerpt) lines.push('', ctx.excerpt.trim())
+  lines.push('', url)
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary
- Adds a "An Social Media senden" button on the admin entry edit page
- New modal (`SocialPostDialog`) lists Postiz-connected channels (currently Bluesky), pre-fills a caption derived from the entry, lets the admin edit it, and publishes immediately via Postiz `/posts`
- Caption defaults: FULL → title + excerpt + permalink, FILLER → daily quote + `#project365`
- Banner image is forwarded to Postiz via `/upload-from-url` and attached to the post
- New `lib/postiz.ts` wraps the public API; new `lib/social-caption.ts` for the caption helper (kept out of the `'use server'` file)
- Configured via `POSTIZ_API_URL` and `POSTIZ_API_KEY` env vars (already set on prod)

## Follow-up (PR-D3 + PR-D4)
- PR-D3: `SocialPost` model to track which entries already went out on which platforms (avoid double-posting)
- PR-D4: Activate Instagram / Threads channels in Postiz

## Test plan
- [ ] Open an existing FULL entry in admin, click button → modal lists Bluesky, prefilled caption, publishes; post appears on Bluesky
- [ ] Open a FILLER entry → caption is the daily quote + hashtag
- [ ] Banner-less entry posts text-only without error
- [ ] Empty caption: send button disabled
- [ ] Network error or auth failure surfaces inline in the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)