### PR TITLE
fix: migrate banner image generation to gpt-image-1-mini

### DIFF
--- a/src/lib/banner-generate.ts
+++ b/src/lib/banner-generate.ts
@@ -87,16 +87,15 @@ The image should feel personal, introspective, and visually match the emotional 
 
 async function generateFromPrompt(prompt: string): Promise<Buffer> {
   const response = await getClient().images.generate({
-    model: 'dall-e-3',
+    model: 'gpt-image-1-mini',
     prompt,
     n: 1,
-    size: '1792x1024',
-    quality: 'standard',
-    response_format: 'b64_json',
+    size: '1536x1024',
+    quality: 'medium',
   })
 
   const b64 = response.data?.[0]?.b64_json
-  if (!b64) throw new Error('DALL-E hat kein Bild zurückgegeben')
+  if (!b64) throw new Error('Image-Model hat kein Bild zurückgegeben')
 
   return Buffer.from(b64, 'base64')
 }


### PR DESCRIPTION
## Summary
- DALL-E 2/3 werden am 12. Mai 2026 von OpenAI eingestellt — AI-Banner-Generierung war dadurch broken
- Umstellung auf `gpt-image-1-mini` mit Landscape-Size `1536x1024` und `quality: 'medium'`
- `response_format` entfernt (gpt-image liefert immer b64_json)

## Test plan
- [ ] Neuen Eintrag im Admin erstellen und AI-Banner generieren lassen
- [ ] Filler-Eintrag mit Metrics-Banner testen
- [ ] Generiertes Bild hat sinnvolle Landscape-Proportionen

🤖 Generated with [Claude Code](https://claude.com/claude-code)