### PR TITLE
fix: store Withings segmental measures separately by position

### DIFF
--- a/prisma/migrations/20260701120000_withings_segmental_position/migration.sql
+++ b/prisma/migrations/20260701120000_withings_segmental_position/migration.sql
@@ -1,0 +1,9 @@
+-- Add `position` to distinguish segmental measures (fat/muscle per body zone)
+-- that share the same Withings meastype within one measure group.
+ALTER TABLE "WithingsMeasurement" ADD COLUMN "position" INTEGER NOT NULL DEFAULT 0;
+
+-- Replace the (grpid, type) uniqueness with (grpid, type, position) so segmental
+-- values are no longer collapsed to a single row.
+DROP INDEX "WithingsMeasurement_grpid_type_key";
+
+CREATE UNIQUE INDEX "WithingsMeasurement_grpid_type_position_key" ON "WithingsMeasurement"("grpid", "type", "position");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -387,7 +387,7 @@ model PageView {
 
 // =============================================
 // WITHINGS MEASUREMENT — generischer Roh-Store
-// Ein Row pro Messwert-Typ einer Withings-Messgruppe.
+// Ein Row pro Messwert (Typ + Körperzone) einer Withings-Messgruppe.
 // Speichert ALLE von der Body Scan gelieferten Datenpunkte
 // (Gewicht, Muskelmasse, Wasser, viszerales Fett, PWV, Gefässalter,
 // segmentale Werte …). Gewicht + Körperfett werden zusätzlich in
@@ -400,10 +400,11 @@ model WithingsMeasurement {
   measuredAt DateTime                      // voller Zeitstempel der Messung
   date       DateTime @db.Date             // Messtag (Europe/Zurich) — für Tages-Joins
   type       Int                           // Withings meastype (1, 6, 76, …)
+  position   Int      @default(0)          // Körperzone bei segmentalen Werten (0 = ganzkörper/ohne Position)
   value      Float                         // aufgelöster Realwert (value * 10^unit)
   createdAt  DateTime @default(now())
 
-  @@unique([grpid, type])
+  @@unique([grpid, type, position])
   @@index([date])
   @@index([type])
 }

--- a/src/lib/withings.test.ts
+++ b/src/lib/withings.test.ts
@@ -36,9 +36,11 @@ const MEASURE_BODY = {
       grpid: 987654,
       date: MEASURE_UNIX,
       measures: [
-        { value: 85200, type: 1, unit: -3 }, // 85.2 kg
-        { value: 223, type: 6, unit: -1 },   // 22.3 %
-        { value: 34500, type: 76, unit: -3 }, // 34.5 kg muscle mass
+        { value: 85200, type: 1, unit: -3 },                 // 85.2 kg (whole body, no position)
+        { value: 223, type: 6, unit: -1 },                   // 22.3 % body fat
+        { value: 34500, type: 76, unit: -3, position: 7 },   // 34.5 kg muscle (whole body)
+        { value: 4470, type: 175, unit: -2, position: 11 },  // 44.7 kg segmental muscle (arm)
+        { value: 4460, type: 175, unit: -2, position: 2 },   // 44.6 kg segmental muscle (leg)
       ],
     },
   ],
@@ -109,10 +111,20 @@ describe('fetchMeasures', () => {
     const groups = await fetchMeasures(0, 1, 'token')
     expect(groups).toHaveLength(1)
     expect(groups[0].grpid).toBe(BigInt(987654))
-    const byType = Object.fromEntries(groups[0].measures.map((m) => [m.type, m.value]))
-    expect(byType[1]).toBeCloseTo(85.2)
-    expect(byType[6]).toBeCloseTo(22.3)
-    expect(byType[76]).toBeCloseTo(34.5)
+    expect(groups[0].measures).toHaveLength(5)
+    const weight = groups[0].measures.find((m) => m.type === 1)!
+    expect(weight.value).toBeCloseTo(85.2)
+    expect(groups[0].measures.find((m) => m.type === 6)!.value).toBeCloseTo(22.3)
+  })
+
+  it('defaults position to 0 when absent and preserves segmental positions', async () => {
+    vi.stubGlobal('fetch', mockEnvelope(0, MEASURE_BODY))
+    const groups = await fetchMeasures(0, 1, 'token')
+    // whole-body weight has no position field → 0
+    expect(groups[0].measures.find((m) => m.type === 1)!.position).toBe(0)
+    // segmental muscle mass keeps its distinct positions
+    const segments = groups[0].measures.filter((m) => m.type === 175).map((m) => m.position).sort((a, b) => a - b)
+    expect(segments).toEqual([2, 11])
   })
 
   it('returns empty array when no measure groups', async () => {
@@ -166,9 +178,17 @@ describe('syncWithingsRange', () => {
 
     const result = await syncWithingsRange('2026-06-30', '2026-06-30', TOKENS, prisma)
 
-    // 3 raw measures stored
-    expect(measurementUpsert).toHaveBeenCalledTimes(3)
-    expect(result.measureCount).toBe(3)
+    // 5 raw measures stored — segmental values are NOT collapsed
+    expect(measurementUpsert).toHaveBeenCalledTimes(5)
+    expect(result.measureCount).toBe(5)
+
+    // The two type-175 segments use distinct (grpid, type, position) keys
+    const seg175 = measurementUpsert.mock.calls
+      .map((c) => c[0].where.grpid_type_position)
+      .filter((k: { type: number }) => k.type === 175)
+      .map((k: { position: number }) => k.position)
+      .sort((a: number, b: number) => a - b)
+    expect(seg175).toEqual([2, 11])
 
     // DailyMetrics mirrored once for the day
     expect(dailyUpsert).toHaveBeenCalledOnce()

--- a/src/lib/withings.ts
+++ b/src/lib/withings.ts
@@ -13,6 +13,8 @@ export interface WithingsTokens {
 /** A single resolved measure (realwert = value * 10^unit already applied). */
 export interface WithingsMeasure {
   type: number
+  /** Body zone for segmental measures; 0 for whole-body / measures without a position. */
+  position: number
   value: number
 }
 
@@ -200,7 +202,7 @@ export function buildWithingsAuthUrl(redirectUri: string, state: string): string
 interface RawMeasureGroup {
   grpid: number
   date: number
-  measures: Array<{ value: number; type: number; unit: number }>
+  measures: Array<{ value: number; type: number; unit: number; position?: number }>
 }
 
 /**
@@ -237,6 +239,9 @@ export async function fetchMeasures(
     measuredAt: new Date(grp.date * 1000),
     measures: grp.measures.map((m) => ({
       type: m.type,
+      // Segmental measures (e.g. fat/muscle per body zone) share a type and are
+      // distinguished by `position`; whole-body measures have no position → 0.
+      position: m.position ?? 0,
       // Withings encodes the real value as value * 10^unit (unit is usually negative)
       value: m.value * 10 ** m.unit,
     })),
@@ -297,11 +302,12 @@ export async function syncWithingsRange(
 
     for (const m of grp.measures) {
       await prisma.withingsMeasurement.upsert({
-        where: { grpid_type: { grpid: grp.grpid, type: m.type } },
+        where: { grpid_type_position: { grpid: grp.grpid, type: m.type, position: m.position } },
         update: { value: m.value, measuredAt: grp.measuredAt, date: dateOnly },
         create: {
           grpid: grp.grpid,
           type: m.type,
+          position: m.position,
           value: m.value,
           measuredAt: grp.measuredAt,
           date: dateOnly,
@@ -309,6 +315,8 @@ export async function syncWithingsRange(
       })
       measureCount++
 
+      // Whole-body weight/body-fat only (position 0); segmental values share these
+      // types only for other measures, so no ambiguity here.
       if (m.type === MEASURE_WEIGHT || m.type === MEASURE_FAT_RATIO) {
         const day = perDay.get(dateStr) ?? {}
         if (m.type === MEASURE_WEIGHT) day.weight = m.value


### PR DESCRIPTION
## Kontext

Nach dem ersten produktiven Withings-Sync fiel auf: der Sync meldete **31 Messwerte**, gespeichert wurden aber nur **19 Zeilen**. Die Roh-Antwort der Withings-API zeigt, warum:

Die Body Scan liefert **segmentale** Werte (Fett/Muskel/Knochen pro Körperzone) als mehrere Messwerte mit **demselben** `meastype`, unterschieden nur durch ein **`position`**-Feld (z. B. type 174/175 je 5×, positions 2, 3, 10, 11, 12). Der bisherige Unique-Key `(grpid, type)` hat diese auf **einen** Wert reduziert (last write wins) — pro Scan gingen ~12 von 31 Werten verloren. Genau die segmentale Körperzusammensetzung, die das geplante Teacher-Dashboard braucht.

## Änderungen

- `WithingsMeasurement.position` (Int, default 0) ergänzt; Unique-Key auf **`(grpid, type, position)`** erweitert
- `fetchMeasures()` liest `position` mit (fehlt → 0 für Ganzkörper-Werte), `syncWithingsRange()` speichert sie
- Migration `20260701120000_withings_segmental_position` (Spalte + Index-Swap, schema-only)
- Tests erweitert: segmentale Werte mit gleichem Typ, aber unterschiedlicher Position werden getrennt gespeichert

Whole-body-Werte und das DailyMetrics-Mirroring (type 1 Gewicht + type 6 Körperfett) bleiben unverändert.

## Verifikation
- ✅ `type-check`, ✅ `test` 92/92, ✅ `next build`

## Deployment-Schritte (nach Merge)
1. Migration läuft via CI/CD
2. `WithingsMeasurement` einmalig leeren (alte kollabierte Rows) + sauberer Re-Backfill des vorhandenen Scans — mache ich per SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)