### PR TITLE
feat: make health inventory page source-agnostic (Apple Health + Withings)

### DIFF
--- a/src/app/admin/health-inventory/page.tsx
+++ b/src/app/admin/health-inventory/page.tsx
@@ -1,220 +1,31 @@
 export const revalidate = 300 // 5-Minuten Cache
 
-import { getHealthInventory, CATEGORY_ORDER, type InventoryRow } from '@/lib/health-inventory'
-
-function formatLastDate(dateStr: string | null): string {
-  if (!dateStr) return '—'
-  const [y, m, d] = dateStr.split('-')
-  return `${d}.${m}.${y}`
-}
-
-function formatLastReceived(date: Date): string {
-  return date.toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit', year: 'numeric' })
-}
-
-// Maps Apple Health raw units to readable display units
-const UNIT_DISPLAY: Record<string, string> = {
-  'count':          'Schritte',
-  'count/min':      'S/min',
-  'kcal':           'kcal',
-  'Cal':            'kcal',
-  'km':             'km',
-  'mi':             'mi',
-  'kg':             'kg',
-  '%':              '%',
-  'bpm':            'bpm',
-  'ms':             'ms',
-  'hr':             'h',
-  'min':            'min',
-  'mmHg':           'mmHg',
-  'dBASPL':         'dB',
-  'mL/kg/min':      'ml/kg/min',
-  'degC':           '°C',
-  'lux':            'lux',
-  'W':              'W',
-  'm/s':            'm/s',
-  'm':              'm',
-  'cm':             'cm',
-  'L':              'L',
-  'mg/dL':          'mg/dL',
-  'IU':             'IE',
-}
-
-function displayUnit(rawUnit: string): string {
-  return UNIT_DISPLAY[rawUnit] ?? rawUnit
-}
-
-function formatValue(value: number | null, rawUnit: string): string {
-  if (value === null) return '—'
-  // Units that are naturally integer (steps, floors, etc.)
-  const integerUnits = ['count', 'count/min']
-  if (integerUnits.includes(rawUnit)) return Math.round(value).toLocaleString('de-CH')
-  if (rawUnit === 'kg' || rawUnit === '%') return value.toFixed(1)
-  if (rawUnit === 'km' || rawUnit === 'mi' || rawUnit === 'm') return value.toFixed(2)
-  if (rawUnit === 'hr') return value.toFixed(1)
-  if (rawUnit === 'ms') return Math.round(value).toLocaleString('de-CH')
-  if (Number.isInteger(value)) return value.toLocaleString('de-CH')
-  return value.toFixed(1)
-}
-
-function StatusBadge({ row }: { row: InventoryRow }) {
-  if (row.usedInDashboard) {
-    return (
-      <span
-        className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-label font-bold tracking-widest uppercase bg-movement-600/15 text-movement-400 border border-movement-600/20 whitespace-nowrap"
-        title={row.dashboardNote}
-      >
-        Im Dashboard
-      </span>
-    )
-  }
-  if (row.mappedToDb) {
-    return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-label font-bold tracking-widest uppercase bg-primary/10 text-primary border border-primary/20 whitespace-nowrap">
-        Gespeichert
-      </span>
-    )
-  }
-  return (
-    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-label font-bold tracking-widest uppercase bg-surface-container-highest text-on-surface-variant border border-outline-variant/20 whitespace-nowrap">
-      Nicht verwendet
-    </span>
-  )
-}
-
-function CategorySection({ category, rows }: { category: string; rows: InventoryRow[] }) {
-  if (rows.length === 0) return null
-
-  const sorted = [...rows].sort((a, b) => {
-    if (a.usedInDashboard !== b.usedInDashboard) return a.usedInDashboard ? -1 : 1
-    if (!!a.mappedToDb !== !!b.mappedToDb) return a.mappedToDb ? -1 : 1
-    return b.sampleCount - a.sampleCount
-  })
-
-  return (
-    <div>
-      <div className="flex items-center gap-3 mb-3">
-        <h2 className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
-          {category}
-        </h2>
-        <span className="text-xs text-on-surface-variant opacity-50">{rows.length}</span>
-      </div>
-      <div className="overflow-x-auto rounded-xl border border-outline-variant/15">
-        <table className="w-full text-sm min-w-[640px]">
-          <thead>
-            <tr className="border-b border-outline-variant/10 bg-surface-container-high">
-              <th className="text-left px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">Attribut</th>
-              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap">Datenpunkte</th>
-              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap" title="Letzter Einzelmesswert aus dem Import (kein Tageswert)">Letzter Messwert</th>
-              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap">Datum</th>
-              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap">Letzter Import</th>
-              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map((row, i) => (
-              <tr
-                key={row.metricName}
-                className={`border-b border-outline-variant/10 last:border-0 transition-colors hover:bg-surface-container-high/50 ${
-                  i % 2 === 0 ? 'bg-surface-container' : 'bg-surface-container-low'
-                }`}
-              >
-                <td className="px-4 py-3">
-                  <p className="font-medium text-on-surface">{row.displayName}</p>
-                  <p className="text-xs text-on-surface-variant font-mono mt-0.5 opacity-60">{row.metricName}</p>
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <span className="font-headline font-bold text-on-surface">
-                    {row.sampleCount.toLocaleString('de-CH')}
-                  </span>
-                </td>
-                <td className="px-4 py-3 text-right text-on-surface-variant whitespace-nowrap">
-                  {formatValue(row.lastValue, row.unit)}
-                  {row.lastValue !== null && (
-                    <span className="ml-1 text-xs opacity-60">{displayUnit(row.unit)}</span>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-right text-on-surface-variant whitespace-nowrap text-xs">
-                  {formatLastDate(row.lastValueDate)}
-                </td>
-                <td className="px-4 py-3 text-right text-on-surface-variant whitespace-nowrap text-xs">
-                  {formatLastReceived(row.lastReceivedAt)}
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <StatusBadge row={row} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  )
-}
+import { getAllInventory, INVENTORY_SOURCES } from '@/lib/inventory'
+import { InventoryBrowser } from '@/components/admin/InventoryBrowser'
 
 export default async function HealthInventoryPage() {
-  const inventory = await getHealthInventory()
-
-  const usedCount = inventory.filter((r) => r.usedInDashboard).length
-  const storedCount = inventory.filter((r) => r.mappedToDb && !r.usedInDashboard).length
-  const unusedCount = inventory.filter((r) => !r.mappedToDb).length
-  const totalCount = inventory.length
-
-  const byCategory = CATEGORY_ORDER.map((cat) => ({
-    category: cat,
-    rows: inventory.filter((r) => r.category === cat),
-  })).filter((g) => g.rows.length > 0)
-
-  // Metrics not in our static map
-  const knownCategories = new Set(CATEGORY_ORDER)
-  const otherRows = inventory.filter((r) => !knownCategories.has(r.category) || r.category === 'Sonstiges')
+  const inventory = await getAllInventory()
 
   return (
     <div className="space-y-8">
       {/* Header */}
       <div>
-        <h1 className="font-headline text-2xl font-bold text-on-surface">Apple Health Inventar</h1>
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Health Inventar</h1>
         <p className="text-on-surface-variant text-sm mt-1">
-          Alle via{' '}
-          <code className="text-xs bg-surface-container-high px-1.5 py-0.5 rounded font-mono">/api/health-import</code>{' '}
-          empfangenen Metriken. Wird bei jedem App-Sync aktualisiert.
+          Alle empfangenen Metriken über alle Datenquellen hinweg (Apple Health, Withings …).
+          Nach Quelle filterbar; wird bei jedem Sync aktualisiert.
         </p>
       </div>
 
-      {totalCount === 0 ? (
+      {inventory.length === 0 ? (
         <div className="p-8 text-center bg-surface-container rounded-xl border border-outline-variant/15">
           <p className="text-on-surface-variant text-sm">Noch keine Daten empfangen.</p>
           <p className="text-on-surface-variant text-xs mt-2">
-            Sobald die Apple Health Auto Export App das nächste Mal synchronisiert, erscheinen hier alle Metriken.
+            Sobald eine Datenquelle das nächste Mal synchronisiert, erscheinen hier alle Metriken.
           </p>
         </div>
       ) : (
-        <>
-          {/* Summary bar */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            {[
-              { label: 'Gesamt empfangen', value: totalCount, color: 'text-on-surface' },
-              { label: 'Im Dashboard',     value: usedCount,   color: 'text-movement-400' },
-              { label: 'Gespeichert',      value: storedCount, color: 'text-primary' },
-              { label: 'Ungenutzt',        value: unusedCount, color: 'text-on-surface-variant' },
-            ].map(({ label, value, color }) => (
-              <div key={label} className="p-4 bg-surface-container rounded-xl border border-outline-variant/15 text-center">
-                <p className={`text-2xl font-headline font-bold ${color}`}>{value}</p>
-                <p className="text-xs text-on-surface-variant mt-0.5">{label}</p>
-              </div>
-            ))}
-          </div>
-
-          {/* Category sections */}
-          {byCategory.map(({ category, rows }) => (
-            <CategorySection key={category} category={category} rows={rows} />
-          ))}
-
-          {/* Fallback: unbekannte Kategorien */}
-          {otherRows.length > 0 && (
-            <CategorySection category="Sonstiges" rows={otherRows} />
-          )}
-        </>
+        <InventoryBrowser rows={inventory} sources={INVENTORY_SOURCES} />
       )}
 
       {/* Context note */}
@@ -222,11 +33,15 @@ export default async function HealthInventoryPage() {
         <p className="font-semibold text-on-surface">Status-Legende</p>
         <ul className="space-y-1">
           <li><span className="text-movement-400 font-semibold">Im Dashboard</span> — Wird auf der öffentlichen Startseite angezeigt</li>
-          <li><span className="text-primary font-semibold">Gespeichert</span> — In DailyMetrics gespeichert, aber noch nicht öffentlich sichtbar</li>
+          <li><span className="text-primary font-semibold">Gespeichert</span> — In der Datenbank gespeichert, aber (noch) nicht öffentlich sichtbar</li>
           <li><span className="text-on-surface-variant font-semibold">Nicht verwendet</span> — Wird empfangen, aber nicht geparst oder gespeichert</li>
         </ul>
         <p className="mt-2 pt-2 border-t border-outline-variant/10">
-          Neue Metriken aktivieren: Parser in <code className="font-mono">lib/apple-health.ts → parseHealthPayload()</code> erweitern + ggf. Migration für neues <code className="font-mono">DailyMetrics</code>-Feld.
+          Datenquellen: <span className="text-on-surface">{INVENTORY_SOURCES.map((s) => s.label).join(', ')}</span>.
+          Neue Metrik aktivieren: im jeweiligen Quellen-Parser mappen (z.B.{' '}
+          <code className="font-mono">lib/apple-health.ts</code> bzw.{' '}
+          <code className="font-mono">lib/withings.ts</code>) und ggf. Migration für ein neues{' '}
+          <code className="font-mono">DailyMetrics</code>-Feld.
         </p>
       </div>
     </div>

--- a/src/components/admin/InventoryBrowser.tsx
+++ b/src/components/admin/InventoryBrowser.tsx
@@ -1,0 +1,249 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { CATEGORY_ORDER, type InventoryRow, type InventorySource } from '@/lib/inventory'
+
+// Maps raw units to readable display units
+const UNIT_DISPLAY: Record<string, string> = {
+  'count':          'Schritte',
+  'count/min':      'S/min',
+  'kcal':           'kcal',
+  'Cal':            'kcal',
+  'km':             'km',
+  'mi':             'mi',
+  'kg':             'kg',
+  '%':              '%',
+  'bpm':            'bpm',
+  'ms':             'ms',
+  'hr':             'h',
+  'min':            'min',
+  'mmHg':           'mmHg',
+  'dBASPL':         'dB',
+  'mL/kg/min':      'ml/kg/min',
+  'ml/min/kg':      'ml/min/kg',
+  'degC':           '°C',
+  '°C':             '°C',
+  'lux':            'lux',
+  'W':              'W',
+  'm/s':            'm/s',
+  'm':              'm',
+  'cm':             'cm',
+  'L':              'L',
+  'mg/dL':          'mg/dL',
+  'IU':             'IE',
+  'Jahre':          'Jahre',
+}
+
+function displayUnit(rawUnit: string): string {
+  return UNIT_DISPLAY[rawUnit] ?? rawUnit
+}
+
+function formatValue(value: number | null, rawUnit: string): string {
+  if (value === null) return '—'
+  const integerUnits = ['count', 'count/min']
+  if (integerUnits.includes(rawUnit)) return Math.round(value).toLocaleString('de-CH')
+  if (rawUnit === 'kg' || rawUnit === '%') return value.toFixed(1)
+  if (rawUnit === 'km' || rawUnit === 'mi' || rawUnit === 'm') return value.toFixed(2)
+  if (rawUnit === 'hr') return value.toFixed(1)
+  if (rawUnit === 'ms') return Math.round(value).toLocaleString('de-CH')
+  if (Number.isInteger(value)) return value.toLocaleString('de-CH')
+  return value.toFixed(1)
+}
+
+function formatLastDate(dateStr: string | null): string {
+  if (!dateStr) return '—'
+  const [y, m, d] = dateStr.split('-')
+  return `${d}.${m}.${y}`
+}
+
+function formatLastReceived(date: Date): string {
+  return date.toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit', year: 'numeric' })
+}
+
+function StatusBadge({ row }: { row: InventoryRow }) {
+  if (row.status === 'DASHBOARD') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-label font-bold tracking-widest uppercase bg-movement-600/15 text-movement-400 border border-movement-600/20 whitespace-nowrap"
+        title={row.dashboardNote}
+      >
+        Im Dashboard
+      </span>
+    )
+  }
+  if (row.status === 'STORED') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-label font-bold tracking-widest uppercase bg-primary/10 text-primary border border-primary/20 whitespace-nowrap">
+        Gespeichert
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-label font-bold tracking-widest uppercase bg-surface-container-highest text-on-surface-variant border border-outline-variant/20 whitespace-nowrap">
+      Nicht verwendet
+    </span>
+  )
+}
+
+function CategorySection({ category, rows }: { category: string; rows: InventoryRow[] }) {
+  if (rows.length === 0) return null
+
+  const statusRank = (r: InventoryRow) => (r.status === 'DASHBOARD' ? 0 : r.status === 'STORED' ? 1 : 2)
+  const sorted = [...rows].sort((a, b) => {
+    if (statusRank(a) !== statusRank(b)) return statusRank(a) - statusRank(b)
+    return b.sampleCount - a.sampleCount
+  })
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-3">
+        <h2 className="text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">
+          {category}
+        </h2>
+        <span className="text-xs text-on-surface-variant opacity-50">{rows.length}</span>
+      </div>
+      <div className="overflow-x-auto rounded-xl border border-outline-variant/15">
+        <table className="w-full text-sm min-w-[640px]">
+          <thead>
+            <tr className="border-b border-outline-variant/10 bg-surface-container-high">
+              <th className="text-left px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">Attribut</th>
+              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap">Datenpunkte</th>
+              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap" title="Letzter Einzelmesswert (kein Tageswert)">Letzter Messwert</th>
+              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap">Datum</th>
+              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant whitespace-nowrap">Letzter Import</th>
+              <th className="text-right px-4 py-2.5 text-xs font-label font-bold tracking-widest uppercase text-on-surface-variant">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row, i) => (
+              <tr
+                key={`${row.source}:${row.key}`}
+                className={`border-b border-outline-variant/10 last:border-0 transition-colors hover:bg-surface-container-high/50 ${
+                  i % 2 === 0 ? 'bg-surface-container' : 'bg-surface-container-low'
+                }`}
+              >
+                <td className="px-4 py-3">
+                  <p className="font-medium text-on-surface">{row.displayName}</p>
+                  <p className="text-xs text-on-surface-variant font-mono mt-0.5 opacity-60">{row.key}</p>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <span className="font-headline font-bold text-on-surface">
+                    {row.sampleCount.toLocaleString('de-CH')}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right text-on-surface-variant whitespace-nowrap">
+                  {formatValue(row.lastValue, row.unit)}
+                  {row.lastValue !== null && row.unit !== '' && (
+                    <span className="ml-1 text-xs opacity-60">{displayUnit(row.unit)}</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right text-on-surface-variant whitespace-nowrap text-xs">
+                  {formatLastDate(row.lastValueDate)}
+                </td>
+                <td className="px-4 py-3 text-right text-on-surface-variant whitespace-nowrap text-xs">
+                  {formatLastReceived(row.lastReceivedAt)}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <StatusBadge row={row} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+const ALL = '__all__'
+
+export function InventoryBrowser({
+  rows,
+  sources,
+}: {
+  rows: InventoryRow[]
+  sources: InventorySource[]
+}) {
+  // Only offer tabs for sources that actually have data.
+  const availableSources = useMemo(
+    () => sources.filter((s) => rows.some((r) => r.source === s.id)),
+    [rows, sources],
+  )
+  const [active, setActive] = useState<string>(ALL)
+
+  const filtered = useMemo(
+    () => (active === ALL ? rows : rows.filter((r) => r.source === active)),
+    [rows, active],
+  )
+
+  const stats = useMemo(
+    () => ({
+      total: filtered.length,
+      dashboard: filtered.filter((r) => r.status === 'DASHBOARD').length,
+      stored: filtered.filter((r) => r.status === 'STORED').length,
+      unused: filtered.filter((r) => r.status === 'UNUSED').length,
+    }),
+    [filtered],
+  )
+
+  // Categories present in the filtered set, ordered by CATEGORY_ORDER (unknowns last).
+  const categories = useMemo(() => {
+    const present = Array.from(new Set(filtered.map((r) => r.category)))
+    return present.sort((a, b) => {
+      const ia = CATEGORY_ORDER.indexOf(a)
+      const ib = CATEGORY_ORDER.indexOf(b)
+      return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
+    })
+  }, [filtered])
+
+  const tabs = [{ id: ALL, label: 'Alle' }, ...availableSources]
+
+  return (
+    <div className="space-y-6">
+      {/* Source tabs */}
+      <div className="flex flex-wrap gap-2">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setActive(t.id)}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              active === t.id
+                ? 'bg-surface-container-highest text-on-surface'
+                : 'bg-surface-container text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'
+            }`}
+          >
+            {t.label}
+            <span className="ml-2 text-xs opacity-60">
+              {t.id === ALL ? rows.length : rows.filter((r) => r.source === t.id).length}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Summary bar */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Gesamt', value: stats.total, color: 'text-on-surface' },
+          { label: 'Im Dashboard', value: stats.dashboard, color: 'text-movement-400' },
+          { label: 'Gespeichert', value: stats.stored, color: 'text-primary' },
+          { label: 'Ungenutzt', value: stats.unused, color: 'text-on-surface-variant' },
+        ].map(({ label, value, color }) => (
+          <div key={label} className="p-4 bg-surface-container rounded-xl border border-outline-variant/15 text-center">
+            <p className={`text-2xl font-headline font-bold ${color}`}>{value}</p>
+            <p className="text-xs text-on-surface-variant mt-0.5">{label}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Category sections */}
+      {categories.map((category) => (
+        <CategorySection
+          key={category}
+          category={category}
+          rows={filtered.filter((r) => r.category === category)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/lib/health-inventory.ts
+++ b/src/lib/health-inventory.ts
@@ -1,10 +1,8 @@
-import { prisma } from '@/lib/db'
-
 // ── Static mapping: Apple Health metric name → display info ──────────────────
 // Key = lowercase normalized metric name (spaces, case-insensitive match)
 // Covers common HealthKit identifiers sent by Health Auto Export app.
 
-interface MetricMeta {
+export interface MetricMeta {
   displayName: string
   category: string
   mappedToDb?: string  // DailyMetrics field name if actively stored
@@ -122,7 +120,7 @@ const METRIC_MAP: Record<string, MetricMeta> = {
   'uv exposure':                    { displayName: 'UV-Exposition',                 category: 'Mind & Sonstiges' },
 }
 
-function lookupMeta(rawName: string): MetricMeta {
+export function lookupMeta(rawName: string): MetricMeta {
   const key = normalizeMetricName(rawName)
   return (
     METRIC_MAP[key] ?? {
@@ -131,50 +129,3 @@ function lookupMeta(rawName: string): MetricMeta {
     }
   )
 }
-
-export interface InventoryRow {
-  metricName: string
-  displayName: string
-  category: string
-  unit: string
-  sampleCount: number
-  lastValue: number | null
-  lastValueDate: string | null
-  lastReceivedAt: Date
-  mappedToDb: string | undefined
-  usedInDashboard: boolean
-  dashboardNote: string | undefined
-}
-
-export async function getHealthInventory(): Promise<InventoryRow[]> {
-  const rows = await prisma.healthMetricInventory.findMany({
-    orderBy: { metricName: 'asc' },
-  })
-
-  return rows.map((row) => {
-    const meta = lookupMeta(row.metricName)
-    return {
-      metricName: row.metricName,
-      displayName: meta.displayName,
-      category: meta.category,
-      unit: row.unit,
-      sampleCount: row.sampleCount,
-      lastValue: row.lastValue,
-      lastValueDate: row.lastValueDate,
-      lastReceivedAt: row.lastReceivedAt,
-      mappedToDb: meta.mappedToDb,
-      usedInDashboard: meta.usedInDashboard ?? false,
-      dashboardNote: meta.dashboardNote,
-    }
-  })
-}
-
-export const CATEGORY_ORDER = [
-  'Aktivität',
-  'Körper',
-  'Herz & Vitalwerte',
-  'Schlaf',
-  'Ernährung',
-  'Mind & Sonstiges',
-  'Sonstiges',
-]

--- a/src/lib/inventory.test.ts
+++ b/src/lib/inventory.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    healthMetricInventory: { findMany: vi.fn() },
+    withingsMeasurement: { groupBy: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/db', () => ({ prisma: mockPrisma }))
+
+import { getAppleHealthInventory, getWithingsInventory, getAllInventory } from './inventory'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// =============================================
+// Apple Health provider
+// =============================================
+
+describe('getAppleHealthInventory', () => {
+  it('maps metric meta to status (DASHBOARD / STORED / UNUSED)', async () => {
+    mockPrisma.healthMetricInventory.findMany.mockResolvedValue([
+      { metricName: 'step_count', unit: 'count', sampleCount: 586, lastValue: 8, lastValueDate: '2026-07-01', lastReceivedAt: new Date('2026-07-01') },
+      { metricName: 'active_energy', unit: 'kcal', sampleCount: 919, lastValue: 1.4, lastValueDate: '2026-07-01', lastReceivedAt: new Date('2026-07-01') },
+      { metricName: 'physical_effort', unit: 'kcal', sampleCount: 945, lastValue: 2.7, lastValueDate: '2026-07-01', lastReceivedAt: new Date('2026-07-01') },
+    ])
+
+    const rows = await getAppleHealthInventory()
+    const byKey = Object.fromEntries(rows.map((r) => [r.key, r]))
+
+    expect(byKey['step_count'].status).toBe('DASHBOARD')
+    expect(byKey['step_count'].source).toBe('APPLE_HEALTH')
+    expect(byKey['active_energy'].status).toBe('STORED') // mapped to caloriesBurned, not on dashboard
+    expect(byKey['physical_effort'].status).toBe('UNUSED') // received but not stored
+  })
+})
+
+// =============================================
+// Withings provider
+// =============================================
+
+describe('getWithingsInventory', () => {
+  it('aggregates per type, resolves last value, and flags dashboard types', async () => {
+    const created = new Date('2026-07-01T09:52:00Z')
+    mockPrisma.withingsMeasurement.groupBy.mockResolvedValue([
+      { type: 1, _count: 3, _max: { date: new Date('2026-07-01'), createdAt: created } },
+      { type: 6, _count: 3, _max: { date: new Date('2026-07-01'), createdAt: created } },
+      { type: 76, _count: 3, _max: { date: new Date('2026-07-01'), createdAt: created } },
+      { type: 175, _count: 5, _max: { date: new Date('2026-07-01'), createdAt: created } },
+      { type: 999, _count: 1, _max: { date: new Date('2026-07-01'), createdAt: created } },
+    ])
+    mockPrisma.$queryRaw.mockResolvedValue([
+      { type: 1, value: 96.1 },
+      { type: 6, value: 26.6 },
+      { type: 76, value: 34.5 },
+      { type: 175, value: 44.7 },
+      { type: 999, value: 1.2 },
+    ])
+
+    const rows = await getWithingsInventory()
+    const byKey = Object.fromEntries(rows.map((r) => [r.key, r]))
+
+    // weight = dashboard type
+    expect(byKey['1'].status).toBe('DASHBOARD')
+    expect(byKey['1'].displayName).toBe('Gewicht')
+    expect(byKey['1'].unit).toBe('kg')
+    expect(byKey['1'].sampleCount).toBe(3)
+    expect(byKey['1'].lastValue).toBe(96.1)
+    expect(byKey['1'].lastValueDate).toBe('2026-07-01')
+
+    // body fat = dashboard type
+    expect(byKey['6'].status).toBe('DASHBOARD')
+
+    // muscle mass = stored (raw store never "unused")
+    expect(byKey['76'].status).toBe('STORED')
+    expect(byKey['76'].category).toBe('Körper')
+
+    // segmental type keeps its full count
+    expect(byKey['175'].sampleCount).toBe(5)
+
+    // unknown type falls back gracefully
+    expect(byKey['999'].displayName).toBe('Typ 999')
+    expect(byKey['999'].category).toBe('Sonstiges')
+    expect(byKey['999'].status).toBe('STORED')
+  })
+
+  it('returns empty array and skips the value query when no measures exist', async () => {
+    mockPrisma.withingsMeasurement.groupBy.mockResolvedValue([])
+    const rows = await getWithingsInventory()
+    expect(rows).toEqual([])
+    expect(mockPrisma.$queryRaw).not.toHaveBeenCalled()
+  })
+})
+
+// =============================================
+// Registry
+// =============================================
+
+describe('getAllInventory', () => {
+  it('combines rows from all providers', async () => {
+    mockPrisma.healthMetricInventory.findMany.mockResolvedValue([
+      { metricName: 'step_count', unit: 'count', sampleCount: 1, lastValue: 8, lastValueDate: '2026-07-01', lastReceivedAt: new Date('2026-07-01') },
+    ])
+    mockPrisma.withingsMeasurement.groupBy.mockResolvedValue([
+      { type: 1, _count: 1, _max: { date: new Date('2026-07-01'), createdAt: new Date('2026-07-01') } },
+    ])
+    mockPrisma.$queryRaw.mockResolvedValue([{ type: 1, value: 96.1 }])
+
+    const rows = await getAllInventory()
+    const sources = new Set(rows.map((r) => r.source))
+    expect(sources).toEqual(new Set(['APPLE_HEALTH', 'WITHINGS']))
+    expect(rows).toHaveLength(2)
+  })
+})

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -1,0 +1,138 @@
+import { prisma } from '@/lib/db'
+import { lookupMeta } from '@/lib/health-inventory'
+import { WITHINGS_MEASURE_TYPES, WITHINGS_DASHBOARD_TYPES, measureTypeLabel } from '@/lib/withings'
+
+// =============================================
+// Generic, source-agnostic health-data inventory
+//
+// Each data source (Apple Health, Withings, later MyFitnessPal …) contributes
+// its metrics as InventoryRow[] via a provider function. The registry
+// (getAllInventory) aggregates them. Adding a source = write a provider + list
+// it in INVENTORY_SOURCES / the providers array — the admin page adapts itself.
+// =============================================
+
+export type InventoryStatus = 'DASHBOARD' | 'STORED' | 'UNUSED'
+
+export interface InventorySource {
+  id: string
+  label: string
+}
+
+export interface InventoryRow {
+  source: string                 // source id, e.g. 'APPLE_HEALTH' | 'WITHINGS'
+  key: string                    // stable key within the source (metric name | withings type)
+  displayName: string
+  category: string
+  unit: string
+  sampleCount: number
+  lastValue: number | null
+  lastValueDate: string | null   // YYYY-MM-DD
+  lastReceivedAt: Date
+  status: InventoryStatus
+  dashboardNote?: string
+}
+
+/** Shared category ordering (superset across all sources). */
+export const CATEGORY_ORDER = [
+  'Aktivität',
+  'Körper',
+  'Herz & Vitalwerte',
+  'Schlaf',
+  'Ernährung',
+  'Nerven',
+  'Mind & Sonstiges',
+  'Sonstiges',
+]
+
+export const INVENTORY_SOURCES: InventorySource[] = [
+  { id: 'APPLE_HEALTH', label: 'Apple Health' },
+  { id: 'WITHINGS', label: 'Withings' },
+]
+
+// =============================================
+// Provider: Apple Health (HealthMetricInventory table)
+// =============================================
+
+export async function getAppleHealthInventory(): Promise<InventoryRow[]> {
+  const rows = await prisma.healthMetricInventory.findMany({ orderBy: { metricName: 'asc' } })
+
+  return rows.map((row) => {
+    const meta = lookupMeta(row.metricName)
+    const status: InventoryStatus = meta.usedInDashboard
+      ? 'DASHBOARD'
+      : meta.mappedToDb
+        ? 'STORED'
+        : 'UNUSED'
+    return {
+      source: 'APPLE_HEALTH',
+      key: row.metricName,
+      displayName: meta.displayName,
+      category: meta.category,
+      unit: row.unit,
+      sampleCount: row.sampleCount,
+      lastValue: row.lastValue,
+      lastValueDate: row.lastValueDate,
+      lastReceivedAt: row.lastReceivedAt,
+      status,
+      dashboardNote: meta.dashboardNote,
+    }
+  })
+}
+
+// =============================================
+// Provider: Withings (derived from the WithingsMeasurement raw store)
+// =============================================
+
+export async function getWithingsInventory(): Promise<InventoryRow[]> {
+  // Aggregate per measure type: count + last date + last import time.
+  const grouped = await prisma.withingsMeasurement.groupBy({
+    by: ['type'],
+    _count: true,
+    _max: { date: true, createdAt: true },
+  })
+
+  if (grouped.length === 0) return []
+
+  // Latest value per type (one query). Segmental types have several positions →
+  // DISTINCT ON returns the most recently measured one, which is fine for an overview.
+  const latest = await prisma.$queryRaw<Array<{ type: number; value: number }>>`
+    SELECT DISTINCT ON (type) type, value
+    FROM "WithingsMeasurement"
+    ORDER BY type, "measuredAt" DESC
+  `
+  const latestValueByType = new Map(latest.map((r) => [r.type, r.value]))
+
+  return grouped.map((g) => {
+    const meta = WITHINGS_MEASURE_TYPES[g.type]
+    const isDashboard = WITHINGS_DASHBOARD_TYPES.has(g.type)
+    return {
+      source: 'WITHINGS',
+      key: String(g.type),
+      displayName: meta?.label ?? measureTypeLabel(g.type),
+      category: meta?.category ?? 'Sonstiges',
+      unit: meta?.unit ?? '',
+      sampleCount: g._count,
+      lastValue: latestValueByType.get(g.type) ?? null,
+      lastValueDate: g._max.date ? g._max.date.toISOString().slice(0, 10) : null,
+      lastReceivedAt: g._max.createdAt ?? new Date(0),
+      // The raw store keeps every measure, so a Withings metric is never "unused".
+      status: isDashboard ? 'DASHBOARD' : 'STORED',
+      dashboardNote: isDashboard ? 'Startseite: Gewicht/Körperfett' : undefined,
+    }
+  })
+}
+
+// =============================================
+// Registry
+// =============================================
+
+const PROVIDERS: Array<() => Promise<InventoryRow[]>> = [
+  getAppleHealthInventory,
+  getWithingsInventory,
+]
+
+/** Runs every source provider and returns the combined inventory. */
+export async function getAllInventory(): Promise<InventoryRow[]> {
+  const results = await Promise.all(PROVIDERS.map((p) => p()))
+  return results.flat()
+}

--- a/src/lib/withings.ts
+++ b/src/lib/withings.ts
@@ -48,6 +48,9 @@ export interface WithingsSyncResult {
 export const MEASURE_WEIGHT = 1
 export const MEASURE_FAT_RATIO = 6
 
+/** Measure types that are mirrored into DailyMetrics and shown on the public dashboard. */
+export const WITHINGS_DASHBOARD_TYPES = new Set<number>([MEASURE_WEIGHT, MEASURE_FAT_RATIO])
+
 export interface MeasureTypeMeta {
   label: string
   unit: string
@@ -67,15 +70,15 @@ export const WITHINGS_MEASURE_TYPES: Record<number, MeasureTypeMeta> = {
   169: { label: 'Intrazellularwasser',        unit: 'kg',    category: 'Körper' },
   174: { label: 'Fettmasse (segmental)',      unit: 'kg',    category: 'Körper' },
   175: { label: 'Muskelmasse (segmental)',    unit: 'kg',    category: 'Körper' },
-  11:  { label: 'Herzfrequenz',               unit: 'bpm',   category: 'Herz & Gefässe' },
-  91:  { label: 'Pulswellengeschwindigkeit',  unit: 'm/s',   category: 'Herz & Gefässe' },
-  155: { label: 'Gefässalter',                unit: 'Jahre', category: 'Herz & Gefässe' },
-  123: { label: 'VO₂ Max',                    unit: 'ml/min/kg', category: 'Herz & Gefässe' },
+  11:  { label: 'Herzfrequenz',               unit: 'bpm',   category: 'Herz & Vitalwerte' },
+  91:  { label: 'Pulswellengeschwindigkeit',  unit: 'm/s',   category: 'Herz & Vitalwerte' },
+  155: { label: 'Gefässalter',                unit: 'Jahre', category: 'Herz & Vitalwerte' },
+  123: { label: 'VO₂ Max',                    unit: 'ml/min/kg', category: 'Herz & Vitalwerte' },
   196: { label: 'Elektrodermale Aktivität (Füsse)', unit: '', category: 'Nerven' },
   4:   { label: 'Körpergrösse',               unit: 'm',     category: 'Körper' },
-  9:   { label: 'Blutdruck diastolisch',      unit: 'mmHg',  category: 'Herz & Gefässe' },
-  10:  { label: 'Blutdruck systolisch',       unit: 'mmHg',  category: 'Herz & Gefässe' },
-  54:  { label: 'SpO₂',                        unit: '%',     category: 'Herz & Gefässe' },
+  9:   { label: 'Blutdruck diastolisch',      unit: 'mmHg',  category: 'Herz & Vitalwerte' },
+  10:  { label: 'Blutdruck systolisch',       unit: 'mmHg',  category: 'Herz & Vitalwerte' },
+  54:  { label: 'SpO₂',                        unit: '%',     category: 'Herz & Vitalwerte' },
   71:  { label: 'Körpertemperatur',           unit: '°C',    category: 'Körper' },
   73:  { label: 'Hauttemperatur',             unit: '°C',    category: 'Körper' },
 }


### PR DESCRIPTION
## Kontext

Die Seite `/admin/health-inventory` war hart auf **Apple Health** verdrahtet (Titel, Text „via `/api/health-import`", las nur `HealthMetricInventory`). Inzwischen gibt es eine zweite Quelle (**Withings**, roh in `WithingsMeasurement`), und als Nächstes kommt **MyFitnessPal** (Nutrition). Die Seite ist jetzt **quellenunabhängig**: jede Quelle liefert ihr Inventar über ein gemeinsames Provider-Interface, dargestellt in **Quellen-Tabs**.

## Ansatz: Source-Provider-Registry

- **`src/lib/inventory.ts`** (neu): generischer `InventoryRow` (mit `source` + `status`) + Registry `getAllInventory()`, die alle Provider parallel ausführt.
  - `getAppleHealthInventory()` — bisherige `HealthMetricInventory`-Logik, gemappt auf `status` DASHBOARD/STORED/UNUSED
  - `getWithingsInventory()` — aus `WithingsMeasurement` abgeleitet (`groupBy(type)` für Count/Datum + `DISTINCT ON (type)` für den letzten Wert); type 1 (Gewicht) & 6 (Körperfett) = **Im Dashboard**, Rest = **Gespeichert** (Roh-Store → nie „ungenutzt")
- **`InventoryBrowser.tsx`** (neu, Client): Quellen-Tabs (Alle / Apple Health / Withings), Statistik-Karten + Kategorie-Tabellen filtern nach aktiver Quelle. Präsentations-Helfer aus der alten `page.tsx` hierher gezogen.
- **`page.tsx`**: dünner Server-Wrapper (`getAllInventory()` → `<InventoryBrowser>`), Titel „Health Inventar", quellenneutraler Text.
- **`health-inventory.ts`**: `lookupMeta`/`MetricMeta` exportiert, view-Logik entfernt (kein `METRIC_MAP`-Duplikat).
- **`withings.ts`**: `WITHINGS_DASHBOARD_TYPES` ergänzt, Kategorie-Vokabular angeglichen.

## MyFitnessPal-Bereitschaft
Neue Quelle = `getMyFitnessPalInventory()` schreiben + in `INVENTORY_SOURCES`/Registry eintragen → Tab erscheint automatisch. Keine Seitenänderung nötig.

## Verifikation
- ✅ `type-check`, ✅ `test` 96/96 (4 neue Inventory-Tests), ✅ `next build` (Route dynamisch)
- Manuell nach Deploy: Tabs Alle/Apple Health/Withings; Withings-Tab listet Körperzusammensetzung, Gewicht/Körperfett = „Im Dashboard", Rest = „Gespeichert"

🤖 Generated with [Claude Code](https://claude.com/claude-code)