### PR TITLE
fix: support German (localized) MyFitnessPal CSV export

### DIFF
--- a/src/app/admin/nutrition-import/actions.ts
+++ b/src/app/admin/nutrition-import/actions.ts
@@ -26,7 +26,7 @@ export async function importNutrition(formData: FormData): Promise<ImportResult>
   const text = await file.text()
   const rows = parseMfpNutritionCsv(text)
   if (rows.length === 0) {
-    return { error: 'Keine gültigen Nutrition-Zeilen gefunden. Ist das die MFP „Nutrition"-CSV (mit Date- und Meal-Spalte)?' }
+    return { error: 'Keine gültigen Nährwert-Zeilen gefunden. Ist das die MFP Nährwerte-/Nutrition-CSV (Spalten Datum/Mahlzeit bzw. Date/Meal)?' }
   }
 
   const summary = await importNutritionCsv(rows, prisma)

--- a/src/app/admin/nutrition-import/page.tsx
+++ b/src/app/admin/nutrition-import/page.tsx
@@ -50,8 +50,8 @@ export default async function NutritionImportPage() {
         <p className="font-semibold text-on-surface">So exportierst du die MFP-Daten</p>
         <ol className="space-y-1 list-decimal list-inside">
           <li>MyFitnessPal Web → <span className="text-on-surface">Einstellungen → Daten exportieren</span> (Nutrition, Zeitraum wählen).</li>
-          <li>Der Export kommt per E-Mail als ZIP mit mehreren CSVs.</li>
-          <li>Hier die <code className="font-mono">Nutrition</code>-CSV hochladen (mit <code className="font-mono">Date</code>- und <code className="font-mono">Meal</code>-Spalte).</li>
+          <li>Der Export kommt als ZIP mit mehreren CSVs (Messwerte, Nährwerte, Training).</li>
+          <li>Hier die <code className="font-mono">Nährwerte</code>-CSV hochladen — Spalten <code className="font-mono">Datum/Mahlzeit</code> (DE) bzw. <code className="font-mono">Date/Meal</code> (EN).</li>
         </ol>
         <p className="mt-2 pt-2 border-t border-outline-variant/10">
           Nur Ernährungsdaten werden übernommen. Gewicht kommt aus Withings, Schritte/Aktivität aus Apple

--- a/src/lib/myfitnesspal.test.ts
+++ b/src/lib/myfitnesspal.test.ts
@@ -51,6 +51,32 @@ describe('parseMfpNutritionCsv', () => {
     const rows = parseMfpNutritionCsv(CSV)
     expect(rows.some((r) => r.meal === 'Snacks')).toBe(false)
   })
+
+  // Real-world: the German MFP export localizes headers (Datum, Mahlzeit, Eiweiß …).
+  it('parses the German (localized) export headers', () => {
+    const deCsv =
+      'Datum,Mahlzeit,Kalorien,Fett (g),Gesättigte Fettsäuren,Mehrfach ungesättigte Fettsäuren,Einfach ungesättigte Fettsäuren,Transfettsäuren,Cholesterin,Natrium (mg),Kalium,Kohlenhydrate (g),Ballaststoffe,Zucker,Eiweiß (g),Vitamin A,Vitamin C,Kalzium,Eisen,export_headers.note\n' +
+      '2026-07-01,Snacks,257.6,6.8,3.9,0.2,0.1,0.0,0.0,0.0,313.6,36.9,4.3,14.5,17.9,10.4,14.0,0.9,2.4,\n'
+
+    const rows = parseMfpNutritionCsv(deCsv)
+    expect(rows).toHaveLength(1)
+    const r = rows[0]
+    expect(r.date).toBe('2026-07-01')
+    expect(r.meal).toBe('Snacks')
+    expect(r.calories).toBeCloseTo(257.6)
+    expect(r.fat).toBeCloseTo(6.8)
+    expect(r.carbs).toBeCloseTo(36.9)
+    expect(r.fiber).toBeCloseTo(4.3)
+    expect(r.sugar).toBeCloseTo(14.5)
+    expect(r.protein).toBeCloseTo(17.9)   // Eiweiß
+    expect(r.sodium).toBe(0)              // Natrium
+    // micros: DE nutrient names folded to canonical keys
+    expect(r.micros.satFat).toBeCloseTo(3.9)
+    expect(r.micros.potassium).toBeCloseTo(313.6) // Kalium
+    expect(r.micros.calcium).toBeCloseTo(0.9)     // Kalzium
+    expect(r.micros.iron).toBeCloseTo(2.4)        // Eisen
+    expect(r.micros.vitaminA).toBeCloseTo(10.4)
+  })
 })
 
 // =============================================

--- a/src/lib/myfitnesspal.ts
+++ b/src/lib/myfitnesspal.ts
@@ -29,32 +29,53 @@ export interface NutritionRow {
 }
 
 // Normalized CSV header → canonical key. Headers are normalized first
-// (lowercased, units in parentheses stripped, whitespace collapsed).
+// (lowercased, diacritics/ß folded, units in parentheses stripped, whitespace
+// collapsed) so both the English and German MFP exports map to the same keys.
 const HEADER_MAP: Record<string, string> = {
+  // meta — EN + DE
   'date': 'date',
+  'datum': 'date',
   'meal': 'meal',
+  'mahlzeit': 'meal',
   'note': 'note',
   'notes': 'note',
-  // macros (typed columns)
+  'notiz': 'note',
+  'export_headers.note': 'note', // DE export ships this untranslated header
+  // macros (typed columns) — EN + DE
   'calories': 'calories',
+  'kalorien': 'calories',
   'protein': 'protein',
+  'eiweiss': 'protein',
   'carbohydrates': 'carbs',
   'carbs': 'carbs',
+  'kohlenhydrate': 'carbs',
   'fat': 'fat',
+  'fett': 'fat',
   'fiber': 'fiber',
+  'ballaststoffe': 'fiber',
   'sugar': 'sugar',
+  'zucker': 'sugar',
   'sodium': 'sodium',
-  // micros (go into the JSON map)
+  'natrium': 'sodium',
+  // micros (go into the JSON map) — EN + DE
   'saturated fat': 'satFat',
+  'gesattigte fettsauren': 'satFat',
   'polyunsaturated fat': 'polyFat',
+  'mehrfach ungesattigte fettsauren': 'polyFat',
   'monounsaturated fat': 'monoFat',
+  'einfach ungesattigte fettsauren': 'monoFat',
   'trans fat': 'transFat',
+  'transfettsauren': 'transFat',
   'cholesterol': 'cholesterol',
+  'cholesterin': 'cholesterol',
   'potassium': 'potassium',
+  'kalium': 'potassium',
   'vitamin a': 'vitaminA',
   'vitamin c': 'vitaminC',
   'calcium': 'calcium',
+  'kalzium': 'calcium',
   'iron': 'iron',
+  'eisen': 'iron',
 }
 
 /** Nutrient metadata for display (macros + known micros). */
@@ -82,17 +103,27 @@ export function nutrientLabel(key: string): string {
   return NUTRIENT_META[key]?.label ?? key
 }
 
-// Normalize a raw CSV header: lowercase, drop "(unit)", collapse whitespace.
+// Normalize a raw CSV header: lowercase, fold German diacritics/ß (ä→a, ü→u,
+// ß→ss) so DE and EN headers match the same keys, drop "(unit)", collapse space.
 function normalizeHeader(h: string): string {
-  return h.toLowerCase().replace(/\([^)]*\)/g, '').replace(/\s+/g, ' ').trim()
+  return h
+    .toLowerCase()
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/ß/g, 'ss')
+    .replace(/\([^)]*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
-// Parse a numeric cell; tolerates thousands separators and empty values.
+// Parse a numeric cell; tolerates German decimal commas, thousands separators
+// and empty values.
 function parseNumber(raw: string | undefined): number | null {
   if (raw == null) return null
-  const cleaned = raw.replace(/,/g, '').trim()
-  if (cleaned === '') return null
-  const n = Number(cleaned)
+  let s = raw.trim()
+  if (s === '') return null
+  // "1234,5" (German decimal) → "1234.5"; "1,234" (thousands) → "1234"
+  s = s.includes(',') && !s.includes('.') ? s.replace(',', '.') : s.replace(/,/g, '')
+  const n = Number(s)
   return Number.isFinite(n) ? n : null
 }
 


### PR DESCRIPTION
## Kontext

Der reale MyFitnessPal-Export ist **lokalisiert** — deutsche Spaltenüberschriften (`Datum`, `Mahlzeit`, `Kalorien`, `Eiweiß (g)`, `Gesättigte Fettsäuren` …). Der Parser aus #210 mappte nur englische Header und hätte **alle Zeilen verworfen** → Import „keine gültigen Zeilen".

Dieser Fix war in #210 committet, ging aber beim Squash-Merge verloren (GitHub-PR-Head hing durch Backend-Lag noch auf dem Vorgänger-Commit, als gemergt wurde). Hier per Cherry-pick nachgereicht.

## Änderungen
- `normalizeHeader` faltet Umlaute/ß (ä→a, ß→ss) → DE- und EN-Header treffen dieselben Keys
- deutsche Header-Aliase in `HEADER_MAP` (inkl. der untranslated `export_headers.note`-Spalte)
- `parseNumber` unterstützt deutsche Dezimalkommas
- Admin-Hinweis/Fehlermeldung nennen Nährwerte-CSV + Datum/Mahlzeit
- Test mit echter deutscher Header-Zeile aus dem Export

## Verifikation
- ✅ `type-check`, ✅ Parser-Tests 5/5 (inkl. deutschem Header-Fall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)