### PR TITLE
feat: add sick day tracking for journal entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Journal-Einträge werden in PostgreSQL gespeichert (JournalEntry Model), nicht a
 
 - Feld `bannerUrl` (nicht `bannerImage` oder `imageUrl`)
 - Felder `movement`, `nutrition`, `smoking` (nicht `habitMovement` etc.)
+- Feld `sickDay` (Boolean, Default `false`): Krankheitstag — Habits bleiben erfasst, zählen aber statistisch neutral. Streaks pausieren (`calculateStreak` mit `null`), Tag fliegt aus Zähler+Nenner der Erfüllungsquoten, Heatmap-Level `-2` (`SICK_LEVEL`), öffentliches Badge „Krank", kein Perfect Day
 - `published` Default: `true`
 - Übersetzungen: separates `Translation` Model
 - Prisma Client Singleton: `lib/db.ts`

--- a/messages/de.json
+++ b/messages/de.json
@@ -149,7 +149,8 @@
       "replacement": "Nikotinersatz",
       "smokeFree": "Rauchfrei"
     },
-    "dayCount": "{count, plural, one {# Tag} other {# Tage}} seit Projektstart"
+    "dayCount": "{count, plural, one {# Tag} other {# Tage}} seit Projektstart",
+    "sickDay": "Krank — zählt nicht"
   },
   "MetricsDashboard": {
     "heading": "Metriken",
@@ -188,7 +189,8 @@
     "day": "Tag {number}",
     "readMore": "Weiterlesen →",
     "perfectDay": "Perfekter Tag",
-    "fillerBadge": "Tagesnotiz"
+    "fillerBadge": "Tagesnotiz",
+    "sickBadge": "Krank"
   },
   "SearchModal": {
     "ariaLabel": "Suchen",
@@ -224,6 +226,8 @@
       "smoked": "Geraucht",
       "nicotine_replacement": "Nikotinersatz",
       "smoke_free": "Rauchfrei"
-    }
+    },
+    "sickDay": "Krankheitstag",
+    "sickDayTitle": "Krankheitstag — Habits pausiert"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -149,7 +149,8 @@
       "replacement": "NRT used",
       "smokeFree": "Smoke-free"
     },
-    "dayCount": "{count, plural, one {# day} other {# days}} since project start"
+    "dayCount": "{count, plural, one {# day} other {# days}} since project start",
+    "sickDay": "Sick — not counted"
   },
   "MetricsDashboard": {
     "heading": "Metrics",
@@ -188,7 +189,8 @@
     "day": "Day {number}",
     "readMore": "Read more →",
     "perfectDay": "Perfect Day",
-    "fillerBadge": "Daily note"
+    "fillerBadge": "Daily note",
+    "sickBadge": "Sick"
   },
   "SearchModal": {
     "ariaLabel": "Search",
@@ -224,6 +226,8 @@
       "smoked": "Smoked",
       "nicotine_replacement": "NRT used",
       "smoke_free": "Smoke-free"
-    }
+    },
+    "sickDay": "Sick day",
+    "sickDayTitle": "Sick day — habits paused"
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -146,7 +146,8 @@
       "replacement": "Substituto de nicotina",
       "smokeFree": "Sem fumar"
     },
-    "dayCount": "{count, plural, one {# dia} other {# dias}} desde o início do projeto"
+    "dayCount": "{count, plural, one {# dia} other {# dias}} desde o início do projeto",
+    "sickDay": "Doente — não conta"
   },
   "MetricsDashboard": {
     "heading": "Métricas",
@@ -185,7 +186,8 @@
     "day": "Dia {number}",
     "readMore": "Ler mais →",
     "perfectDay": "Dia Perfeito",
-    "fillerBadge": "Nota do dia"
+    "fillerBadge": "Nota do dia",
+    "sickBadge": "Doente"
   },
   "SearchModal": {
     "ariaLabel": "Pesquisar",
@@ -221,6 +223,8 @@
       "smoked": "Fumou",
       "nicotine_replacement": "Substituto de nicotina",
       "smoke_free": "Sem fumar"
-    }
+    },
+    "sickDay": "Dia de doença",
+    "sickDayTitle": "Dia de doença — hábitos pausados"
   }
 }

--- a/prisma/migrations/20260707000000_add_sick_day/migration.sql
+++ b/prisma/migrations/20260707000000_add_sick_day/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JournalEntry" ADD COLUMN "sickDay" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,10 @@ model JournalEntry {
   // Süssigkeiten: null = nicht erfasst, false = keine, true = konsumiert
   sweetsConsumed Boolean?
 
+  // Krankheitstag: Habits bleiben erfasst, zählen aber statistisch neutral
+  // (Streaks pausieren, Tag fliegt aus den Erfüllungsquoten)
+  sickDay Boolean @default(false)
+
   // Privates Notizfeld — niemals in öffentlichen Queries zurückgeben
   privateNotes String? @db.Text
 

--- a/src/app/admin/entries/[id]/edit/page.tsx
+++ b/src/app/admin/entries/[id]/edit/page.tsx
@@ -26,6 +26,7 @@ export default async function EditEntryPage({ params }: EditEntryPageProps) {
     movement: entry.movement,
     nutrition: entry.nutrition,
     smoking: entry.smoking,
+    sickDay: entry.sickDay,
     tags: entry.tags,
     published: entry.published,
     privateNotes: entry.privateNotes ?? '',

--- a/src/app/admin/entries/actions.ts
+++ b/src/app/admin/entries/actions.ts
@@ -20,6 +20,7 @@ export interface EntryFormData {
   movement: MovementLevel
   nutrition: NutritionLevel
   smoking: SmokingStatus
+  sickDay: boolean
   tags: string[]
   published: boolean
   privateNotes?: string
@@ -78,6 +79,7 @@ export async function createEntry(data: EntryFormData): Promise<ActionResult> {
         movement: data.movement,
         nutrition: data.nutrition,
         smoking: data.smoking,
+        sickDay: data.sickDay,
         tags: isFiller ? [] : data.tags,
         published: data.published,
         privateNotes: data.privateNotes?.trim() || null,
@@ -121,6 +123,7 @@ export async function updateEntry(id: string, data: EntryFormData): Promise<Acti
         movement: data.movement,
         nutrition: data.nutrition,
         smoking: data.smoking,
+        sickDay: data.sickDay,
         tags: isFiller ? [] : data.tags,
         published: data.published,
         privateNotes: data.privateNotes?.trim() || null,

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -32,6 +32,7 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
         movement: true,
         nutrition: true,
         smoking: true,
+        sickDay: true,
         translations: { select: { locale: true, updatedAt: true } },
       },
     }),
@@ -87,6 +88,11 @@ export default async function EntriesPage({ searchParams }: EntriesPageProps) {
                     {entry.entryType === 'FILLER' && (
                       <span className="text-xs px-1.5 py-0.5 bg-surface-container-high text-on-surface-variant rounded shrink-0">
                         Tagesnotiz
+                      </span>
+                    )}
+                    {entry.sickDay && (
+                      <span className="text-xs px-1.5 py-0.5 bg-tertiary/15 text-tertiary rounded shrink-0">
+                        Krank
                       </span>
                     )}
                     {!entry.published && (

--- a/src/components/admin/EntryForm.tsx
+++ b/src/components/admin/EntryForm.tsx
@@ -63,6 +63,7 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
     (mealLog?.score != null ? scoreToNutritionLevel(mealLog.score) : 'TWO_MEALS')
   const [nutrition, setNutrition] = useState<NutritionLevel>(defaultNutrition)
   const [smoking, setSmoking] = useState<SmokingStatus>(initial?.smoking ?? 'SMOKE_FREE')
+  const [sickDay, setSickDay] = useState(initial?.sickDay ?? false)
   const [bannerUrl, setBannerUrl] = useState<string | undefined>(initial?.bannerUrl)
   const [tags, setTags] = useState<string>(initial?.tags?.join(', ') ?? '')
   const [published, setPublished] = useState(initial?.published ?? true)
@@ -109,6 +110,7 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
       movement,
       nutrition,
       smoking,
+      sickDay,
       tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
       published,
       privateNotes,
@@ -168,6 +170,7 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
           movement={movement}
           nutrition={nutrition}
           smoking={smoking}
+          sickDay={sickDay}
           tags={tags}
           bannerUrl={bannerUrl}
           mealScore={mealLog?.score}
@@ -385,17 +388,50 @@ export function EntryForm({ mode, entryId, initial, mealLog }: EntryFormProps) {
         />
       </div>
 
-      {/* Die drei Säulen */}
-      <HabitsPicker
-        movement={movement}
-        nutrition={nutrition}
-        smoking={smoking}
-        onMovementChange={setMovement}
-        onNutritionChange={setNutrition}
-        onSmokingChange={setSmoking}
-        nutritionLocked={!!mealLog?.score}
-        mealScore={mealLog?.score}
-      />
+      {/* Krankheitstag */}
+      <div className="rounded-xl border border-outline-variant/30 bg-surface-container-low p-4 space-y-1.5">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setSickDay((s) => !s)}
+            className={clsx(
+              'relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none',
+              sickDay ? 'bg-tertiary' : 'bg-outline'
+            )}
+          >
+            <span
+              className={clsx(
+                'inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform',
+                sickDay ? 'translate-x-4.5' : 'translate-x-0.5'
+              )}
+            />
+          </button>
+          <span className="flex items-center gap-1.5 text-sm text-on-surface-variant">
+            <span className="material-symbols-outlined text-base" style={{ fontVariationSettings: "'FILL' 0" }}>sick</span>
+            Krankheitstag
+          </span>
+        </div>
+        {sickDay && (
+          <p className="text-xs text-on-surface-variant">
+            Der Tag wird öffentlich als Kranktag markiert. Die Säulen zählen nicht in Statistik und
+            Erfüllungsquoten, Streaks pausieren (weder unterbrochen noch erhöht).
+          </p>
+        )}
+      </div>
+
+      {/* Die drei Säulen — auf Kranktagen statistisch irrelevant, daher gedimmt */}
+      <div className={clsx(sickDay && 'opacity-40 pointer-events-none select-none')} aria-disabled={sickDay}>
+        <HabitsPicker
+          movement={movement}
+          nutrition={nutrition}
+          smoking={smoking}
+          onMovementChange={setMovement}
+          onNutritionChange={setNutrition}
+          onSmokingChange={setSmoking}
+          nutritionLocked={!!mealLog?.score}
+          mealScore={mealLog?.score}
+        />
+      </div>
 
       {/* Submit */}
       <div className="flex items-center justify-between pt-2">

--- a/src/components/admin/EntryPreview.tsx
+++ b/src/components/admin/EntryPreview.tsx
@@ -74,6 +74,8 @@ export interface EntryPreviewProps {
   movement: MovementLevel
   nutrition: NutritionLevel
   smoking: SmokingStatus
+  /** Krankheitstag — ersetzt die drei Säulen-Badges durch ein neutrales Badge. */
+  sickDay?: boolean
   tags: string
   bannerUrl?: string
   /** When a meal-log score is present, the nutrition badge shows the score (e.g. `9.6 / 10`)
@@ -92,6 +94,7 @@ export function EntryPreview({
   movement,
   nutrition,
   smoking,
+  sickDay = false,
   tags,
   bannerUrl,
   mealScore,
@@ -162,21 +165,31 @@ export function EntryPreview({
 
           {/* Habit badges */}
           <div className="flex flex-wrap gap-1.5">
-            <HabitBadge
-              label={MOVEMENT_LABELS[movement]}
-              fulfilled={isMovementOk(movement)}
-              colorClass="bg-movement-100 bg-movement-600/20 text-movement-700 text-movement-400"
-            />
-            <HabitBadge
-              label={nutritionLabel}
-              fulfilled={isNutritionOk(nutrition, mealScore)}
-              colorClass="bg-nutrition-100 bg-nutrition-600/20 text-nutrition-700 text-nutrition-400"
-            />
-            <HabitBadge
-              label={SMOKING_LABELS[smoking]}
-              fulfilled={isSmokingOk(smoking)}
-              colorClass="bg-smoking-100 bg-smoking-600/20 text-smoking-700 text-smoking-400"
-            />
+            {sickDay ? (
+              <HabitBadge
+                label="Krankheitstag"
+                fulfilled
+                colorClass="bg-tertiary/20 text-tertiary"
+              />
+            ) : (
+              <>
+                <HabitBadge
+                  label={MOVEMENT_LABELS[movement]}
+                  fulfilled={isMovementOk(movement)}
+                  colorClass="bg-movement-100 bg-movement-600/20 text-movement-700 text-movement-400"
+                />
+                <HabitBadge
+                  label={nutritionLabel}
+                  fulfilled={isNutritionOk(nutrition, mealScore)}
+                  colorClass="bg-nutrition-100 bg-nutrition-600/20 text-nutrition-700 text-nutrition-400"
+                />
+                <HabitBadge
+                  label={SMOKING_LABELS[smoking]}
+                  fulfilled={isSmokingOk(smoking)}
+                  colorClass="bg-smoking-100 bg-smoking-600/20 text-smoking-700 text-smoking-400"
+                />
+              </>
+            )}
           </div>
 
           {/* Tags */}

--- a/src/components/habits/HabitYearGrid.tsx
+++ b/src/components/habits/HabitYearGrid.tsx
@@ -4,6 +4,12 @@ import { useTranslations, useLocale } from 'next-intl'
 
 type Pillar = 'movement' | 'nutrition' | 'smoking'
 
+// Krankheitstag — neutraler Sonderzustand. Muss mit SICK_LEVEL in
+// `lib/habits.ts` übereinstimmen (dort dupliziert, weil dieses Client-Modul
+// lib/habits nicht importieren darf — es zieht Prisma in den Bundle).
+const SICK_LEVEL = -2
+const SICK_COLOR = 'bg-tertiary/25'
+
 // All class names must be static strings for Tailwind to include them
 const COLOR_BY_LEVEL: Record<Pillar, readonly string[]> = {
   movement: [
@@ -126,6 +132,7 @@ export function HabitYearGrid({ movementDays, nutritionDays, smokingDays }: Habi
   }
 
   function getLabel(pillar: Pillar, level: number): string {
+    if (level === SICK_LEVEL) return t('sickDay')
     if (level === -1) return t('noEntry')
     const key = LEVEL_KEYS[pillar][level]
     return key ? t(key as Parameters<typeof t>[0]) : t('noEntry')
@@ -186,7 +193,10 @@ export function HabitYearGrid({ movementDays, nutritionDays, smokingDays }: Habi
                           }
 
                           const level = levelMap.get(dateStr) ?? -1
-                          const colorClass = colors[level + 1] ?? 'bg-surface-container-low'
+                          const colorClass =
+                            level === SICK_LEVEL
+                              ? SICK_COLOR
+                              : colors[level + 1] ?? 'bg-surface-container-low'
 
                           return (
                             <div

--- a/src/components/habits/HabitsDashboard.tsx
+++ b/src/components/habits/HabitsDashboard.tsx
@@ -8,6 +8,7 @@ import {
   getMovementLevel,
   getNutritionLevel,
   getSmokingLevel,
+  SICK_LEVEL,
 } from '@/lib/habits'
 import { HabitPillar } from './HabitPillar'
 import { HabitYearGrid } from './HabitYearGrid'
@@ -34,31 +35,39 @@ export async function HabitsDashboard() {
   const today = new Date().toISOString().slice(0, 10)
   const allDates = generateDateRange(startDate, today)
 
-  const movementDays = allDates.map((date) => ({
-    date,
-    level: entryMap.has(date) ? getMovementLevel(entryMap.get(date)!.habits.movement) : -1,
-  }))
+  const movementDays = allDates.map((date) => {
+    const e = entryMap.get(date)
+    return {
+      date,
+      level: e ? (e.sickDay ? SICK_LEVEL : getMovementLevel(e.habits.movement)) : -1,
+    }
+  })
   const nutritionDays = allDates.map((date) => {
     const e = entryMap.get(date)
     return {
       date,
-      level: e ? getNutritionLevel(e.habits.nutrition, e.mealScore) : -1,
+      level: e ? (e.sickDay ? SICK_LEVEL : getNutritionLevel(e.habits.nutrition, e.mealScore)) : -1,
     }
   })
-  const smokingDays = allDates.map((date) => ({
-    date,
-    level: entryMap.has(date) ? getSmokingLevel(entryMap.get(date)!.habits.smoking) : -1,
-  }))
+  const smokingDays = allDates.map((date) => {
+    const e = entryMap.get(date)
+    return {
+      date,
+      level: e ? (e.sickDay ? SICK_LEVEL : getSmokingLevel(e.habits.smoking)) : -1,
+    }
+  })
 
-  const movementFulfilled = entries.filter((e) => isMovementFulfilled(e.habits.movement)).length
-  const nutritionFulfilled = entries.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)).length
-  const smokingFulfilled = entries.filter((e) => isSmokingFulfilled(e.habits.smoking)).length
+  // Krankheitstage zählen weder in Zähler noch Nenner der Erfüllungsquoten
+  const activeEntries = entries.filter((e) => !e.sickDay)
+  const movementFulfilled = activeEntries.filter((e) => isMovementFulfilled(e.habits.movement)).length
+  const nutritionFulfilled = activeEntries.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)).length
+  const smokingFulfilled = activeEntries.filter((e) => isSmokingFulfilled(e.habits.smoking)).length
 
   // Letzte 30 Tage (Tage mit Eintrag, max 30 jüngste)
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - 29)
   const cutoffISO = cutoff.toISOString().slice(0, 10)
-  const recent = entries.filter((e) => e.date >= cutoffISO)
+  const recent = activeEntries.filter((e) => e.date >= cutoffISO)
   const recentTotal = recent.length
   const movementRecent = recent.filter((e) => isMovementFulfilled(e.habits.movement)).length
   const nutritionRecent = recent.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)).length
@@ -82,21 +91,21 @@ export async function HabitsDashboard() {
         <HabitPillar
           pillar="movement"
           totalFulfilled={movementFulfilled}
-          totalEntries={entries.length}
+          totalEntries={activeEntries.length}
           recentFulfilled={movementRecent}
           recentTotal={recentTotal}
         />
         <HabitPillar
           pillar="nutrition"
           totalFulfilled={nutritionFulfilled}
-          totalEntries={entries.length}
+          totalEntries={activeEntries.length}
           recentFulfilled={nutritionRecent}
           recentTotal={recentTotal}
         />
         <HabitPillar
           pillar="smoking"
           totalFulfilled={smokingFulfilled}
-          totalEntries={entries.length}
+          totalEntries={activeEntries.length}
           recentFulfilled={smokingRecent}
           recentTotal={recentTotal}
         />

--- a/src/components/journal/HabitBadges.tsx
+++ b/src/components/journal/HabitBadges.tsx
@@ -9,6 +9,9 @@ interface HabitBadgesProps {
    * the nutrition badge shows the score (e.g. `9.6 / 10`) instead of the
    * meal-count label, and fulfillment is computed from the score. */
   mealScore?: number | null
+  /** Sick day: replaces the three pillar badges with a single neutral
+   * "sick day" badge — habits are recorded but statistically paused. */
+  sickDay?: boolean
 }
 
 interface BadgeProps {
@@ -35,8 +38,23 @@ function HabitBadge({ label, fulfilled, colorClass, dimClass, icon, title }: Bad
   )
 }
 
-export function HabitBadges({ habits, mealScore }: HabitBadgesProps) {
+export function HabitBadges({ habits, mealScore, sickDay = false }: HabitBadgesProps) {
   const t = useTranslations('HabitBadges')
+
+  if (sickDay) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <span
+          className="inline-flex items-center gap-1.5 text-xs font-label font-bold tracking-widest uppercase px-2.5 py-1 rounded-full border bg-tertiary/10 text-tertiary border-tertiary/30"
+          title={t('sickDayTitle')}
+        >
+          <Icon name="sick" size={14} fill />
+          {t('sickDay')}
+        </span>
+      </div>
+    )
+  }
+
   const hasScore = mealScore !== null && mealScore !== undefined
   const nutritionLabel = hasScore
     ? `${mealScore.toFixed(1)} / 10`

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -20,8 +20,16 @@ export async function JournalCard({ entry }: JournalCardProps) {
 
   const excerpt = entry.excerpt ?? ''
   const dayNumber = getDayNumber(entry.date, startDate)
-  const perfect = isPerfectDay(entry.habits, entry.mealScore)
+  const sick = entry.sickDay
+  const perfect = !sick && isPerfectDay(entry.habits, entry.mealScore)
   const isFiller = entry.entryType === 'filler'
+
+  const sickBadge = sick ? (
+    <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-tertiary bg-tertiary/10 border border-tertiary/20 rounded px-2 py-0.5">
+      <Icon name="sick" size={12} fill />
+      {t('sickBadge')}
+    </span>
+  ) : null
 
   function formatDate(dateStr: string): string {
     return new Date(dateStr).toLocaleDateString(locale, {
@@ -69,6 +77,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
             <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-on-surface-variant bg-surface-container-high border border-outline-variant/20 rounded px-2 py-0.5">
               {t('fillerBadge')}
             </span>
+            {sickBadge}
             {perfect && (
               <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2 py-0.5">
                 ✦ {t('perfectDay')}
@@ -87,7 +96,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
           )}
 
           <div className="pt-2 border-t border-outline-variant/10">
-            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} />
+            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} sickDay={sick} />
           </div>
         </div>
       </article>
@@ -124,6 +133,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
             <span className="font-label font-bold text-xs tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2.5 py-0.5">
               {t('day', { number: dayNumber })}
             </span>
+            {sickBadge}
             {perfect && (
               <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2 py-0.5">
                 ✦ {t('perfectDay')}
@@ -146,7 +156,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
           )}
 
           <div className="flex items-center justify-between gap-4 pt-2 border-t border-outline-variant/10">
-            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} />
+            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} sickDay={sick} />
             <span className="inline-flex items-center gap-1 text-xs font-label font-bold tracking-widest uppercase text-primary shrink-0 group-hover:gap-1.5 transition-all duration-150">
               {t('readMore')}
               <Icon name="arrow_forward" size={12} />

--- a/src/components/journal/JournalCardHome.tsx
+++ b/src/components/journal/JournalCardHome.tsx
@@ -4,6 +4,7 @@ import type { JournalEntryMeta } from '@/lib/journal'
 import { getDayNumber, isPerfectDay } from '@/lib/journal'
 import { getProjectStartDate } from '@/lib/project-config'
 import { ReactionBarCompact } from '@/components/reactions/ReactionBarCompact'
+import { Icon } from '@/components/ui/Icon'
 
 interface JournalCardHomeProps {
   entry: JournalEntryMeta
@@ -17,8 +18,16 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
   ])
 
   const dayNumber = getDayNumber(entry.date, startDate)
-  const perfect = isPerfectDay(entry.habits, entry.mealScore)
+  const sick = entry.sickDay
+  const perfect = !sick && isPerfectDay(entry.habits, entry.mealScore)
   const isFiller = entry.entryType === 'filler'
+
+  const sickBadge = sick ? (
+    <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-tertiary bg-tertiary/10 border border-tertiary/20 rounded px-2 py-0.5 mr-1">
+      <Icon name="sick" size={12} fill />
+      {t('sickBadge')}
+    </span>
+  ) : null
 
   const formattedDate = new Date(entry.date).toLocaleDateString(locale, {
     day: 'numeric',
@@ -40,6 +49,7 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
             <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-on-surface-variant bg-surface-container-high border border-outline-variant/20 rounded px-2 py-0.5 mr-1">
               {t('fillerBadge')}
             </span>
+            {sickBadge}
             {perfect && (
               <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2 py-0.5">
                 ✦ {t('perfectDay')}
@@ -76,6 +86,7 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
 
         {/* Date + Day number */}
         <div className="flex items-center gap-2">
+          {sickBadge}
           {perfect && (
             <span className="inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase text-primary bg-primary/10 border border-primary/20 rounded px-2 py-0.5 mr-1">
               ✦ {t('perfectDay')}

--- a/src/components/journal/JournalPost.tsx
+++ b/src/components/journal/JournalPost.tsx
@@ -85,7 +85,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
       )}
 
       <div className="flex flex-col gap-3 mb-8">
-        <HabitBadges habits={entry.habits} mealScore={entry.mealScore} />
+        <HabitBadges habits={entry.habits} mealScore={entry.mealScore} sickDay={entry.sickDay} />
         {entry.tags && entry.tags.length > 0 && (
           <ul className="flex flex-wrap gap-2">
             {entry.tags.map((tag) => (

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -199,4 +199,36 @@ describe('calculateStreak', () => {
       longest: 4,
     })
   })
+
+  // Krankheitstage (null) pausieren den Streak: weder unterbrochen noch gezählt.
+  it('null pauses the current streak instead of breaking it', () => {
+    // newest first: [true, null, true, true]
+    expect(calculateStreak([true, null, true, true])).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('current streak continues past leading nulls', () => {
+    // newest entries are sick days, streak from before continues
+    expect(calculateStreak([null, null, true, true])).toEqual({ current: 2, longest: 2 })
+  })
+
+  it('null does not count toward the streak length', () => {
+    expect(calculateStreak([true, null, null, true])).toEqual({ current: 2, longest: 2 })
+  })
+
+  it('false after null still breaks the current streak', () => {
+    // newest first: [true, null, false, true]
+    expect(calculateStreak([true, null, false, true])).toEqual({ current: 1, longest: 1 })
+  })
+
+  it('longest streak spans a null gap', () => {
+    // [false, true, null, true, true, false]
+    expect(calculateStreak([false, true, null, true, true, false])).toEqual({
+      current: 0,
+      longest: 3,
+    })
+  })
+
+  it('all null returns 0/0', () => {
+    expect(calculateStreak([null, null, null])).toEqual({ current: 0, longest: 0 })
+  })
 })

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -69,26 +69,29 @@ export interface StreakResult {
 
 /**
  * Berechnet den aktuellen und längsten Streak aus einer Boolean-Liste.
- * @param values - sortiert neueste zuerst
+ * @param values - sortiert neueste zuerst. `null` = neutraler Tag
+ *   (Krankheitstag): pausiert den Streak — weder unterbrochen noch gezählt.
  */
-export function calculateStreak(values: boolean[]): StreakResult {
+export function calculateStreak(values: (boolean | null)[]): StreakResult {
   // Aktueller Streak: konsekutive `true`-Werte ab dem neuesten Eintrag
   let current = 0
   for (const v of values) {
-    if (v) current++
-    else break
+    if (v === true) current++
+    else if (v === false) break
+    // null → skip, Streak läuft weiter
   }
 
   // Längster Streak: längste konsekutive `true`-Sequenz
   let longest = 0
   let run = 0
   for (const v of values) {
-    if (v) {
+    if (v === true) {
       run++
       if (run > longest) longest = run
-    } else {
+    } else if (v === false) {
       run = 0
     }
+    // null → run bleibt
   }
 
   return { current, longest }
@@ -96,8 +99,16 @@ export function calculateStreak(values: boolean[]): StreakResult {
 
 // =============================================
 // Erfüllungsgrad-Level (für Heatmap)
-//   -1 = kein Eintrag, 0 = niedrigster, max = bester
+//   -2 = Krankheitstag (neutral), -1 = kein Eintrag, 0 = niedrigster, max = bester
 // =============================================
+
+/**
+ * Heatmap-Level für Krankheitstage — neutraler Sonderzustand, weder Erfolg
+ * noch Misserfolg. Muss mit der lokalen Konstante in `HabitYearGrid.tsx`
+ * übereinstimmen (dort dupliziert, weil Client-Komponenten dieses Modul
+ * nicht importieren dürfen — es zieht Prisma in den Bundle).
+ */
+export const SICK_LEVEL = -2
 
 export function getMovementLevel(m: MovementValue): number {
   if (m === 'steps_trained') return 3
@@ -127,17 +138,23 @@ export function getSmokingLevel(s: SmokingValue): number {
 
 export async function getMovementStreak(): Promise<StreakResult> {
   const entries = await getAllEntries()
-  return calculateStreak(entries.map((e) => isMovementFulfilled(e.habits.movement)))
+  return calculateStreak(
+    entries.map((e) => (e.sickDay ? null : isMovementFulfilled(e.habits.movement))),
+  )
 }
 
 export async function getNutritionStreak(): Promise<StreakResult> {
   const entries = await getAllEntries()
-  return calculateStreak(entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)))
+  return calculateStreak(
+    entries.map((e) => (e.sickDay ? null : isNutritionFulfilled(e.habits.nutrition, e.mealScore))),
+  )
 }
 
 export async function getSmokingStreak(): Promise<StreakResult> {
   const entries = await getAllEntries()
-  return calculateStreak(entries.map((e) => isSmokingFulfilled(e.habits.smoking)))
+  return calculateStreak(
+    entries.map((e) => (e.sickDay ? null : isSmokingFulfilled(e.habits.smoking))),
+  )
 }
 
 /**

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -35,6 +35,12 @@ export interface JournalEntry {
   dailyQuote?: string | null
   sweetsConsumed?: boolean | null
   /**
+   * Krankheitstag: Habits bleiben erfasst, werden aber statistisch neutral
+   * behandelt — Streaks pausieren, der Tag zählt nicht in die Erfüllungsquoten
+   * und wird öffentlich als Kranktag markiert.
+   */
+  sickDay: boolean
+  /**
    * Nutrition score (0–10) from the day's MealLog, when one exists. The enum
    * `habits.nutrition` mirrors this via `scoreToNutritionLevel` (auto-synced
    * by `saveMealLogAction`), but the raw score is the canonical fulfillment
@@ -106,6 +112,7 @@ function toMeta(entry: PrismaJournalEntry): JournalEntryMeta {
       smoking: SMOKING_TO_VALUE[entry.smoking],
     },
     sweetsConsumed: entry.sweetsConsumed,
+    sickDay: entry.sickDay,
   }
 }
 

--- a/src/lib/month-summary.ts
+++ b/src/lib/month-summary.ts
@@ -87,6 +87,7 @@ interface EntryContext {
   movement: MovementLevel
   nutrition: NutritionLevel
   smoking: SmokingStatus
+  sickDay: boolean
 }
 
 interface MetricsContext {
@@ -130,6 +131,7 @@ interface SummaryContext {
     nutritionGood: string
     smokingClean: string
     smokingSmoked: string
+    sickDays: number
   }
   metrics: MetricsContext
   drinks: DrinksContext
@@ -140,7 +142,11 @@ interface SummaryContext {
 
 function buildPrompt(ctx: SummaryContext): string {
   const entriesText = ctx.entries
-    .map((e) => `- ${e.date} "${e.title}" | Bewegung: ${e.movement} | Ernährung: ${e.nutrition} | Rauchen: ${e.smoking}${e.excerpt ? ` | "${e.excerpt}"` : ''}`)
+    .map((e) =>
+      e.sickDay
+        ? `- ${e.date} "${e.title}" | KRANKHEITSTAG (Habits pausiert)${e.excerpt ? ` | "${e.excerpt}"` : ''}`
+        : `- ${e.date} "${e.title}" | Bewegung: ${e.movement} | Ernährung: ${e.nutrition} | Rauchen: ${e.smoking}${e.excerpt ? ` | "${e.excerpt}"` : ''}`,
+    )
     .join('\n')
 
   const booksCompletedText = ctx.books.booksCompleted.length > 0
@@ -158,6 +164,7 @@ HABITS-STATISTIK (die drei Säulen):
 - Ernährung gut (mind. 2 Mahlzeiten): ${ctx.habitStats.nutritionGood}
 - Nicht geraucht (NICOTINE_REPLACEMENT oder SMOKE_FREE): ${ctx.habitStats.smokingClean}
 - Geraucht (SMOKED): ${ctx.habitStats.smokingSmoked}
+- Krankheitstage (zählen nicht in die Quoten): ${ctx.habitStats.sickDays}
 
 METRIKEN (Monatsdurchschnitt):
 - Gewicht: ${fmt(ctx.metrics.avgWeight, 1, ' kg')}
@@ -227,7 +234,7 @@ export async function generateAndSaveMonthSummary(year: number, month: number): 
     prisma.journalEntry.findMany({
       where: { date: { gte: start, lte: end }, published: true },
       orderBy: { date: 'asc' },
-      select: { date: true, title: true, excerpt: true, movement: true, nutrition: true, smoking: true },
+      select: { date: true, title: true, excerpt: true, movement: true, nutrition: true, smoking: true, sickDay: true },
     }),
     prisma.dailyMetrics.findMany({
       where: { date: { gte: start, lte: end } },
@@ -251,9 +258,11 @@ export async function generateAndSaveMonthSummary(year: number, month: number): 
     }),
   ])
 
-  const movements = entries.map((e) => e.movement)
-  const nutritions = entries.map((e) => e.nutrition)
-  const smokings = entries.map((e) => e.smoking)
+  // Krankheitstage zählen nicht in die Habit-Quoten (neutral)
+  const activeEntries = entries.filter((e) => !e.sickDay)
+  const movements = activeEntries.map((e) => e.movement)
+  const nutritions = activeEntries.map((e) => e.nutrition)
+  const smokings = activeEntries.map((e) => e.smoking)
 
   // Drinks: group by day to compute daily averages
   const drinkDays = new Map<string, { water: number; cola: number }>()
@@ -296,12 +305,14 @@ export async function generateAndSaveMonthSummary(year: number, month: number): 
       movement: e.movement,
       nutrition: e.nutrition,
       smoking: e.smoking,
+      sickDay: e.sickDay,
     })),
     habitStats: {
       movementGood: habitRate(movements, [MovementLevel.STEPS_ONLY, MovementLevel.TRAINED_ONLY, MovementLevel.STEPS_TRAINED]),
       nutritionGood: habitRate(nutritions, [NutritionLevel.TWO_MEALS, NutritionLevel.THREE_MEALS]),
       smokingClean: habitRate(smokings, [SmokingStatus.NICOTINE_REPLACEMENT, SmokingStatus.SMOKE_FREE]),
       smokingSmoked: habitRate(smokings, [SmokingStatus.SMOKED]),
+      sickDays: entries.length - activeEntries.length,
     },
     metrics: {
       avgWeight: avg(metricsRows.map((m) => m.weight)),


### PR DESCRIPTION
## Beschreibung

Neues Feld `sickDay` auf `JournalEntry`: Krankheitstage können im Admin-Editor per Toggle markiert werden, werden öffentlich als solche ausgewiesen und beeinflussen die Habit-Statistik nicht mehr negativ.

- **Schema:** `sickDay Boolean @default(false)` + Migration `20260707000000_add_sick_day`
- **Streaks pausieren:** `calculateStreak` akzeptiert `null` — Kranktage unterbrechen den Streak nicht und zählen nicht mit
- **Erfüllungsquoten:** Kranktage fliegen im Habits-Dashboard aus Zähler *und* Nenner (Gesamt + letzte 30 Tage)
- **Jahresübersicht:** Kranktage erscheinen als neutrale violette Zellen (Tertiary) mit Tooltip „Krank — zählt nicht" (Heatmap-Level `-2`)
- **Öffentlich:** „Krank"-Badge (Material Symbol `sick`) auf Feed-/Home-Karten und Detailseite; statt der drei Säulen-Badges ein neutrales „Krankheitstag"-Badge; kein Perfect Day auf Kranktagen
- **Admin:** Toggle „Krankheitstag" im Editor (dimmt die Habits-Picker), „Krank"-Chip in der Einträge-Liste, Live-Vorschau angepasst
- **AI-Monats-Zusammenfassung:** Kranktage werden separat ausgewiesen und aus den Habit-Quoten ausgenommen
- **i18n:** Neue Keys für DE/EN/PT
- **Doku:** `CLAUDE.md` um die `sickDay`-Schema-Details ergänzt

## Verknüpftes Issue

Kein Issue — Feature direkt aus der Session angefordert (Kranktage 3.7.–6.7. sollen nach Deploy im Admin markiert werden).

## Art der Änderung

- [ ] 🐛 Bug Fix
- [x] ✨ Neues Feature
- [ ] 🔧 Refactoring
- [ ] 📝 Dokumentation
- [ ] 🎨 Styling
- [ ] ⚡ Performance
- [ ] 🧪 Tests
- [ ] 🔨 Chore (Dependencies, Config, etc.)

## Checkliste

- [x] Code folgt den Projektkonventionen (CLAUDE.md)
- [x] TypeScript kompiliert ohne Fehler (`pnpm type-check`)
- [x] Linting bestanden (`pnpm lint`)
- [x] Tests geschrieben und bestanden (`pnpm test` — 109 Tests, davon 6 neue für die Pause-Semantik)
- [ ] Responsive getestet (Mobile + Desktop)
- [x] Prisma-Migration erstellt (falls Schema geändert)
- [x] Umgebungsvariablen dokumentiert (keine neuen)

## Screenshots

—

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177K2kFGkNwdfZjkZYT2WU2

---
_Generated by [Claude Code](https://claude.ai/code/session_0177K2kFGkNwdfZjkZYT2WU2)_