### PR TITLE
feat(nutrition): MVP-1 Nutrition-Tracking – additiver Teil (N-01–N-08)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules/
 .pnpm-store/
 
+# Private uploads (body photos, meal photos) — created at runtime, never commit
+private/
+
 # Next.js
 .next/
 out/

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tiptap/extension-typography": "^3.21.0",
     "@tiptap/react": "^3.21.0",
     "@tiptap/starter-kit": "^3.21.0",
+    "@zxing/browser": "^0.2.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "next": "^14.2.29",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.21.0
         version: 3.21.0
+      '@zxing/browser':
+        specifier: ^0.2.1
+        version: 0.2.1(@zxing/library@0.23.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1580,6 +1583,18 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@zxing/browser@0.2.1':
+    resolution: {integrity: sha512-92pVfVDUXbc15xu9vIEmhNyqIEASMEkDF92CwT6T+7sg2EHXJRktH9CQKoQSXe51UtbNsj+Fm09H/JBWHMs/Sw==}
+    peerDependencies:
+      '@zxing/library': ^0.23.0
+
+  '@zxing/library@0.23.0':
+    resolution: {integrity: sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA==}
+    engines: {node: '>= 24.0.0'}
+
+  '@zxing/text-encoding@0.9.0':
+    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3420,6 +3435,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3789,6 +3805,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -5361,6 +5381,21 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@zxing/browser@0.2.1(@zxing/library@0.23.0)':
+    dependencies:
+      '@zxing/library': 0.23.0
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
+
+  '@zxing/library@0.23.0':
+    dependencies:
+      ts-custom-error: 3.3.1
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
+
+  '@zxing/text-encoding@0.9.0':
+    optional: true
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -8262,6 +8297,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-custom-error@3.3.1: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/prisma/migrations/20260710063721_add_nutrition_foundation/migration.sql
+++ b/prisma/migrations/20260710063721_add_nutrition_foundation/migration.sql
@@ -1,0 +1,310 @@
+-- CreateEnum
+CREATE TYPE "FulfillmentStatus" AS ENUM ('FULFILLED', 'NOT_FULFILLED', 'OPEN');
+
+-- CreateEnum
+CREATE TYPE "DayType" AS ENUM ('NORMAL', 'REFEED');
+
+-- CreateEnum
+CREATE TYPE "PhaseMode" AS ENUM ('DEFICIT', 'MAINTENANCE', 'SURPLUS');
+
+-- CreateEnum
+CREATE TYPE "FoodSource" AS ENUM ('EXTERNAL_DB', 'MANUAL', 'AI');
+
+-- CreateEnum
+CREATE TYPE "MealSource" AS ENUM ('BARCODE', 'PHOTO_AI', 'MANUAL', 'FAVORITE', 'DISH');
+
+-- CreateEnum
+CREATE TYPE "PhotoType" AS ENUM ('PLATE', 'MENU');
+
+-- CreateEnum
+CREATE TYPE "Sex" AS ENUM ('MALE', 'FEMALE');
+
+-- CreateEnum
+CREATE TYPE "DeficitMethod" AS ENUM ('MODERATE', 'AGGRESSIVE', 'SIMPLE');
+
+-- CreateTable
+CREATE TABLE "FoodItem" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "brand" TEXT,
+    "barcode" TEXT,
+    "source" "FoodSource" NOT NULL DEFAULT 'MANUAL',
+    "baseUnit" TEXT NOT NULL DEFAULT 'g',
+    "kcal" DOUBLE PRECISION NOT NULL,
+    "proteinG" DOUBLE PRECISION NOT NULL,
+    "carbsG" DOUBLE PRECISION NOT NULL,
+    "fatG" DOUBLE PRECISION NOT NULL,
+    "fiberG" DOUBLE PRECISION,
+    "sugarG" DOUBLE PRECISION,
+    "saturatedFatG" DOUBLE PRECISION,
+    "sodiumMg" DOUBLE PRECISION,
+    "potassiumMg" DOUBLE PRECISION,
+    "ironMg" DOUBLE PRECISION,
+    "magnesiumMg" DOUBLE PRECISION,
+    "calciumMg" DOUBLE PRECISION,
+    "zincMg" DOUBLE PRECISION,
+    "vitaminDUg" DOUBLE PRECISION,
+    "vitaminB12Ug" DOUBLE PRECISION,
+    "vitaminCMg" DOUBLE PRECISION,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "externalDbId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FoodItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Dish" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "note" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Dish_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DishItem" (
+    "id" TEXT NOT NULL,
+    "dishId" TEXT NOT NULL,
+    "foodItemId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "unit" TEXT NOT NULL,
+
+    CONSTRAINT "DishItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Favorite" (
+    "id" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "foodItemId" TEXT,
+    "dishId" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Favorite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MealEntry" (
+    "id" TEXT NOT NULL,
+    "dayId" TEXT NOT NULL,
+    "loggedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "mealSlot" TEXT,
+    "sourceType" "MealSource" NOT NULL,
+    "foodItemId" TEXT,
+    "dishId" TEXT,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "unit" TEXT NOT NULL,
+    "kcal" DOUBLE PRECISION NOT NULL,
+    "proteinG" DOUBLE PRECISION NOT NULL,
+    "carbsG" DOUBLE PRECISION NOT NULL,
+    "fatG" DOUBLE PRECISION NOT NULL,
+    "fiberG" DOUBLE PRECISION,
+    "sugarG" DOUBLE PRECISION,
+    "saturatedFatG" DOUBLE PRECISION,
+    "sodiumMg" DOUBLE PRECISION,
+    "potassiumMg" DOUBLE PRECISION,
+    "ironMg" DOUBLE PRECISION,
+    "magnesiumMg" DOUBLE PRECISION,
+    "calciumMg" DOUBLE PRECISION,
+    "zincMg" DOUBLE PRECISION,
+    "vitaminDUg" DOUBLE PRECISION,
+    "vitaminB12Ug" DOUBLE PRECISION,
+    "vitaminCMg" DOUBLE PRECISION,
+    "externalName" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MealEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MealPhoto" (
+    "id" TEXT NOT NULL,
+    "mealEntryId" TEXT NOT NULL,
+    "imagePath" TEXT NOT NULL,
+    "photoType" "PhotoType" NOT NULL,
+    "aiAnalysis" JSONB,
+    "aiConfidence" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MealPhoto_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Day" (
+    "id" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "dayType" "DayType" NOT NULL DEFAULT 'NORMAL',
+    "phaseId" TEXT,
+    "targetKcal" DOUBLE PRECISION,
+    "targetProteinG" DOUBLE PRECISION,
+    "targetFatG" DOUBLE PRECISION,
+    "targetCarbsG" DOUBLE PRECISION,
+    "actualKcal" DOUBLE PRECISION,
+    "actualProteinG" DOUBLE PRECISION,
+    "actualFatG" DOUBLE PRECISION,
+    "actualCarbsG" DOUBLE PRECISION,
+    "fulfillmentStatus" "FulfillmentStatus" NOT NULL DEFAULT 'OPEN',
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Day_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Phase" (
+    "id" TEXT NOT NULL,
+    "mode" "PhaseMode" NOT NULL,
+    "startDate" DATE NOT NULL,
+    "endDate" DATE,
+    "targetsId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Phase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NutritionTargets" (
+    "id" TEXT NOT NULL,
+    "validFrom" DATE NOT NULL,
+    "baseWeightKg" DOUBLE PRECISION NOT NULL,
+    "sex" "Sex" NOT NULL,
+    "heightCm" DOUBLE PRECISION NOT NULL,
+    "age" INTEGER NOT NULL,
+    "bodyFatPct" DOUBLE PRECISION,
+    "activityFactor" DOUBLE PRECISION NOT NULL,
+    "deficitMode" "DeficitMethod" NOT NULL,
+    "targetKcal" DOUBLE PRECISION NOT NULL,
+    "proteinG" DOUBLE PRECISION NOT NULL,
+    "fatG" DOUBLE PRECISION NOT NULL,
+    "carbsG" DOUBLE PRECISION NOT NULL,
+    "mealsPerDay" INTEGER NOT NULL,
+    "calcNote" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NutritionTargets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RefeedRule" (
+    "id" TEXT NOT NULL,
+    "phaseId" TEXT NOT NULL,
+    "recurringWeekdays" INTEGER[],
+    "refeedKcal" DOUBLE PRECISION NOT NULL,
+    "refeedProteinG" DOUBLE PRECISION NOT NULL,
+    "refeedFatG" DOUBLE PRECISION NOT NULL,
+    "refeedCarbsG" DOUBLE PRECISION NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RefeedRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FoodItem_barcode_key" ON "FoodItem"("barcode");
+
+-- CreateIndex
+CREATE INDEX "FoodItem_barcode_idx" ON "FoodItem"("barcode");
+
+-- CreateIndex
+CREATE INDEX "FoodItem_isActive_idx" ON "FoodItem"("isActive");
+
+-- CreateIndex
+CREATE INDEX "Dish_isActive_idx" ON "Dish"("isActive");
+
+-- CreateIndex
+CREATE INDEX "DishItem_dishId_idx" ON "DishItem"("dishId");
+
+-- CreateIndex
+CREATE INDEX "DishItem_foodItemId_idx" ON "DishItem"("foodItemId");
+
+-- CreateIndex
+CREATE INDEX "Favorite_foodItemId_idx" ON "Favorite"("foodItemId");
+
+-- CreateIndex
+CREATE INDEX "Favorite_dishId_idx" ON "Favorite"("dishId");
+
+-- CreateIndex
+CREATE INDEX "Favorite_sortOrder_idx" ON "Favorite"("sortOrder");
+
+-- CreateIndex
+CREATE INDEX "MealEntry_dayId_idx" ON "MealEntry"("dayId");
+
+-- CreateIndex
+CREATE INDEX "MealEntry_foodItemId_idx" ON "MealEntry"("foodItemId");
+
+-- CreateIndex
+CREATE INDEX "MealEntry_dishId_idx" ON "MealEntry"("dishId");
+
+-- CreateIndex
+CREATE INDEX "MealPhoto_mealEntryId_idx" ON "MealPhoto"("mealEntryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Day_date_key" ON "Day"("date");
+
+-- CreateIndex
+CREATE INDEX "Day_phaseId_idx" ON "Day"("phaseId");
+
+-- CreateIndex
+CREATE INDEX "Day_fulfillmentStatus_idx" ON "Day"("fulfillmentStatus");
+
+-- CreateIndex
+CREATE INDEX "Phase_status_idx" ON "Phase"("status");
+
+-- CreateIndex
+CREATE INDEX "Phase_startDate_idx" ON "Phase"("startDate");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NutritionTargets_validFrom_key" ON "NutritionTargets"("validFrom");
+
+-- CreateIndex
+CREATE INDEX "NutritionTargets_validFrom_idx" ON "NutritionTargets"("validFrom");
+
+-- CreateIndex
+CREATE INDEX "RefeedRule_phaseId_idx" ON "RefeedRule"("phaseId");
+
+-- AddForeignKey
+ALTER TABLE "DishItem" ADD CONSTRAINT "DishItem_dishId_fkey" FOREIGN KEY ("dishId") REFERENCES "Dish"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DishItem" ADD CONSTRAINT "DishItem_foodItemId_fkey" FOREIGN KEY ("foodItemId") REFERENCES "FoodItem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_foodItemId_fkey" FOREIGN KEY ("foodItemId") REFERENCES "FoodItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_dishId_fkey" FOREIGN KEY ("dishId") REFERENCES "Dish"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealEntry" ADD CONSTRAINT "MealEntry_dayId_fkey" FOREIGN KEY ("dayId") REFERENCES "Day"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealEntry" ADD CONSTRAINT "MealEntry_foodItemId_fkey" FOREIGN KEY ("foodItemId") REFERENCES "FoodItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealEntry" ADD CONSTRAINT "MealEntry_dishId_fkey" FOREIGN KEY ("dishId") REFERENCES "Dish"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPhoto" ADD CONSTRAINT "MealPhoto_mealEntryId_fkey" FOREIGN KEY ("mealEntryId") REFERENCES "MealEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Day" ADD CONSTRAINT "Day_phaseId_fkey" FOREIGN KEY ("phaseId") REFERENCES "Phase"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Phase" ADD CONSTRAINT "Phase_targetsId_fkey" FOREIGN KEY ("targetsId") REFERENCES "NutritionTargets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefeedRule" ADD CONSTRAINT "RefeedRule_phaseId_fkey" FOREIGN KEY ("phaseId") REFERENCES "Phase"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,10 +143,10 @@ enum MetricSource {
 
 model UserProfile {
   id               String   @id @default("singleton")
-  heightCm         Float?   // Körpergrösse in cm
-  targetWeight     Float?   // Zielgewicht in kg
-  targetSteps      Int?     // Tagesziel Schritte
-  projectStartDate String?  // Projekt-Startdatum YYYY-MM-DD (Default: 2026-03-26)
+  heightCm         Float? // Körpergrösse in cm
+  targetWeight     Float? // Zielgewicht in kg
+  targetSteps      Int? // Tagesziel Schritte
+  projectStartDate String? // Projekt-Startdatum YYYY-MM-DD (Default: 2026-03-26)
   updatedAt        DateTime @updatedAt
 }
 
@@ -182,7 +182,7 @@ enum ReactionType {
 model MonthSummary {
   id          String   @id @default(cuid())
   year        Int
-  month       Int      // 1–12
+  month       Int // 1–12
   contentDe   String   @db.Text
   contentEn   String?  @db.Text
   contentPt   String?  @db.Text
@@ -200,7 +200,7 @@ model MonthSummary {
 
 model BodyPhoto {
   id        String        @id @default(cuid())
-  filename  String        // gespeicherter Dateiname auf Disk
+  filename  String // gespeicherter Dateiname auf Disk
   date      DateTime      @db.Date
   category  PhotoCategory @default(FRONT)
   notes     String?
@@ -223,13 +223,13 @@ enum PhotoCategory {
 model MealLog {
   id             String   @id @default(cuid())
   date           DateTime @unique @db.Date
-  breakfast      Float?   // null = nicht eingenommen, 1.0–10.0
-  snackMorning   Float?   // Zwischenmahlzeit Morgen
-  lunch          Float?   // Mittagessen
-  snackAfternoon Float?   // Zwischenmahlzeit Nachmittag
-  dinner         Float?   // Abendessen
-  snack          Float?   // Tages-Snack optional (Nüsse etc.) — Bonus
-  score          Float?   // berechneter Tages-Score 0.0–5.0
+  breakfast      Float? // null = nicht eingenommen, 1.0–10.0
+  snackMorning   Float? // Zwischenmahlzeit Morgen
+  lunch          Float? // Mittagessen
+  snackAfternoon Float? // Zwischenmahlzeit Nachmittag
+  dinner         Float? // Abendessen
+  snack          Float? // Tages-Snack optional (Nüsse etc.) — Bonus
+  score          Float? // berechneter Tages-Score 0.0–5.0
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
@@ -248,7 +248,7 @@ model MealPlan {
   lunch          String?
   snackAfternoon String?
   dinner         String?
-  snack          String?  // optionaler Bonus-Snack
+  snack          String? // optionaler Bonus-Snack
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
@@ -265,21 +265,21 @@ model MealPlan {
 model NutritionLog {
   id        String   @id @default(cuid())
   date      DateTime @db.Date
-  meal      String                     // 'Breakfast' | 'Lunch' | 'Dinner' | 'Snacks' (MFP-Meal)
+  meal      String // 'Breakfast' | 'Lunch' | 'Dinner' | 'Snacks' (MFP-Meal)
   calories  Float?
-  protein   Float?                     // g
-  carbs     Float?                     // g
-  fat       Float?                     // g
-  fiber     Float?                     // g
-  sugar     Float?                     // g
-  sodium    Float?                     // mg
-  micros    Json?                      // restliche Nährstoffe (satFat, cholesterol, potassium, vitA/C, calcium, iron, …)
+  protein   Float? // g
+  carbs     Float? // g
+  fat       Float? // g
+  fiber     Float? // g
+  sugar     Float? // g
+  sodium    Float? // mg
+  micros    Json? // restliche Nährstoffe (satFat, cholesterol, potassium, vitA/C, calcium, iron, …)
   note      String?
   source    String   @default("MYFITNESSPAL")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([date, meal, source])       // idempotenter Re-Import
+  @@unique([date, meal, source]) // idempotenter Re-Import
   @@index([date])
 }
 
@@ -288,15 +288,15 @@ model NutritionLog {
 // =============================================
 
 model Book {
-  id          String      @id @default(cuid())
-  title       String
-  author      String?
-  totalPages  Int?
-  startDate   DateTime?   @db.Date
-  endDate     DateTime?   @db.Date
-  completed   Boolean     @default(false)
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  id         String    @id @default(cuid())
+  title      String
+  author     String?
+  totalPages Int?
+  startDate  DateTime? @db.Date
+  endDate    DateTime? @db.Date
+  completed  Boolean   @default(false)
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
 
   readingLogs ReadingLog[]
 
@@ -304,12 +304,12 @@ model Book {
 }
 
 model ReadingLog {
-  id         String   @id @default(cuid())
-  date       DateTime @db.Date
-  pagesRead  Int
-  bookId     String
-  book       Book     @relation(fields: [bookId], references: [id], onDelete: Cascade)
-  createdAt  DateTime @default(now())
+  id        String   @id @default(cuid())
+  date      DateTime @db.Date
+  pagesRead Int
+  bookId    String
+  book      Book     @relation(fields: [bookId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
 
   @@unique([date, bookId])
   @@index([date])
@@ -329,16 +329,16 @@ model ReadingLog {
 model BodyMeasurement {
   id            String   @id @default(cuid())
   date          DateTime @unique @db.Date
-  chest         Float?   // Brustumfang cm
-  waist         Float?   // Taillenumfang cm
-  hip           Float?   // Hüftumfang cm
-  upperArmLeft  Float?   // Oberarm links cm
-  upperArmRight Float?   // Oberarm rechts cm
-  thighLeft     Float?   // Oberschenkel links cm
-  thighRight    Float?   // Oberschenkel rechts cm
-  calfLeft      Float?   // Wade links cm
-  calfRight     Float?   // Wade rechts cm
-  neck          Float?   // Halsumfang cm (optional)
+  chest         Float? // Brustumfang cm
+  waist         Float? // Taillenumfang cm
+  hip           Float? // Hüftumfang cm
+  upperArmLeft  Float? // Oberarm links cm
+  upperArmRight Float? // Oberarm rechts cm
+  thighLeft     Float? // Oberschenkel links cm
+  thighRight    Float? // Oberschenkel rechts cm
+  calfLeft      Float? // Wade links cm
+  calfRight     Float? // Wade rechts cm
+  neck          Float? // Halsumfang cm (optional)
   notes         String?  @db.Text
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
@@ -353,7 +353,7 @@ model BodyMeasurement {
 model DrinkLog {
   id        String    @id @default(cuid())
   type      DrinkType
-  volume    Int       // ml
+  volume    Int // ml
   timestamp DateTime  @default(now())
 
   @@index([timestamp])
@@ -397,20 +397,20 @@ model AppSetting {
 // =============================================
 
 model HealthMetricInventory {
-  metricName     String   @id                // z.B. "Stand Time", "Step Count"
-  unit           String   @default("")       // z.B. "count", "hr", "kcal"
-  sampleCount    Int      @default(0)        // Anzahl Datenpunkte im letzten Import
-  lastValue      Float?                      // letzter qty/avg/asleep Wert
-  lastValueDate  String?                     // YYYY-MM-DD des letzten Datenpunkts
-  lastReceivedAt DateTime @default(now())    // Zeitpunkt des letzten Imports
+  metricName     String   @id // z.B. "Stand Time", "Step Count"
+  unit           String   @default("") // z.B. "count", "hr", "kcal"
+  sampleCount    Int      @default(0) // Anzahl Datenpunkte im letzten Import
+  lastValue      Float? // letzter qty/avg/asleep Wert
+  lastValueDate  String? // YYYY-MM-DD des letzten Datenpunkts
+  lastReceivedAt DateTime @default(now()) // Zeitpunkt des letzten Imports
   createdAt      DateTime @default(now())
 }
 
 model PageView {
   id          String   @id @default(cuid())
-  path        String                          // Normalisierter Pfad ohne Locale (/journal/slug)
-  referrer    String?                         // Nur Hostname des Referrers
-  sessionHash String                          // Tagesbezogener Hash — nie auf Person zurückführbar
+  path        String // Normalisierter Pfad ohne Locale (/journal/slug)
+  referrer    String? // Nur Hostname des Referrers
+  sessionHash String // Tagesbezogener Hash — nie auf Person zurückführbar
   timestamp   DateTime @default(now())
 
   @@index([timestamp])
@@ -428,12 +428,12 @@ model PageView {
 
 model WithingsMeasurement {
   id         String   @id @default(cuid())
-  grpid      BigInt                        // Withings measure-group id
-  measuredAt DateTime                      // voller Zeitstempel der Messung
-  date       DateTime @db.Date             // Messtag (Europe/Zurich) — für Tages-Joins
-  type       Int                           // Withings meastype (1, 6, 76, …)
-  position   Int      @default(0)          // Körperzone bei segmentalen Werten (0 = ganzkörper/ohne Position)
-  value      Float                         // aufgelöster Realwert (value * 10^unit)
+  grpid      BigInt // Withings measure-group id
+  measuredAt DateTime // voller Zeitstempel der Messung
+  date       DateTime @db.Date // Messtag (Europe/Zurich) — für Tages-Joins
+  type       Int // Withings meastype (1, 6, 76, …)
+  position   Int      @default(0) // Körperzone bei segmentalen Werten (0 = ganzkörper/ohne Position)
+  value      Float // aufgelöster Realwert (value * 10^unit)
   createdAt  DateTime @default(now())
 
   @@unique([grpid, type, position])
@@ -449,14 +449,340 @@ model WithingsMeasurement {
 model WithingsSyncLog {
   id              String   @id @default(cuid())
   syncedAt        DateTime @default(now())
-  triggeredBy     String   @default("CRON")   // CRON | MANUAL
-  syncDate        String                       // YYYY-MM-DD — der synchronisierte Tag
-  status          String                       // SUCCESS | ERROR
+  triggeredBy     String   @default("CRON") // CRON | MANUAL
+  syncDate        String // YYYY-MM-DD — der synchronisierte Tag
+  status          String // SUCCESS | ERROR
   weight          Float?
   bodyFat         Float?
-  measureCount    Int?                         // Anzahl gespeicherter Roh-Messwerte
+  measureCount    Int? // Anzahl gespeicherter Roh-Messwerte
   tokensRefreshed Boolean  @default(false)
   errorMessage    String?
 
   @@index([syncedAt(sort: Desc)])
+}
+
+// =============================================================================
+// NUTRITION TRACKING (Phase 7 — Nutrition-Umbau, MVP-1)
+// Ersetzt das Score-System (MealLog/MealPlan) durch natives Ernährungs-Tracking:
+// Kaloriendefizit erreicht = Tag erfüllt. Additiv angelegt (N-01); die Kopplung
+// an JournalEntry.nutrition und der Score-Rückbau folgen in N-08/N-09.
+//
+// Prinzipien (Notion-Spec, Teil 3):
+//  • Snapshots sind immutable: MealEntry speichert Nährwerte als Snapshot +
+//    Referenz aufs FoodItem; Day speichert den SOLL-Snapshot. Katalog-
+//    Korrekturen wirken nur auf zukünftige Logs.
+//  • NutritionTargets sind versioniert (validFrom); der je Tag geltende Satz
+//    ergibt sich aus dem letzten validFrom ≤ Tagesdatum.
+//  • Alle Nährwerte am FoodItem beziehen sich auf 100 Basiseinheiten (g/ml).
+// =============================================================================
+
+// --- Einzel-Lebensmittel: Nährwerte je 100 g/ml -----------------------------
+
+model FoodItem {
+  id       String     @id @default(cuid())
+  name     String
+  brand    String?
+  barcode  String?    @unique // eindeutig, wenn vorhanden (Dedup, N-03)
+  source   FoodSource @default(MANUAL)
+  baseUnit String     @default("g") // g | ml | stück
+
+  // Pflicht-Nährwerte je 100 Basiseinheiten
+  kcal     Float
+  proteinG Float
+  carbsG   Float
+  fatG     Float
+
+  // Fokussierter Mikro-Satz (best-effort, nullable) — je 100 Basiseinheiten
+  fiberG        Float? // Ballaststoffe (g)
+  sugarG        Float? // Zucker (g)
+  saturatedFatG Float? // gesättigte Fettsäuren (g)
+  sodiumMg      Float? // Natrium (mg)
+  potassiumMg   Float? // Kalium (mg)
+  ironMg        Float? // Eisen (mg)
+  magnesiumMg   Float? // Magnesium (mg)
+  calciumMg     Float? // Calcium (mg)
+  zincMg        Float? // Zink (mg)
+  vitaminDUg    Float? // Vitamin D (µg)
+  vitaminB12Ug  Float? // Vitamin B12 (µg)
+  vitaminCMg    Float? // Vitamin C (mg)
+
+  isActive     Boolean @default(true) // false = archiviert (nie hart löschen wenn referenziert)
+  externalDbId String? // z.B. Open-Food-Facts-Code
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  dishItems   DishItem[]
+  mealEntries MealEntry[]
+  favorites   Favorite[]
+
+  @@index([barcode])
+  @@index([isActive])
+}
+
+// --- Gericht: benannte Kombination mehrerer FoodItems -----------------------
+
+model Dish {
+  id        String   @id @default(cuid())
+  name      String
+  note      String?
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  items       DishItem[]
+  mealEntries MealEntry[]
+  favorites   Favorite[]
+
+  @@index([isActive])
+}
+
+model DishItem {
+  id         String   @id @default(cuid())
+  dishId     String
+  dish       Dish     @relation(fields: [dishId], references: [id], onDelete: Cascade)
+  foodItemId String
+  foodItem   FoodItem @relation(fields: [foodItemId], references: [id])
+  amount     Float // in `unit`
+  unit       String // g | ml | stück
+
+  @@index([dishId])
+  @@index([foodItemId])
+}
+
+// --- Favorit: Schnellzugriff auf FoodItem ODER Dish -------------------------
+
+model Favorite {
+  id         String    @id @default(cuid())
+  targetType String // food | dish (App-seitig: genau eine Referenz gesetzt)
+  foodItemId String?
+  foodItem   FoodItem? @relation(fields: [foodItemId], references: [id], onDelete: Cascade)
+  dishId     String?
+  dish       Dish?     @relation(fields: [dishId], references: [id], onDelete: Cascade)
+  sortOrder  Int       @default(0)
+  createdAt  DateTime  @default(now())
+
+  @@index([foodItemId])
+  @@index([dishId])
+  @@index([sortOrder])
+}
+
+// --- Geloggte Mahlzeit: Referenz + immutable Nährwert-Snapshot --------------
+
+model MealEntry {
+  id         String     @id @default(cuid())
+  dayId      String
+  day        Day        @relation(fields: [dayId], references: [id], onDelete: Cascade)
+  loggedAt   DateTime   @default(now())
+  mealSlot   String? // Frühstück | Mittag | Abend | Snack
+  sourceType MealSource
+
+  // Referenz auf genau eines von FoodItem/Dish (App-seitig erzwungen)
+  foodItemId String?
+  foodItem   FoodItem? @relation(fields: [foodItemId], references: [id])
+  dishId     String?
+  dish       Dish?     @relation(fields: [dishId], references: [id])
+
+  amount Float
+  unit   String
+
+  // Immutable Nährwert-Snapshot (aus FoodItem/Dish × Menge zum Log-Zeitpunkt)
+  kcal          Float
+  proteinG      Float
+  carbsG        Float
+  fatG          Float
+  // Mikro-Snapshot (nullable, best-effort)
+  fiberG        Float?
+  sugarG        Float?
+  saturatedFatG Float?
+  sodiumMg      Float?
+  potassiumMg   Float?
+  ironMg        Float?
+  magnesiumMg   Float?
+  calciumMg     Float?
+  zincMg        Float?
+  vitaminDUg    Float?
+  vitaminB12Ug  Float?
+  vitaminCMg    Float?
+
+  externalName String? // Gerichtstitel von Speisekarte (Foto→AI)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  photos MealPhoto[]
+
+  @@index([dayId])
+  @@index([foodItemId])
+  @@index([dishId])
+}
+
+// --- Foto(s) + AI-Analyse je MealEntry (Teller/Speisekarte) -----------------
+
+model MealPhoto {
+  id           String    @id @default(cuid())
+  mealEntryId  String
+  mealEntry    MealEntry @relation(fields: [mealEntryId], references: [id], onDelete: Cascade)
+  imagePath    String
+  photoType    PhotoType
+  aiAnalysis   Json? // rohes JSON der Vision-Antwort
+  aiConfidence Float?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@index([mealEntryId])
+}
+
+// --- Kalendertag: Tag-Typ, SOLL-Snapshot, IST-Aggregat, Erfüllung ----------
+
+model Day {
+  id      String   @id @default(cuid())
+  date    DateTime @unique @db.Date
+  dayType DayType  @default(NORMAL)
+  phaseId String?
+  phase   Phase?   @relation(fields: [phaseId], references: [id])
+
+  // SOLL-Snapshot (aus Phase/Targets + Tag-Typ; von N-07 gesetzt)
+  targetKcal     Float?
+  targetProteinG Float?
+  targetFatG     Float?
+  targetCarbsG   Float?
+
+  // IST-Aggregat (Cache, aus MealEntries berechnet; von N-07 gepflegt)
+  actualKcal     Float?
+  actualProteinG Float?
+  actualFatG     Float?
+  actualCarbsG   Float?
+
+  fulfillmentStatus FulfillmentStatus @default(OPEN)
+  note              String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  mealEntries MealEntry[]
+
+  @@index([phaseId])
+  @@index([fulfillmentStatus])
+}
+
+// --- Phase: Zeitraum mit Modus (Defizit/Erhalt/Überschuss) ------------------
+
+model Phase {
+  id        String            @id @default(cuid())
+  mode      PhaseMode
+  startDate DateTime          @db.Date
+  endDate   DateTime?         @db.Date
+  targetsId String?
+  targets   NutritionTargets? @relation(fields: [targetsId], references: [id])
+  status    String            @default("ACTIVE") // ACTIVE | COMPLETED | PAUSED
+  note      String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  days        Day[]
+  refeedRules RefeedRule[]
+
+  @@index([status])
+  @@index([startDate])
+}
+
+// --- NutritionTargets: versionierte Eckdaten (gültig-ab) --------------------
+
+model NutritionTargets {
+  id             String        @id @default(cuid())
+  validFrom      DateTime      @unique @db.Date
+  baseWeightKg   Float
+  sex            Sex
+  heightCm       Float
+  age            Int
+  bodyFatPct     Float?
+  activityFactor Float
+  deficitMode    DeficitMethod
+
+  // Errechnete Ziel-Eckdaten
+  targetKcal  Float
+  proteinG    Float
+  fatG        Float
+  carbsG      Float
+  mealsPerDay Int
+  calcNote    String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  phases Phase[]
+
+  @@index([validFrom])
+}
+
+// --- RefeedRule: Refeed-Planung einer Phase (Wochentage + Refeed-SOLL) ------
+
+model RefeedRule {
+  id                String @id @default(cuid())
+  phaseId           String
+  phase             Phase  @relation(fields: [phaseId], references: [id], onDelete: Cascade)
+  recurringWeekdays Int[] // ISO-Wochentage 1=Mo … 7=So (z.B. [3,7] = Mi+So)
+
+  // Refeed-SOLL: kcal = Erhaltungskalorien, hohe KH, niedriges Fett, reduziertes Protein
+  refeedKcal     Float
+  refeedProteinG Float
+  refeedFatG     Float
+  refeedCarbsG   Float
+  active         Boolean @default(true)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([phaseId])
+}
+
+// --- Nutrition-Enums --------------------------------------------------------
+
+enum FulfillmentStatus {
+  FULFILLED
+  NOT_FULFILLED
+  OPEN
+}
+
+enum DayType {
+  NORMAL
+  REFEED
+}
+
+enum PhaseMode {
+  DEFICIT
+  MAINTENANCE
+  SURPLUS
+}
+
+enum FoodSource {
+  EXTERNAL_DB
+  MANUAL
+  AI
+}
+
+enum MealSource {
+  BARCODE
+  PHOTO_AI
+  MANUAL
+  FAVORITE
+  DISH
+}
+
+enum PhotoType {
+  PLATE
+  MENU
+}
+
+enum Sex {
+  MALE
+  FEMALE
+}
+
+enum DeficitMethod {
+  MODERATE // TDEE × 0,8
+  AGGRESSIVE // TDEE × 0,7
+  SIMPLE // TDEE − 500
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,9 +4,18 @@ import {
   NutritionLevel,
   SmokingStatus,
   MetricSource,
+  Sex,
+  DeficitMethod,
+  PhaseMode,
 } from '@prisma/client'
 
 const prisma = new PrismaClient()
+
+// Nutrition-Umbau (N-01): Anker-Datum der ersten Eckdaten. Entspricht dem
+// Berechnungsstand aus der Fibel-Methodik (Notion-Sub-Page, Stand 2026-07-08).
+// Bewusst ein fixes Datum statt `new Date()` → reproduzierbarer, idempotenter Seed.
+const INITIAL_TARGETS_VALID_FROM = new Date('2026-07-08')
+const INITIAL_PHASE_ID = 'seed-phase-deficit-1'
 
 async function main() {
   console.log('Seeding database...')
@@ -44,6 +53,49 @@ async function main() {
       steps: 10500,
       weight: 85.0,
       source: MetricSource.MANUAL,
+    },
+  })
+
+  // =============================================
+  // Nutrition-Tracking (N-01) — Erste Eckdaten + aktive Defizit-Phase
+  // Werte aus der Fibel-Methodik (Notion-Sub-Page „Ernährungs-Eckdaten"):
+  // BMR HB#1+#2 → Ø 1'856 → ×1,55 = TDEE 2'877 → ×0,8 = 2'301 kcal,
+  // Protein auf Zielgewicht korrigiert (185 g), Fett 20 %/min (51 g), KH Rest (275 g).
+  // =============================================
+
+  const targets = await prisma.nutritionTargets.upsert({
+    where: { validFrom: INITIAL_TARGETS_VALID_FROM },
+    update: {},
+    create: {
+      validFrom: INITIAL_TARGETS_VALID_FROM,
+      baseWeightKg: 94,
+      sex: Sex.MALE,
+      heightCm: 170,
+      age: 43,
+      bodyFatPct: 27,
+      activityFactor: 1.55,
+      deficitMode: DeficitMethod.MODERATE, // TDEE × 0,8
+      targetKcal: 2301,
+      proteinG: 185,
+      fatG: 51,
+      carbsG: 275,
+      mealsPerDay: 4,
+      calcNote:
+        'Fibel/Roscher: BMR HB#1 1793 + HB#2 1919 → Ø 1856 → ×1,55 (moderat) = TDEE 2877 → ×0,8 = 2301 kcal. ' +
+        'Protein auf Zielgewicht (~80 kg) korrigiert wegen ~27 % KF (185 g statt 226 g). Fett 20 % (51 g, min. 47 g ✓). KH Rest (275 g).',
+    },
+  })
+
+  await prisma.phase.upsert({
+    where: { id: INITIAL_PHASE_ID },
+    update: {},
+    create: {
+      id: INITIAL_PHASE_ID,
+      mode: PhaseMode.DEFICIT,
+      startDate: INITIAL_TARGETS_VALID_FROM,
+      status: 'ACTIVE',
+      targetsId: targets.id,
+      note: 'Erste Defizit-Phase (Seed) — 20 % Defizit, Start der Fettverlust-Fibel-Methodik.',
     },
   })
 

--- a/src/app/admin/dishes/actions.ts
+++ b/src/app/admin/dishes/actions.ts
@@ -1,0 +1,76 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { requireAdmin } from '@/lib/auth'
+import { createDish, updateDish, removeDish, type DishItemInput } from '@/lib/nutrition/dishes'
+import { addDishFavorite, removeDishFavorite } from '@/lib/nutrition/favorites'
+
+export interface ActionResult {
+  error?: string
+  success?: boolean
+  info?: string
+}
+
+export interface DishFormData {
+  id?: string
+  name: string
+  note: string
+  items: { foodItemId: string; amount: string; unit: string }[]
+}
+
+export async function saveDish(data: DishFormData): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  const name = data.name.trim()
+  if (!name) return { error: 'Name ist erforderlich.' }
+
+  const items: DishItemInput[] = []
+  for (const raw of data.items) {
+    if (!raw.foodItemId) continue
+    const amount = parseFloat(raw.amount.replace(',', '.'))
+    if (isNaN(amount) || amount <= 0) return { error: 'Alle Zutaten brauchen eine Menge > 0.' }
+    items.push({ foodItemId: raw.foodItemId, amount, unit: raw.unit || 'g' })
+  }
+  if (items.length === 0) return { error: 'Mindestens eine Zutat erforderlich.' }
+
+  try {
+    if (data.id) await updateDish(data.id, { name, note: data.note.trim() || null, items })
+    else await createDish({ name, note: data.note.trim() || null, items })
+    revalidatePath('/admin/dishes')
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('saveDish:', e)
+    return { error: 'Speichern fehlgeschlagen.' }
+  }
+}
+
+export async function deleteDishAction(id: string): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  try {
+    const res = await removeDish(id)
+    revalidatePath('/admin/dishes')
+    revalidatePath('/admin/log')
+    return { success: true, info: res === 'archived' ? 'Archiviert (referenziert).' : 'Gelöscht.' }
+  } catch (e) {
+    console.error('deleteDishAction:', e)
+    return { error: 'Löschen fehlgeschlagen.' }
+  }
+}
+
+export async function toggleDishFavorite(dishId: string, on: boolean): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  try {
+    if (on) await addDishFavorite(dishId)
+    else await removeDishFavorite(dishId)
+    revalidatePath('/admin/dishes')
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('toggleDishFavorite:', e)
+    return { error: 'Favorit fehlgeschlagen.' }
+  }
+}

--- a/src/app/admin/dishes/page.tsx
+++ b/src/app/admin/dishes/page.tsx
@@ -1,0 +1,31 @@
+import { requireAdmin } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { DishManager } from '@/components/nutrition/DishManager'
+import { listDishes } from '@/lib/nutrition/dishes'
+import { listFoodItems } from '@/lib/nutrition/food'
+import { favoriteIdSets } from '@/lib/nutrition/favorites'
+
+export const dynamic = 'force-dynamic'
+
+export default async function DishesPage() {
+  const session = await requireAdmin()
+  if (!session) redirect('/admin/login')
+
+  const [dishes, catalog, favs] = await Promise.all([
+    listDishes(true),
+    listFoodItems(false),
+    favoriteIdSets(),
+  ])
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Gerichte</h1>
+        <p className="text-on-surface-variant text-sm mt-1">
+          Wiederverwendbare Kombinationen (z.&nbsp;B. Frühstück). Als ★ Favorit für 1-Klick im Log.
+        </p>
+      </div>
+      <DishManager dishes={dishes} catalog={catalog} favoriteDishIds={[...favs.dishes]} />
+    </div>
+  )
+}

--- a/src/app/admin/food/actions.ts
+++ b/src/app/admin/food/actions.ts
@@ -10,6 +10,7 @@ import {
   importFood,
   type FoodItemInput,
 } from '@/lib/nutrition/food'
+import { addFoodFavorite, removeFoodFavorite } from '@/lib/nutrition/favorites'
 import type { NormalizedFood } from '@/lib/nutrition/food-provider'
 
 export interface ActionResult {
@@ -163,5 +164,20 @@ export async function restoreFoodItem(id: string): Promise<ActionResult> {
   } catch (e) {
     console.error('restoreFoodItem:', e)
     return { error: 'Reaktivieren fehlgeschlagen.' }
+  }
+}
+
+export async function toggleFoodFavorite(foodItemId: string, on: boolean): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  try {
+    if (on) await addFoodFavorite(foodItemId)
+    else await removeFoodFavorite(foodItemId)
+    revalidatePath('/admin/food')
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('toggleFoodFavorite:', e)
+    return { error: 'Favorit fehlgeschlagen.' }
   }
 }

--- a/src/app/admin/food/actions.ts
+++ b/src/app/admin/food/actions.ts
@@ -1,0 +1,167 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { requireAdmin } from '@/lib/auth'
+import {
+  createFoodItem,
+  updateFoodItem,
+  removeFoodItem,
+  reactivateFoodItem,
+  importFood,
+  type FoodItemInput,
+} from '@/lib/nutrition/food'
+import type { NormalizedFood } from '@/lib/nutrition/food-provider'
+
+export interface ActionResult {
+  error?: string
+  success?: boolean
+  info?: string
+}
+
+/** Formular-Datentyp (Strings), wie in den übrigen Admin-Actions. */
+export interface FoodFormData {
+  id?: string
+  name: string
+  brand: string
+  barcode: string
+  baseUnit: string
+  kcal: string
+  proteinG: string
+  carbsG: string
+  fatG: string
+  fiberG: string
+  sugarG: string
+  saturatedFatG: string
+  sodiumMg: string
+  potassiumMg: string
+  ironMg: string
+  magnesiumMg: string
+  calciumMg: string
+  zincMg: string
+  vitaminDUg: string
+  vitaminB12Ug: string
+  vitaminCMg: string
+}
+
+function req(val: string): number | null {
+  if (!val.trim()) return null
+  const n = parseFloat(val.replace(',', '.'))
+  return isNaN(n) ? null : n
+}
+
+function parseForm(data: FoodFormData): { input: FoodItemInput } | { error: string } {
+  const name = data.name.trim()
+  if (!name) return { error: 'Name ist erforderlich.' }
+
+  const kcal = req(data.kcal)
+  const proteinG = req(data.proteinG)
+  const carbsG = req(data.carbsG)
+  const fatG = req(data.fatG)
+  if (kcal === null || proteinG === null || carbsG === null || fatG === null) {
+    return { error: 'Kalorien und Makros (P/KH/F) sind Pflicht.' }
+  }
+  if ([kcal, proteinG, carbsG, fatG].some((n) => n < 0)) {
+    return { error: 'Nährwerte dürfen nicht negativ sein.' }
+  }
+
+  return {
+    input: {
+      name,
+      brand: data.brand.trim() || null,
+      barcode: data.barcode.trim() || null,
+      baseUnit: data.baseUnit || 'g',
+      source: 'MANUAL',
+      externalDbId: null,
+      kcal,
+      proteinG,
+      carbsG,
+      fatG,
+      fiberG: req(data.fiberG),
+      sugarG: req(data.sugarG),
+      saturatedFatG: req(data.saturatedFatG),
+      sodiumMg: req(data.sodiumMg),
+      potassiumMg: req(data.potassiumMg),
+      ironMg: req(data.ironMg),
+      magnesiumMg: req(data.magnesiumMg),
+      calciumMg: req(data.calciumMg),
+      zincMg: req(data.zincMg),
+      vitaminDUg: req(data.vitaminDUg),
+      vitaminB12Ug: req(data.vitaminB12Ug),
+      vitaminCMg: req(data.vitaminCMg),
+    },
+  }
+}
+
+export async function saveFoodItem(data: FoodFormData): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  const parsed = parseForm(data)
+  if ('error' in parsed) return parsed
+
+  // Beim manuellen Anlegen bleibt die Quelle MANUAL; beim Bearbeiten eines
+  // importierten Eintrags die ursprüngliche Quelle unangetastet lassen wäre
+  // ideal — für MVP genügt: neue Einträge MANUAL, Updates behalten Felder.
+  try {
+    if (data.id) {
+      await updateFoodItem(data.id, parsed.input)
+    } else {
+      await createFoodItem(parsed.input)
+    }
+    revalidatePath('/admin/food')
+    return { success: true }
+  } catch (e) {
+    if (String(e).includes('Unique constraint') || String(e).includes('barcode')) {
+      return { error: 'Ein Produkt mit diesem Barcode existiert bereits.' }
+    }
+    console.error('saveFoodItem:', e)
+    return { error: 'Fehler beim Speichern.' }
+  }
+}
+
+/** Übernimmt ein OFF-Suchergebnis in den Katalog (Dedup über Barcode). */
+export async function importFoodItem(food: NormalizedFood): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  try {
+    const { item, created } = await importFood(food)
+    revalidatePath('/admin/food')
+    return {
+      success: true,
+      info: created ? `„${item.name}" übernommen.` : `„${item.name}" ist bereits im Katalog.`,
+    }
+  } catch (e) {
+    console.error('importFoodItem:', e)
+    return { error: 'Import fehlgeschlagen.' }
+  }
+}
+
+export async function deleteFoodItem(id: string): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  try {
+    const result = await removeFoodItem(id)
+    revalidatePath('/admin/food')
+    return {
+      success: true,
+      info: result === 'archived' ? 'Archiviert (wird noch referenziert).' : 'Gelöscht.',
+    }
+  } catch (e) {
+    console.error('deleteFoodItem:', e)
+    return { error: 'Löschen fehlgeschlagen.' }
+  }
+}
+
+export async function restoreFoodItem(id: string): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  try {
+    await reactivateFoodItem(id)
+    revalidatePath('/admin/food')
+    return { success: true }
+  } catch (e) {
+    console.error('restoreFoodItem:', e)
+    return { error: 'Reaktivieren fehlgeschlagen.' }
+  }
+}

--- a/src/app/admin/food/page.tsx
+++ b/src/app/admin/food/page.tsx
@@ -1,0 +1,25 @@
+import { requireAdmin } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { listFoodItems } from '@/lib/nutrition/food'
+import { FoodCatalog } from '@/components/admin/FoodCatalog'
+
+export const dynamic = 'force-dynamic'
+
+export default async function FoodPage() {
+  const session = await requireAdmin()
+  if (!session) redirect('/admin/login')
+
+  const catalog = await listFoodItems(true) // inkl. archivierter Einträge
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Lebensmittel-Katalog</h1>
+        <p className="text-on-surface-variant text-sm mt-1">
+          Produkte aus Open Food Facts übernehmen oder manuell anlegen. Nährwerte je 100 g/ml.
+        </p>
+      </div>
+      <FoodCatalog catalog={catalog} />
+    </div>
+  )
+}

--- a/src/app/admin/food/page.tsx
+++ b/src/app/admin/food/page.tsx
@@ -1,6 +1,7 @@
 import { requireAdmin } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { listFoodItems } from '@/lib/nutrition/food'
+import { favoriteIdSets } from '@/lib/nutrition/favorites'
 import { FoodCatalog } from '@/components/admin/FoodCatalog'
 
 export const dynamic = 'force-dynamic'
@@ -9,7 +10,10 @@ export default async function FoodPage() {
   const session = await requireAdmin()
   if (!session) redirect('/admin/login')
 
-  const catalog = await listFoodItems(true) // inkl. archivierter Einträge
+  const [catalog, favs] = await Promise.all([
+    listFoodItems(true), // inkl. archivierter Einträge
+    favoriteIdSets(),
+  ])
 
   return (
     <div>
@@ -19,7 +23,7 @@ export default async function FoodPage() {
           Produkte aus Open Food Facts übernehmen oder manuell anlegen. Nährwerte je 100 g/ml.
         </p>
       </div>
-      <FoodCatalog catalog={catalog} />
+      <FoodCatalog catalog={catalog} favoriteFoodIds={[...favs.foods]} />
     </div>
   )
 }

--- a/src/app/admin/log/actions.ts
+++ b/src/app/admin/log/actions.ts
@@ -1,0 +1,131 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { requireAdmin } from '@/lib/auth'
+import { dateOnly } from '@/lib/nutrition/day'
+import { logFood, logDish, logFavorite, deleteMealEntry } from '@/lib/nutrition/meals'
+import { findByBarcode, importFood } from '@/lib/nutrition/food'
+import { openFoodFacts } from '@/lib/nutrition/providers/open-food-facts'
+
+export interface ActionResult {
+  error?: string
+  success?: boolean
+}
+
+function guardDate(date: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null
+  return dateOnly(date)
+}
+
+export async function logFoodEntry(args: {
+  date: string
+  foodItemId: string
+  amount: number
+  mealSlot?: string | null
+}): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  const d = guardDate(args.date)
+  if (!d) return { error: 'Datum ungültig' }
+  if (!args.foodItemId) return { error: 'Kein Produkt gewählt' }
+  if (!(args.amount > 0)) return { error: 'Menge muss > 0 sein' }
+  try {
+    await logFood({ date: d, foodItemId: args.foodItemId, amount: args.amount, mealSlot: args.mealSlot })
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('logFoodEntry:', e)
+    return { error: 'Loggen fehlgeschlagen' }
+  }
+}
+
+export async function logDishEntry(args: {
+  date: string
+  dishId: string
+  multiplier: number
+  mealSlot?: string | null
+}): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  const d = guardDate(args.date)
+  if (!d) return { error: 'Datum ungültig' }
+  if (!args.dishId) return { error: 'Kein Gericht gewählt' }
+  try {
+    await logDish({ date: d, dishId: args.dishId, multiplier: args.multiplier, mealSlot: args.mealSlot })
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('logDishEntry:', e)
+    return { error: 'Loggen fehlgeschlagen' }
+  }
+}
+
+export async function quickLogFavorite(args: {
+  favoriteId: string
+  date: string
+  mealSlot?: string | null
+}): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  const d = guardDate(args.date)
+  if (!d) return { error: 'Datum ungültig' }
+  try {
+    await logFavorite({ favoriteId: args.favoriteId, date: d, mealSlot: args.mealSlot })
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('quickLogFavorite:', e)
+    return { error: 'Loggen fehlgeschlagen' }
+  }
+}
+
+/**
+ * Scan-to-Log: Barcode → lokaler Katalog oder OFF-Import → als Menge loggen.
+ * Verbindet N-03/N-04 mit dem Logging (fremde Produkte via Barcode).
+ */
+export async function logScannedBarcode(args: {
+  barcode: string
+  date: string
+  amount: number
+  mealSlot?: string | null
+}): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  const d = guardDate(args.date)
+  if (!d) return { error: 'Datum ungültig' }
+  if (!(args.amount > 0)) return { error: 'Menge muss > 0 sein' }
+  const code = args.barcode.trim()
+  if (!code) return { error: 'Kein Barcode' }
+
+  try {
+    let foodId: string
+    const local = await findByBarcode(code)
+    if (local) {
+      foodId = local.id
+    } else {
+      const off = await openFoodFacts.lookupByBarcode(code)
+      if (!off) return { error: `Barcode ${code} nicht gefunden.` }
+      const { item } = await importFood(off)
+      foodId = item.id
+    }
+    await logFood({ date: d, foodItemId: foodId, amount: args.amount, mealSlot: args.mealSlot, sourceType: 'BARCODE' })
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('logScannedBarcode:', e)
+    return { error: 'Loggen fehlgeschlagen' }
+  }
+}
+
+export async function removeEntry(id: string): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  try {
+    await deleteMealEntry(id)
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('removeEntry:', e)
+    return { error: 'Löschen fehlgeschlagen' }
+  }
+}

--- a/src/app/admin/log/actions.ts
+++ b/src/app/admin/log/actions.ts
@@ -6,6 +6,7 @@ import { dateOnly } from '@/lib/nutrition/day'
 import { logFood, logDish, logFavorite, deleteMealEntry } from '@/lib/nutrition/meals'
 import { findByBarcode, importFood } from '@/lib/nutrition/food'
 import { openFoodFacts } from '@/lib/nutrition/providers/open-food-facts'
+import { recomputeDay, setDayRefeed } from '@/lib/nutrition/day-aggregate'
 
 export interface ActionResult {
   error?: string
@@ -31,6 +32,7 @@ export async function logFoodEntry(args: {
   if (!(args.amount > 0)) return { error: 'Menge muss > 0 sein' }
   try {
     await logFood({ date: d, foodItemId: args.foodItemId, amount: args.amount, mealSlot: args.mealSlot })
+    await recomputeDay(d)
     revalidatePath('/admin/log')
     return { success: true }
   } catch (e) {
@@ -52,6 +54,7 @@ export async function logDishEntry(args: {
   if (!args.dishId) return { error: 'Kein Gericht gewählt' }
   try {
     await logDish({ date: d, dishId: args.dishId, multiplier: args.multiplier, mealSlot: args.mealSlot })
+    await recomputeDay(d)
     revalidatePath('/admin/log')
     return { success: true }
   } catch (e) {
@@ -71,6 +74,7 @@ export async function quickLogFavorite(args: {
   if (!d) return { error: 'Datum ungültig' }
   try {
     await logFavorite({ favoriteId: args.favoriteId, date: d, mealSlot: args.mealSlot })
+    await recomputeDay(d)
     revalidatePath('/admin/log')
     return { success: true }
   } catch (e) {
@@ -109,6 +113,7 @@ export async function logScannedBarcode(args: {
       foodId = item.id
     }
     await logFood({ date: d, foodItemId: foodId, amount: args.amount, mealSlot: args.mealSlot, sourceType: 'BARCODE' })
+    await recomputeDay(d)
     revalidatePath('/admin/log')
     return { success: true }
   } catch (e) {
@@ -121,11 +126,28 @@ export async function removeEntry(id: string): Promise<ActionResult> {
   const session = await requireAdmin()
   if (!session) return { error: 'Nicht autorisiert' }
   try {
-    await deleteMealEntry(id)
+    const date = await deleteMealEntry(id)
+    if (date) await recomputeDay(date)
     revalidatePath('/admin/log')
     return { success: true }
   } catch (e) {
     console.error('removeEntry:', e)
     return { error: 'Löschen fehlgeschlagen' }
+  }
+}
+
+/** Ad-hoc: Tag als Refeed markieren (oder zurück auf Normal). */
+export async function toggleRefeedDay(date: string, refeed: boolean): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+  const d = guardDate(date)
+  if (!d) return { error: 'Datum ungültig' }
+  try {
+    await setDayRefeed(d, refeed)
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('toggleRefeedDay:', e)
+    return { error: 'Umschalten fehlgeschlagen' }
   }
 }

--- a/src/app/admin/log/page.tsx
+++ b/src/app/admin/log/page.tsx
@@ -2,10 +2,10 @@ import { requireAdmin } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { MealLogger } from '@/components/nutrition/MealLogger'
 import { dateOnly } from '@/lib/nutrition/day'
-import { listDayEntries, sumEntries } from '@/lib/nutrition/meals'
+import { listDayEntries } from '@/lib/nutrition/meals'
 import { listFavorites } from '@/lib/nutrition/favorites'
 import { listDishes } from '@/lib/nutrition/dishes'
-import { resolveTargetsForDate } from '@/lib/nutrition/targets'
+import { recomputeDay } from '@/lib/nutrition/day-aggregate'
 import { zurichDateStr } from '@/lib/timezone'
 
 export const dynamic = 'force-dynamic'
@@ -22,14 +22,13 @@ export default async function LogPage({ searchParams }: PageProps) {
   const date = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : zurichDateStr()
   const d = dateOnly(date)
 
-  const [entries, favorites, dishes, targets] = await Promise.all([
+  // recomputeDay persistiert SOLL/IST + Erfüllung und liefert die Tages-Summary.
+  const [summary, entries, favorites, dishes] = await Promise.all([
+    recomputeDay(d),
     listDayEntries(d),
     listFavorites(),
     listDishes(false),
-    resolveTargetsForDate(d),
   ])
-
-  const totals = sumEntries(entries)
 
   return (
     <div>
@@ -44,8 +43,7 @@ export default async function LogPage({ searchParams }: PageProps) {
         entries={entries}
         favorites={favorites}
         dishes={dishes}
-        totals={totals}
-        targetKcal={targets?.targetKcal ?? null}
+        summary={summary}
       />
     </div>
   )

--- a/src/app/admin/log/page.tsx
+++ b/src/app/admin/log/page.tsx
@@ -1,0 +1,52 @@
+import { requireAdmin } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { MealLogger } from '@/components/nutrition/MealLogger'
+import { dateOnly } from '@/lib/nutrition/day'
+import { listDayEntries, sumEntries } from '@/lib/nutrition/meals'
+import { listFavorites } from '@/lib/nutrition/favorites'
+import { listDishes } from '@/lib/nutrition/dishes'
+import { resolveTargetsForDate } from '@/lib/nutrition/targets'
+import { zurichDateStr } from '@/lib/timezone'
+
+export const dynamic = 'force-dynamic'
+
+interface PageProps {
+  searchParams: Promise<{ date?: string }>
+}
+
+export default async function LogPage({ searchParams }: PageProps) {
+  const session = await requireAdmin()
+  if (!session) redirect('/admin/login')
+
+  const { date: dateParam } = await searchParams
+  const date = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : zurichDateStr()
+  const d = dateOnly(date)
+
+  const [entries, favorites, dishes, targets] = await Promise.all([
+    listDayEntries(d),
+    listFavorites(),
+    listDishes(false),
+    resolveTargetsForDate(d),
+  ])
+
+  const totals = sumEntries(entries)
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Mahlzeiten loggen</h1>
+        <p className="text-on-surface-variant text-sm mt-1">
+          Favoriten für 1-Klick, Katalog/Scan für den Rest. Snapshot wird beim Loggen fixiert.
+        </p>
+      </div>
+      <MealLogger
+        date={date}
+        entries={entries}
+        favorites={favorites}
+        dishes={dishes}
+        totals={totals}
+        targetKcal={targets?.targetKcal ?? null}
+      />
+    </div>
+  )
+}

--- a/src/app/admin/nutrition/actions.ts
+++ b/src/app/admin/nutrition/actions.ts
@@ -4,6 +4,8 @@ import { revalidatePath } from 'next/cache'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { computeEckdaten, type EckdatenInput } from '@/lib/nutrition/calc'
+import { getActivePhase, resolveTargetsForDate } from '@/lib/nutrition/targets'
+import { deriveRefeedSoll, saveRefeedRule } from '@/lib/nutrition/refeed'
 
 // -----------------------------------------------------------------------------
 // Formular-Datentyp (Strings — wie in den übrigen Admin-Actions)
@@ -228,6 +230,33 @@ export async function addTargetsVersion(data: EckdatenFormData): Promise<ActionR
 // -----------------------------------------------------------------------------
 // Aktive Phase beenden (ohne Nachfolger)
 // -----------------------------------------------------------------------------
+
+/**
+ * Setzt die wiederkehrenden Refeed-Wochentage der aktiven Phase. Das Refeed-SOLL
+ * wird aus den aktuell gültigen Eckdaten abgeleitet (Erhaltungskalorien, 1,6 g/kg
+ * Protein, 0,5 g/kg Fett, KH Rest).
+ */
+export async function saveRefeedRuleAction(weekdays: number[]): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  const active = await getActivePhase()
+  if (!active) return { error: 'Keine aktive Phase — bitte zuerst eine Phase anlegen.' }
+  const targets = active.targets ?? (await resolveTargetsForDate())
+  if (!targets) return { error: 'Keine gültigen Eckdaten für die Refeed-Berechnung.' }
+
+  const cleaned = [...new Set(weekdays.filter((d) => Number.isInteger(d) && d >= 1 && d <= 7))].sort()
+
+  try {
+    await saveRefeedRule({ phaseId: active.id, recurringWeekdays: cleaned, soll: deriveRefeedSoll(targets) })
+    revalidatePath('/admin/nutrition')
+    revalidatePath('/admin/log')
+    return { success: true }
+  } catch (e) {
+    console.error('saveRefeedRuleAction:', e)
+    return { error: 'Refeed-Regel speichern fehlgeschlagen.' }
+  }
+}
 
 export async function endActivePhase(endDateStr: string): Promise<ActionResult> {
   const session = await requireAdmin()

--- a/src/app/admin/nutrition/actions.ts
+++ b/src/app/admin/nutrition/actions.ts
@@ -1,0 +1,251 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { computeEckdaten, type EckdatenInput } from '@/lib/nutrition/calc'
+
+// -----------------------------------------------------------------------------
+// Formular-Datentyp (Strings — wie in den übrigen Admin-Actions)
+// -----------------------------------------------------------------------------
+
+export interface EckdatenFormData {
+  weightKg: string
+  heightCm: string
+  age: string
+  sex: 'MALE' | 'FEMALE'
+  bodyFatPct: string
+  activityFactor: string
+  phaseMode: 'DEFICIT' | 'MAINTENANCE' | 'SURPLUS'
+  deficitMethod: 'MODERATE' | 'AGGRESSIVE' | 'SIMPLE'
+  validFrom: string // YYYY-MM-DD
+  note: string
+}
+
+export interface ActionResult {
+  error?: string
+  success?: boolean
+}
+
+function toFloat(val: string): number | null {
+  if (!val.trim()) return null
+  const n = parseFloat(val.replace(',', '.'))
+  return isNaN(n) ? null : n
+}
+
+/** Formular → validierter Rechen-Input (oder Fehlermeldung). */
+function parseInput(data: EckdatenFormData): { input: EckdatenInput } | { error: string } {
+  const weightKg = toFloat(data.weightKg)
+  const heightCm = toFloat(data.heightCm)
+  const age = toFloat(data.age)
+  const activityFactor = toFloat(data.activityFactor)
+  const bodyFatPct = toFloat(data.bodyFatPct)
+
+  if (weightKg === null || weightKg <= 0) return { error: 'Gewicht (kg) ist erforderlich.' }
+  if (heightCm === null || heightCm <= 0) return { error: 'Grösse (cm) ist erforderlich.' }
+  if (age === null || age <= 0) return { error: 'Alter ist erforderlich.' }
+  if (activityFactor === null || activityFactor <= 0)
+    return { error: 'Aktivitätsfaktor ist erforderlich.' }
+  if (data.sex !== 'MALE' && data.sex !== 'FEMALE') return { error: 'Geschlecht ungültig.' }
+
+  return {
+    input: {
+      weightKg,
+      heightCm,
+      age,
+      sex: data.sex,
+      bodyFatPct,
+      activityFactor,
+      phaseMode: data.phaseMode,
+      deficitMethod: data.deficitMethod,
+    },
+  }
+}
+
+function parseDate(val: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(val)) return null
+  const d = new Date(val)
+  return isNaN(d.getTime()) ? null : d
+}
+
+function revalidate() {
+  revalidatePath('/admin/nutrition')
+}
+
+// -----------------------------------------------------------------------------
+// Neue Phase anlegen / wechseln
+//   → berechnet Eckdaten serverseitig, legt eine NutritionTargets-Version an
+//     (validFrom = Phasenstart) und schaltet die bisher aktive Phase auf
+//     COMPLETED (endDate = Phasenstart − 1 Tag).
+// -----------------------------------------------------------------------------
+
+export async function createPhase(data: EckdatenFormData): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  const parsed = parseInput(data)
+  if ('error' in parsed) return parsed
+
+  const startDate = parseDate(data.validFrom)
+  if (!startDate) return { error: 'Startdatum ungültig (YYYY-MM-DD).' }
+
+  const eck = computeEckdaten(parsed.input)
+  const prevEnd = new Date(startDate.getTime() - 24 * 60 * 60 * 1000)
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Bisher aktive Phase(n) beenden
+      await tx.phase.updateMany({
+        where: { status: 'ACTIVE' },
+        data: { status: 'COMPLETED', endDate: prevEnd },
+      })
+
+      // Eckdaten-Version (idempotent je validFrom)
+      const targets = await tx.nutritionTargets.upsert({
+        where: { validFrom: startDate },
+        update: {
+          baseWeightKg: parsed.input.weightKg,
+          sex: parsed.input.sex,
+          heightCm: parsed.input.heightCm,
+          age: parsed.input.age,
+          bodyFatPct: parsed.input.bodyFatPct,
+          activityFactor: parsed.input.activityFactor,
+          deficitMode: data.deficitMethod,
+          targetKcal: eck.targetKcal,
+          proteinG: eck.proteinG,
+          fatG: eck.fatG,
+          carbsG: eck.carbsG,
+          mealsPerDay: eck.mealsPerDay,
+          calcNote: eck.calcNote,
+        },
+        create: {
+          validFrom: startDate,
+          baseWeightKg: parsed.input.weightKg,
+          sex: parsed.input.sex,
+          heightCm: parsed.input.heightCm,
+          age: parsed.input.age,
+          bodyFatPct: parsed.input.bodyFatPct,
+          activityFactor: parsed.input.activityFactor,
+          deficitMode: data.deficitMethod,
+          targetKcal: eck.targetKcal,
+          proteinG: eck.proteinG,
+          fatG: eck.fatG,
+          carbsG: eck.carbsG,
+          mealsPerDay: eck.mealsPerDay,
+          calcNote: eck.calcNote,
+        },
+      })
+
+      await tx.phase.create({
+        data: {
+          mode: data.phaseMode,
+          startDate,
+          status: 'ACTIVE',
+          targetsId: targets.id,
+          note: data.note.trim() || null,
+        },
+      })
+    })
+
+    revalidate()
+    return { success: true }
+  } catch (e) {
+    console.error('createPhase:', e)
+    return { error: 'Fehler beim Anlegen der Phase.' }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Eckdaten neu berechnen (Kalibrierung innerhalb der laufenden Phase)
+//   → legt eine neue NutritionTargets-Version an und verknüpft die aktive Phase
+//     damit. Die Erfüllung vergangener Tage bleibt über deren SOLL-Snapshot stabil.
+// -----------------------------------------------------------------------------
+
+export async function addTargetsVersion(data: EckdatenFormData): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  const parsed = parseInput(data)
+  if ('error' in parsed) return parsed
+
+  const validFrom = parseDate(data.validFrom)
+  if (!validFrom) return { error: 'Gültig-ab-Datum ungültig (YYYY-MM-DD).' }
+
+  const active = await prisma.phase.findFirst({ where: { status: 'ACTIVE' } })
+  if (!active) return { error: 'Keine aktive Phase — bitte zuerst eine Phase anlegen.' }
+
+  const eck = computeEckdaten(parsed.input)
+
+  try {
+    const targets = await prisma.nutritionTargets.upsert({
+      where: { validFrom },
+      update: {
+        baseWeightKg: parsed.input.weightKg,
+        sex: parsed.input.sex,
+        heightCm: parsed.input.heightCm,
+        age: parsed.input.age,
+        bodyFatPct: parsed.input.bodyFatPct,
+        activityFactor: parsed.input.activityFactor,
+        deficitMode: data.deficitMethod,
+        targetKcal: eck.targetKcal,
+        proteinG: eck.proteinG,
+        fatG: eck.fatG,
+        carbsG: eck.carbsG,
+        mealsPerDay: eck.mealsPerDay,
+        calcNote: eck.calcNote,
+      },
+      create: {
+        validFrom,
+        baseWeightKg: parsed.input.weightKg,
+        sex: parsed.input.sex,
+        heightCm: parsed.input.heightCm,
+        age: parsed.input.age,
+        bodyFatPct: parsed.input.bodyFatPct,
+        activityFactor: parsed.input.activityFactor,
+        deficitMode: data.deficitMethod,
+        targetKcal: eck.targetKcal,
+        proteinG: eck.proteinG,
+        fatG: eck.fatG,
+        carbsG: eck.carbsG,
+        mealsPerDay: eck.mealsPerDay,
+        calcNote: eck.calcNote,
+      },
+    })
+
+    await prisma.phase.update({
+      where: { id: active.id },
+      data: { targetsId: targets.id },
+    })
+
+    revalidate()
+    return { success: true }
+  } catch (e) {
+    console.error('addTargetsVersion:', e)
+    return { error: 'Fehler beim Speichern der Eckdaten-Version.' }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Aktive Phase beenden (ohne Nachfolger)
+// -----------------------------------------------------------------------------
+
+export async function endActivePhase(endDateStr: string): Promise<ActionResult> {
+  const session = await requireAdmin()
+  if (!session) return { error: 'Nicht autorisiert' }
+
+  const endDate = parseDate(endDateStr)
+  if (!endDate) return { error: 'Enddatum ungültig (YYYY-MM-DD).' }
+
+  try {
+    const res = await prisma.phase.updateMany({
+      where: { status: 'ACTIVE' },
+      data: { status: 'COMPLETED', endDate },
+    })
+    if (res.count === 0) return { error: 'Keine aktive Phase vorhanden.' }
+    revalidate()
+    return { success: true }
+  } catch (e) {
+    console.error('endActivePhase:', e)
+    return { error: 'Fehler beim Beenden der Phase.' }
+  }
+}

--- a/src/app/admin/nutrition/page.tsx
+++ b/src/app/admin/nutrition/page.tsx
@@ -6,11 +6,13 @@ import {
   listTargetVersions,
   resolveTargetsForDate,
 } from '@/lib/nutrition/targets'
+import { getActiveRefeedRule, deriveRefeedSoll } from '@/lib/nutrition/refeed'
 import { zurichDateStr } from '@/lib/timezone'
 import {
   NutritionPhaseForm,
   type NutritionPhaseFormInitial,
 } from '@/components/admin/NutritionPhaseForm'
+import { RefeedRuleForm } from '@/components/admin/RefeedRuleForm'
 import type { NutritionTargets } from '@prisma/client'
 
 export const dynamic = 'force-dynamic'
@@ -73,6 +75,10 @@ export default async function NutritionPage() {
 
   const initial = initialFromTargets(active?.targets ?? todayTargets)
 
+  const refeedRule = active ? await getActiveRefeedRule(active.id) : null
+  const refeedBaseTargets = active?.targets ?? todayTargets
+  const derivedRefeedSoll = refeedBaseTargets ? deriveRefeedSoll(refeedBaseTargets) : null
+
   return (
     <div>
       <div className="mb-6">
@@ -115,6 +121,19 @@ export default async function NutritionPage() {
           Phase anlegen / Eckdaten berechnen
         </h2>
         <NutritionPhaseForm initial={initial} />
+      </section>
+
+      {/* Refeed-Regel */}
+      <section className="mb-10">
+        <h2 className="font-headline text-base font-semibold text-on-surface mb-3">Refeed-Tage</h2>
+        {active ? (
+          <RefeedRuleForm
+            initialWeekdays={refeedRule?.recurringWeekdays ?? []}
+            derivedSoll={derivedRefeedSoll}
+          />
+        ) : (
+          <p className="text-sm text-on-surface-variant">Erst eine aktive Phase anlegen.</p>
+        )}
       </section>
 
       {/* Phasen-Verlauf */}

--- a/src/app/admin/nutrition/page.tsx
+++ b/src/app/admin/nutrition/page.tsx
@@ -1,0 +1,216 @@
+import { requireAdmin } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import {
+  getActivePhase,
+  listPhases,
+  listTargetVersions,
+  resolveTargetsForDate,
+} from '@/lib/nutrition/targets'
+import { zurichDateStr } from '@/lib/timezone'
+import {
+  NutritionPhaseForm,
+  type NutritionPhaseFormInitial,
+} from '@/components/admin/NutritionPhaseForm'
+import type { NutritionTargets } from '@prisma/client'
+
+export const dynamic = 'force-dynamic'
+
+const PHASE_MODE_LABEL: Record<string, string> = {
+  DEFICIT: 'Defizit',
+  MAINTENANCE: 'Erhalt',
+  SURPLUS: 'Leichter Überschuss',
+}
+const DEFICIT_LABEL: Record<string, string> = {
+  MODERATE: 'moderat (× 0,8)',
+  AGGRESSIVE: 'aggressiv (× 0,7)',
+  SIMPLE: 'einfach (− 500)',
+}
+
+function fmtDate(d: Date | null): string {
+  if (!d) return '—'
+  return d.toLocaleDateString('de-CH', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function initialFromTargets(t: NutritionTargets | null): NutritionPhaseFormInitial {
+  const today = zurichDateStr()
+  if (!t) {
+    // Fallback-Defaults (Fibel-Ausgangswerte)
+    return {
+      weightKg: '94',
+      heightCm: '170',
+      age: '43',
+      sex: 'MALE',
+      bodyFatPct: '27',
+      activityFactor: '1.55',
+      phaseMode: 'DEFICIT',
+      deficitMethod: 'MODERATE',
+      validFrom: today,
+    }
+  }
+  return {
+    weightKg: t.baseWeightKg.toString(),
+    heightCm: t.heightCm.toString(),
+    age: t.age.toString(),
+    sex: t.sex,
+    bodyFatPct: t.bodyFatPct?.toString() ?? '',
+    activityFactor: t.activityFactor.toString(),
+    phaseMode: 'DEFICIT',
+    deficitMethod: t.deficitMode,
+    validFrom: today,
+  }
+}
+
+export default async function NutritionPage() {
+  const session = await requireAdmin()
+  if (!session) redirect('/admin/login')
+
+  const [active, todayTargets, phases, versions] = await Promise.all([
+    getActivePhase(),
+    resolveTargetsForDate(),
+    listPhases(),
+    listTargetVersions(),
+  ])
+
+  const initial = initialFromTargets(active?.targets ?? todayTargets)
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="font-headline text-2xl font-bold text-on-surface">Ernährung — Ziele & Phasen</h1>
+        <p className="text-on-surface-variant text-sm mt-1">
+          Eckdaten nach Fibel-Methodik: BMR → TDEE → Defizit → Makros. Versioniert über das
+          Gültig-ab-Datum.
+        </p>
+      </div>
+
+      {/* Aktuell gültige Eckdaten (heute) */}
+      <section className="mb-8">
+        <h2 className="font-headline text-base font-semibold text-on-surface mb-3">
+          Aktuell gültig ({fmtDate(new Date())})
+        </h2>
+        {todayTargets ? (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <Stat label="Ziel-Kalorien" value={`${todayTargets.targetKcal}`} unit="kcal" accent />
+            <Stat label="Protein" value={`${todayTargets.proteinG}`} unit="g" />
+            <Stat label="Fett" value={`${todayTargets.fatG}`} unit="g" />
+            <Stat label="Kohlenhydrate" value={`${todayTargets.carbsG}`} unit="g" />
+          </div>
+        ) : (
+          <p className="text-sm text-on-surface-variant">
+            Noch keine gültigen Eckdaten für heute. Lege unten eine Phase an.
+          </p>
+        )}
+        {active && (
+          <p className="text-xs text-on-surface-variant mt-2">
+            Aktive Phase: <span className="text-on-surface">{PHASE_MODE_LABEL[active.mode] ?? active.mode}</span>{' '}
+            seit {fmtDate(active.startDate)}
+            {active.note ? ` · ${active.note}` : ''}
+          </p>
+        )}
+      </section>
+
+      {/* Formular */}
+      <section className="mb-10">
+        <h2 className="font-headline text-base font-semibold text-on-surface mb-3">
+          Phase anlegen / Eckdaten berechnen
+        </h2>
+        <NutritionPhaseForm initial={initial} />
+      </section>
+
+      {/* Phasen-Verlauf */}
+      <section className="mb-10">
+        <h2 className="font-headline text-base font-semibold text-on-surface mb-3">Phasen</h2>
+        {phases.length === 0 ? (
+          <p className="text-sm text-on-surface-variant">Noch keine Phasen.</p>
+        ) : (
+          <TableWrap
+            head={['Modus', 'Start', 'Ende', 'Status', 'Ziel-kcal', 'Notiz']}
+            rows={phases.map((p) => [
+              PHASE_MODE_LABEL[p.mode] ?? p.mode,
+              fmtDate(p.startDate),
+              fmtDate(p.endDate),
+              p.status,
+              p.targets ? `${p.targets.targetKcal} kcal` : '—',
+              p.note ?? '—',
+            ])}
+          />
+        )}
+      </section>
+
+      {/* Eckdaten-Versionen */}
+      <section>
+        <h2 className="font-headline text-base font-semibold text-on-surface mb-3">
+          Eckdaten-Versionen
+        </h2>
+        {versions.length === 0 ? (
+          <p className="text-sm text-on-surface-variant">Noch keine Eckdaten.</p>
+        ) : (
+          <TableWrap
+            head={['Gültig ab', 'kcal', 'P', 'F', 'KH', 'Gewicht', 'Methode']}
+            rows={versions.map((v) => [
+              fmtDate(v.validFrom),
+              `${v.targetKcal}`,
+              `${v.proteinG}`,
+              `${v.fatG}`,
+              `${v.carbsG}`,
+              `${v.baseWeightKg} kg`,
+              DEFICIT_LABEL[v.deficitMode] ?? v.deficitMode,
+            ])}
+          />
+        )}
+      </section>
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  unit,
+  accent,
+}: {
+  label: string
+  value: string
+  unit: string
+  accent?: boolean
+}) {
+  return (
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high p-4">
+      <p className="text-[10px] uppercase tracking-widest text-on-surface-variant mb-1">{label}</p>
+      <p className={`font-headline text-xl font-bold tabular-nums ${accent ? 'text-primary' : 'text-on-surface'}`}>
+        {value} <span className="text-xs font-normal text-on-surface-variant">{unit}</span>
+      </p>
+    </div>
+  )
+}
+
+function TableWrap({ head, rows }: { head: string[]; rows: string[][] }) {
+  return (
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-surface-container text-on-surface-variant text-left">
+              {head.map((h) => (
+                <th key={h} className="px-4 py-3 font-medium whitespace-nowrap">
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i} className="border-b border-surface-container last:border-0">
+                {r.map((c, j) => (
+                  <td key={j} className="px-4 py-3 text-on-surface whitespace-nowrap">
+                    {c}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/nutrition/food/barcode/[barcode]/route.ts
+++ b/src/app/api/nutrition/food/barcode/[barcode]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { openFoodFacts } from '@/lib/nutrition/providers/open-food-facts'
+import { findByBarcode } from '@/lib/nutrition/food'
+
+// Barcode-Lookup (auch von N-04/Scanner genutzt): erst lokaler Katalog
+// (bereits gespeichert), dann Open Food Facts.
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ barcode: string }> },
+) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 })
+
+  const { barcode } = await params
+  const code = barcode?.trim()
+  if (!code) return NextResponse.json({ error: 'Kein Barcode' }, { status: 400 })
+
+  // 1) Lokaler Katalog (bereits gespeicherte Produkte)
+  const local = await findByBarcode(code)
+  if (local) return NextResponse.json({ source: 'local', item: local })
+
+  // 2) Open Food Facts
+  try {
+    const off = await openFoodFacts.lookupByBarcode(code)
+    if (!off) return NextResponse.json({ error: 'Produkt nicht gefunden' }, { status: 404 })
+    return NextResponse.json({ source: 'off', food: off })
+  } catch (e) {
+    console.error('barcode lookup:', e)
+    return NextResponse.json({ error: 'Lookup fehlgeschlagen' }, { status: 502 })
+  }
+}

--- a/src/app/api/nutrition/food/search/route.ts
+++ b/src/app/api/nutrition/food/search/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { openFoodFacts } from '@/lib/nutrition/providers/open-food-facts'
+import { searchLocalFoodItems } from '@/lib/nutrition/food'
+
+// Serverseitiger Proxy: hält externe Provider (und spätere Keys) vom Client fern.
+export async function GET(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 })
+
+  const q = request.nextUrl.searchParams.get('q')?.trim() ?? ''
+  if (q.length < 2) {
+    return NextResponse.json({ local: [], off: [] })
+  }
+
+  try {
+    const [local, off] = await Promise.all([
+      searchLocalFoodItems(q),
+      openFoodFacts.searchByText(q).catch((e) => {
+        console.error('OFF search:', e)
+        return []
+      }),
+    ])
+    return NextResponse.json({ local, off })
+  } catch (e) {
+    console.error('food search:', e)
+    return NextResponse.json({ error: 'Suche fehlgeschlagen' }, { status: 502 })
+  }
+}

--- a/src/app/api/nutrition/meal-photo/[id]/route.ts
+++ b/src/app/api/nutrition/meal-photo/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { readMealPhoto } from '@/lib/nutrition/meal-photos'
+
+// Geschützte Auslieferung eines Mahlzeiten-Fotos (liegt ausserhalb public/).
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await requireAdmin()
+  if (!session) return new NextResponse('Nicht autorisiert', { status: 401 })
+
+  const { id } = await params
+  const photo = await prisma.mealPhoto.findUnique({ where: { id } })
+  if (!photo) return new NextResponse('Not Found', { status: 404 })
+
+  const file = await readMealPhoto(photo.imagePath)
+  if (!file) return new NextResponse('Not Found', { status: 404 })
+
+  return new NextResponse(new Uint8Array(file.buffer), {
+    headers: {
+      'Content-Type': file.contentType,
+      'Cache-Control': 'private, max-age=31536000, immutable',
+    },
+  })
+}

--- a/src/app/api/nutrition/photo-estimate/route.ts
+++ b/src/app/api/nutrition/photo-estimate/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { estimateFromPhotos, type VisionImage } from '@/lib/nutrition/vision'
+import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_BYTES } from '@/lib/nutrition/meal-photos'
+
+async function toVisionImage(file: File): Promise<VisionImage> {
+  const spec = ALLOWED_IMAGE_TYPES[file.type]
+  if (!spec) throw new Error('Nur JPEG, PNG oder WebP werden unterstützt')
+  if (file.size > MAX_IMAGE_BYTES) throw new Error('Bild darf maximal 12 MB gross sein')
+  const data = Buffer.from(await file.arrayBuffer()).toString('base64')
+  return { data, mediaType: spec.media }
+}
+
+// Schätzt Nährwerte aus Foto(s) — persistiert noch nichts (das passiert beim
+// Bestätigen über /api/nutrition/photo-log). Keys bleiben serverseitig.
+export async function POST(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 })
+
+  let form: FormData
+  try {
+    form = await request.formData()
+  } catch {
+    return NextResponse.json({ error: 'Ungültige Anfrage' }, { status: 400 })
+  }
+
+  const plate = form.get('plate')
+  if (!(plate instanceof File)) {
+    return NextResponse.json({ error: 'Teller-Foto fehlt' }, { status: 400 })
+  }
+  const menu = form.get('menu')
+  const title = (form.get('title') as string | null)?.trim() || null
+
+  try {
+    const plateImg = await toVisionImage(plate)
+    const menuImg = menu instanceof File ? await toVisionImage(menu) : null
+    const estimate = await estimateFromPhotos({ plate: plateImg, menu: menuImg, title })
+    return NextResponse.json({ estimate })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Schätzung fehlgeschlagen'
+    console.error('photo-estimate:', e)
+    const status = msg.includes('unterstützt') || msg.includes('maximal') ? 422 : 502
+    return NextResponse.json({ error: msg }, { status })
+  }
+}

--- a/src/app/api/nutrition/photo-log/route.ts
+++ b/src/app/api/nutrition/photo-log/route.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from '@/lib/auth'
 import { saveMealPhoto } from '@/lib/nutrition/meal-photos'
 import { logPhotoMeal, type PhotoInput } from '@/lib/nutrition/meals'
 import { dateOnly } from '@/lib/nutrition/day'
+import { recomputeDay } from '@/lib/nutrition/day-aggregate'
 
 function num(form: FormData, key: string): number {
   const v = parseFloat(String(form.get(key) ?? '').replace(',', '.'))
@@ -65,6 +66,7 @@ export async function POST(request: NextRequest) {
       fatG: num(form, 'fatG'),
       photos,
     })
+    await recomputeDay(dateOnly(dateStr))
     return NextResponse.json({ ok: true, id: entry.id })
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Loggen fehlgeschlagen'

--- a/src/app/api/nutrition/photo-log/route.ts
+++ b/src/app/api/nutrition/photo-log/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { saveMealPhoto } from '@/lib/nutrition/meal-photos'
+import { logPhotoMeal, type PhotoInput } from '@/lib/nutrition/meals'
+import { dateOnly } from '@/lib/nutrition/day'
+
+function num(form: FormData, key: string): number {
+  const v = parseFloat(String(form.get(key) ?? '').replace(',', '.'))
+  return isNaN(v) ? 0 : Math.max(0, v)
+}
+
+// Persistiert die (bestätigten/korrigierten) Foto-Schätzwerte:
+// speichert die Bilder und legt MealEntry (PHOTO_AI) + MealPhoto(s) an.
+export async function POST(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 })
+
+  let form: FormData
+  try {
+    form = await request.formData()
+  } catch {
+    return NextResponse.json({ error: 'Ungültige Anfrage' }, { status: 400 })
+  }
+
+  const dateStr = String(form.get('date') ?? '')
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    return NextResponse.json({ error: 'Datum ungültig' }, { status: 400 })
+  }
+  const plate = form.get('plate')
+  if (!(plate instanceof File)) {
+    return NextResponse.json({ error: 'Teller-Foto fehlt' }, { status: 400 })
+  }
+  const menu = form.get('menu')
+  const mealSlot = (form.get('mealSlot') as string | null)?.trim() || null
+  const dishName = (form.get('dishName') as string | null)?.trim() || 'Geschätzte Mahlzeit'
+
+  let aiAnalysis: unknown = undefined
+  const rawStr = form.get('aiRaw')
+  if (typeof rawStr === 'string' && rawStr) {
+    try {
+      aiAnalysis = JSON.parse(rawStr)
+    } catch {
+      aiAnalysis = { raw: rawStr }
+    }
+  }
+  const confidenceVal = form.get('confidence')
+  const confidence = confidenceVal != null ? num(form, 'confidence') : null
+
+  try {
+    const photos: PhotoInput[] = []
+    const plateName = await saveMealPhoto(plate)
+    photos.push({ filename: plateName, photoType: 'PLATE', aiAnalysis, aiConfidence: confidence })
+    if (menu instanceof File) {
+      const menuName = await saveMealPhoto(menu)
+      photos.push({ filename: menuName, photoType: 'MENU' })
+    }
+
+    const entry = await logPhotoMeal({
+      date: dateOnly(dateStr),
+      mealSlot,
+      externalName: dishName,
+      kcal: num(form, 'kcal'),
+      proteinG: num(form, 'proteinG'),
+      carbsG: num(form, 'carbsG'),
+      fatG: num(form, 'fatG'),
+      photos,
+    })
+    return NextResponse.json({ ok: true, id: entry.id })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Loggen fehlgeschlagen'
+    console.error('photo-log:', e)
+    const status = msg.includes('unterstützt') || msg.includes('maximal') ? 422 : 500
+    return NextResponse.json({ error: msg }, { status })
+  }
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -21,6 +21,7 @@ const NAV_GROUPS = [
     label: 'Daten',
     items: [
       { href: '/admin/quick-log',   label: 'Quick Log',      exact: false },
+      { href: '/admin/nutrition',   label: 'Ziele & Phasen', exact: false },
       { href: '/admin/meal-plan',   label: 'Mahlzeitenplan', exact: false },
       { href: '/admin/drinks',     label: 'Getränke',   exact: false },
       { href: '/admin/metrics',            label: 'Metriken',    exact: false },

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -22,6 +22,7 @@ const NAV_GROUPS = [
     items: [
       { href: '/admin/quick-log',   label: 'Quick Log',      exact: false },
       { href: '/admin/nutrition',   label: 'Ziele & Phasen', exact: false },
+      { href: '/admin/food',        label: 'Lebensmittel',   exact: false },
       { href: '/admin/meal-plan',   label: 'Mahlzeitenplan', exact: false },
       { href: '/admin/drinks',     label: 'Getränke',   exact: false },
       { href: '/admin/metrics',            label: 'Metriken',    exact: false },

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -21,8 +21,10 @@ const NAV_GROUPS = [
     label: 'Daten',
     items: [
       { href: '/admin/quick-log',   label: 'Quick Log',      exact: false },
+      { href: '/admin/log',         label: 'Loggen',         exact: false },
       { href: '/admin/nutrition',   label: 'Ziele & Phasen', exact: false },
       { href: '/admin/food',        label: 'Lebensmittel',   exact: false },
+      { href: '/admin/dishes',      label: 'Gerichte',       exact: false },
       { href: '/admin/meal-plan',   label: 'Mahlzeitenplan', exact: false },
       { href: '/admin/drinks',     label: 'Getränke',   exact: false },
       { href: '/admin/metrics',            label: 'Metriken',    exact: false },

--- a/src/components/admin/FoodCatalog.tsx
+++ b/src/components/admin/FoodCatalog.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import type { FoodItem } from '@prisma/client'
 import type { NormalizedFood } from '@/lib/nutrition/food-provider'
+import { BarcodeScanner } from '@/components/nutrition/BarcodeScanner'
 import {
   saveFoodItem,
   importFoodItem,
@@ -66,6 +67,34 @@ export function FoodCatalog({ catalog }: { catalog: FoodItem[] }) {
   const [query, setQuery] = useState('')
   const [searching, setSearching] = useState(false)
   const [results, setResults] = useState<SearchResponse | null>(null)
+  const [showScanner, setShowScanner] = useState(false)
+
+  // Barcode-Scan → Lookup (lokal, dann OFF)
+  async function onBarcodeDetected(code: string) {
+    setShowScanner(false)
+    setMsg(null)
+    try {
+      const res = await fetch(`/api/nutrition/food/barcode/${encodeURIComponent(code)}`)
+      if (res.status === 404) {
+        setForm({ ...EMPTY, barcode: code })
+        setMsg({ kind: 'err', text: `Barcode ${code} nicht gefunden — bitte manuell anlegen.` })
+        return
+      }
+      if (!res.ok) throw new Error()
+      const data = (await res.json()) as
+        | { source: 'local'; item: FoodItem }
+        | { source: 'off'; food: NormalizedFood }
+      if (data.source === 'local') {
+        setForm(itemToForm(data.item))
+        setMsg({ kind: 'ok', text: `„${data.item.name}" ist bereits im Katalog (zum Bearbeiten geladen).` })
+      } else {
+        loadOff(data.food)
+        setMsg({ kind: 'ok', text: `„${data.food.name}" gefunden — prüfen und übernehmen.` })
+      }
+    } catch {
+      setMsg({ kind: 'err', text: 'Barcode-Lookup fehlgeschlagen.' })
+    }
+  }
 
   const runSearch = useCallback(async () => {
     if (query.trim().length < 2) return
@@ -179,7 +208,20 @@ export function FoodCatalog({ catalog }: { catalog: FoodItem[] }) {
           >
             {searching ? '…' : 'Suchen'}
           </button>
+          <button
+            type="button"
+            onClick={() => setShowScanner((v) => !v)}
+            className="flex-none px-4 py-1.5 border border-surface-container-high text-on-surface rounded-lg text-sm font-medium hover:border-outline transition-colors"
+          >
+            {showScanner ? 'Scanner aus' : 'Scannen'}
+          </button>
         </div>
+
+        {showScanner && (
+          <div className="mt-4">
+            <BarcodeScanner onDetected={onBarcodeDetected} onClose={() => setShowScanner(false)} />
+          </div>
+        )}
 
         {results && (
           <div className="mt-4 space-y-4">

--- a/src/components/admin/FoodCatalog.tsx
+++ b/src/components/admin/FoodCatalog.tsx
@@ -10,6 +10,7 @@ import {
   importFoodItem,
   deleteFoodItem,
   restoreFoodItem,
+  toggleFoodFavorite,
   type FoodFormData,
 } from '@/app/admin/food/actions'
 
@@ -58,10 +59,17 @@ interface SearchResponse {
   off: NormalizedFood[]
 }
 
-export function FoodCatalog({ catalog }: { catalog: FoodItem[] }) {
+export function FoodCatalog({
+  catalog,
+  favoriteFoodIds,
+}: {
+  catalog: FoodItem[]
+  favoriteFoodIds: string[]
+}) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+  const favSet = new Set(favoriteFoodIds)
 
   // --- Suche ----------------------------------------------------------------
   const [query, setQuery] = useState('')
@@ -170,6 +178,14 @@ export function FoodCatalog({ catalog }: { catalog: FoodItem[] }) {
     startTransition(async () => {
       await restoreFoodItem(id)
       router.refresh()
+    })
+  }
+
+  function toggleFav(id: string, on: boolean) {
+    startTransition(async () => {
+      const r = await toggleFoodFavorite(id, on)
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else router.refresh()
     })
   }
 
@@ -410,6 +426,16 @@ export function FoodCatalog({ catalog }: { catalog: FoodItem[] }) {
                         </span>
                       </td>
                       <td className="px-4 py-3 text-right whitespace-nowrap">
+                        <button
+                          type="button"
+                          onClick={() => toggleFav(f.id, !favSet.has(f.id))}
+                          disabled={isPending}
+                          className={`mr-3 ${favSet.has(f.id) ? 'text-primary' : 'text-on-surface-variant hover:text-on-surface'} disabled:opacity-50`}
+                          title="Favorit"
+                          aria-label="Favorit"
+                        >
+                          {favSet.has(f.id) ? '★' : '☆'}
+                        </button>
                         <button
                           type="button"
                           onClick={() => setForm(itemToForm(f))}

--- a/src/components/admin/FoodCatalog.tsx
+++ b/src/components/admin/FoodCatalog.tsx
@@ -1,0 +1,408 @@
+'use client'
+
+import { useState, useTransition, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import type { FoodItem } from '@prisma/client'
+import type { NormalizedFood } from '@/lib/nutrition/food-provider'
+import {
+  saveFoodItem,
+  importFoodItem,
+  deleteFoodItem,
+  restoreFoodItem,
+  type FoodFormData,
+} from '@/app/admin/food/actions'
+
+const EMPTY: FoodFormData = {
+  name: '', brand: '', barcode: '', baseUnit: 'g',
+  kcal: '', proteinG: '', carbsG: '', fatG: '',
+  fiberG: '', sugarG: '', saturatedFatG: '', sodiumMg: '', potassiumMg: '',
+  ironMg: '', magnesiumMg: '', calciumMg: '', zincMg: '',
+  vitaminDUg: '', vitaminB12Ug: '', vitaminCMg: '',
+}
+
+const s = (n: number | null | undefined) => (n === null || n === undefined ? '' : String(n))
+
+function itemToForm(f: FoodItem): FoodFormData {
+  return {
+    id: f.id, name: f.name, brand: f.brand ?? '', barcode: f.barcode ?? '', baseUnit: f.baseUnit,
+    kcal: s(f.kcal), proteinG: s(f.proteinG), carbsG: s(f.carbsG), fatG: s(f.fatG),
+    fiberG: s(f.fiberG), sugarG: s(f.sugarG), saturatedFatG: s(f.saturatedFatG),
+    sodiumMg: s(f.sodiumMg), potassiumMg: s(f.potassiumMg), ironMg: s(f.ironMg),
+    magnesiumMg: s(f.magnesiumMg), calciumMg: s(f.calciumMg), zincMg: s(f.zincMg),
+    vitaminDUg: s(f.vitaminDUg), vitaminB12Ug: s(f.vitaminB12Ug), vitaminCMg: s(f.vitaminCMg),
+  }
+}
+
+const inputCls =
+  'w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container'
+
+function Num({
+  label, unit, value, onChange, step = 'any',
+}: {
+  label: string; unit?: string; value: string; onChange: (v: string) => void; step?: string
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-on-surface-variant mb-1">
+        {label} {unit && <span className="font-normal">({unit})</span>}
+      </label>
+      <input type="number" inputMode="decimal" step={step} min={0} value={value}
+        onChange={(e) => onChange(e.target.value)} className={inputCls} />
+    </div>
+  )
+}
+
+interface SearchResponse {
+  local: FoodItem[]
+  off: NormalizedFood[]
+}
+
+export function FoodCatalog({ catalog }: { catalog: FoodItem[] }) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+
+  // --- Suche ----------------------------------------------------------------
+  const [query, setQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [results, setResults] = useState<SearchResponse | null>(null)
+
+  const runSearch = useCallback(async () => {
+    if (query.trim().length < 2) return
+    setSearching(true)
+    setMsg(null)
+    try {
+      const res = await fetch(`/api/nutrition/food/search?q=${encodeURIComponent(query.trim())}`)
+      if (!res.ok) throw new Error()
+      setResults((await res.json()) as SearchResponse)
+    } catch {
+      setMsg({ kind: 'err', text: 'Suche fehlgeschlagen.' })
+    } finally {
+      setSearching(false)
+    }
+  }, [query])
+
+  function doImport(food: NormalizedFood) {
+    setMsg(null)
+    startTransition(async () => {
+      const r = await importFoodItem(food)
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else {
+        setMsg({ kind: 'ok', text: r.info ?? 'Übernommen.' })
+        router.refresh()
+      }
+    })
+  }
+
+  // --- Formular (anlegen / bearbeiten) --------------------------------------
+  const [form, setForm] = useState<FoodFormData>(EMPTY)
+  const set = (k: keyof FoodFormData) => (v: string) => setForm((f) => ({ ...f, [k]: v }))
+  const editing = Boolean(form.id)
+
+  function loadOff(food: NormalizedFood) {
+    setForm({
+      id: undefined, name: food.name, brand: food.brand ?? '', barcode: food.barcode ?? '',
+      baseUnit: food.baseUnit, kcal: s(food.kcal), proteinG: s(food.proteinG),
+      carbsG: s(food.carbsG), fatG: s(food.fatG), fiberG: s(food.fiberG), sugarG: s(food.sugarG),
+      saturatedFatG: s(food.saturatedFatG), sodiumMg: s(food.sodiumMg), potassiumMg: s(food.potassiumMg),
+      ironMg: s(food.ironMg), magnesiumMg: s(food.magnesiumMg), calciumMg: s(food.calciumMg),
+      zincMg: s(food.zincMg), vitaminDUg: s(food.vitaminDUg), vitaminB12Ug: s(food.vitaminB12Ug),
+      vitaminCMg: s(food.vitaminCMg),
+    })
+    setMsg(null)
+    if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  function save() {
+    setMsg(null)
+    startTransition(async () => {
+      const r = await saveFoodItem(form)
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else {
+        setMsg({ kind: 'ok', text: editing ? 'Gespeichert.' : 'Angelegt.' })
+        setForm(EMPTY)
+        router.refresh()
+      }
+    })
+  }
+
+  function remove(id: string) {
+    startTransition(async () => {
+      const r = await deleteFoodItem(id)
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else {
+        setMsg({ kind: 'ok', text: r.info ?? 'Entfernt.' })
+        router.refresh()
+      }
+    })
+  }
+
+  function restore(id: string) {
+    startTransition(async () => {
+      await restoreFoodItem(id)
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="space-y-8">
+      {msg && (
+        <div
+          className={`p-3 rounded-lg text-sm ${
+            msg.kind === 'ok'
+              ? 'bg-primary/10 border border-primary/30 text-primary'
+              : 'bg-error/10 border border-error/30 text-error'
+          }`}
+        >
+          {msg.text}
+        </div>
+      )}
+
+      {/* Suche (lokal + Open Food Facts) */}
+      <section className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <h3 className="font-headline text-sm font-semibold text-on-surface mb-3">
+          Suche (Katalog + Open Food Facts)
+        </h3>
+        <div className="flex gap-2">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && runSearch()}
+            placeholder="Produktname oder Barcode…"
+            className={inputCls}
+          />
+          <button
+            type="button"
+            onClick={runSearch}
+            disabled={searching || query.trim().length < 2}
+            className="flex-none px-4 py-1.5 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors"
+          >
+            {searching ? '…' : 'Suchen'}
+          </button>
+        </div>
+
+        {results && (
+          <div className="mt-4 space-y-4">
+            {results.local.length > 0 && (
+              <div>
+                <p className="text-xs uppercase tracking-widest text-on-surface-variant mb-2">
+                  Bereits im Katalog
+                </p>
+                <ul className="space-y-1">
+                  {results.local.map((l) => (
+                    <li key={l.id} className="text-sm text-on-surface-variant">
+                      {l.name}
+                      {l.brand ? ` · ${l.brand}` : ''} — {l.kcal} kcal
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div>
+              <p className="text-xs uppercase tracking-widest text-on-surface-variant mb-2">
+                Open Food Facts ({results.off.length})
+              </p>
+              {results.off.length === 0 ? (
+                <p className="text-sm text-on-surface-variant">Keine Treffer.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {results.off.map((r, i) => (
+                    <li
+                      key={`${r.barcode ?? 'n'}-${i}`}
+                      className="flex items-center justify-between gap-3 rounded-lg bg-surface-container-high px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm text-on-surface truncate">
+                          {r.name}
+                          {r.brand ? <span className="text-on-surface-variant"> · {r.brand}</span> : ''}
+                        </p>
+                        <p className="text-xs text-on-surface-variant">
+                          {r.kcal} kcal · P{r.proteinG} F{r.fatG} KH{r.carbsG}
+                          {r.barcode ? ` · ${r.barcode}` : ''}
+                        </p>
+                      </div>
+                      <div className="flex flex-none gap-1">
+                        <button
+                          type="button"
+                          onClick={() => loadOff(r)}
+                          className="px-2.5 py-1 text-xs rounded-lg border border-surface-container-high text-on-surface-variant hover:text-on-surface hover:border-outline transition-colors"
+                        >
+                          Prüfen
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => doImport(r)}
+                          disabled={isPending}
+                          className="px-2.5 py-1 text-xs rounded-lg bg-primary text-on-primary hover:bg-primary-container disabled:opacity-50 transition-colors"
+                        >
+                          Übernehmen
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Anlegen / Bearbeiten */}
+      <section className="bg-surface-container rounded-2xl border border-surface-container-high p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="font-headline text-sm font-semibold text-on-surface">
+            {editing ? 'Produkt bearbeiten' : 'Produkt anlegen'}
+          </h3>
+          {editing && (
+            <button
+              type="button"
+              onClick={() => setForm(EMPTY)}
+              className="text-xs text-on-surface-variant hover:text-on-surface"
+            >
+              Abbrechen
+            </button>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div className="col-span-2">
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Name</label>
+            <input value={form.name} onChange={(e) => set('name')(e.target.value)} className={inputCls} />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Marke</label>
+            <input value={form.brand} onChange={(e) => set('brand')(e.target.value)} className={inputCls} />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Basiseinheit</label>
+            <select value={form.baseUnit} onChange={(e) => set('baseUnit')(e.target.value)} className={inputCls}>
+              <option value="g">g</option>
+              <option value="ml">ml</option>
+              <option value="stück">Stück</option>
+            </select>
+          </div>
+          <div className="col-span-2">
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Barcode</label>
+            <input value={form.barcode} onChange={(e) => set('barcode')(e.target.value)} className={inputCls} />
+          </div>
+        </div>
+
+        <p className="text-xs text-on-surface-variant pt-1">Nährwerte je 100 {form.baseUnit} · Makros Pflicht</p>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <Num label="Kalorien" unit="kcal" value={form.kcal} onChange={set('kcal')} />
+          <Num label="Protein" unit="g" value={form.proteinG} onChange={set('proteinG')} />
+          <Num label="Kohlenhydrate" unit="g" value={form.carbsG} onChange={set('carbsG')} />
+          <Num label="Fett" unit="g" value={form.fatG} onChange={set('fatG')} />
+        </div>
+
+        <details>
+          <summary className="text-xs text-on-surface-variant cursor-pointer select-none">
+            Mikronährstoffe (optional)
+          </summary>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mt-3">
+            <Num label="Ballaststoffe" unit="g" value={form.fiberG} onChange={set('fiberG')} />
+            <Num label="Zucker" unit="g" value={form.sugarG} onChange={set('sugarG')} />
+            <Num label="ges. Fettsäuren" unit="g" value={form.saturatedFatG} onChange={set('saturatedFatG')} />
+            <Num label="Natrium" unit="mg" value={form.sodiumMg} onChange={set('sodiumMg')} />
+            <Num label="Kalium" unit="mg" value={form.potassiumMg} onChange={set('potassiumMg')} />
+            <Num label="Eisen" unit="mg" value={form.ironMg} onChange={set('ironMg')} />
+            <Num label="Magnesium" unit="mg" value={form.magnesiumMg} onChange={set('magnesiumMg')} />
+            <Num label="Calcium" unit="mg" value={form.calciumMg} onChange={set('calciumMg')} />
+            <Num label="Zink" unit="mg" value={form.zincMg} onChange={set('zincMg')} />
+            <Num label="Vitamin D" unit="µg" value={form.vitaminDUg} onChange={set('vitaminDUg')} />
+            <Num label="Vitamin B12" unit="µg" value={form.vitaminB12Ug} onChange={set('vitaminB12Ug')} />
+            <Num label="Vitamin C" unit="mg" value={form.vitaminCMg} onChange={set('vitaminCMg')} />
+          </div>
+        </details>
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={save}
+            disabled={isPending}
+            className="px-6 py-2.5 bg-primary text-on-primary rounded-xl text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors"
+          >
+            {isPending ? 'Speichern…' : editing ? 'Änderungen speichern' : 'Produkt anlegen'}
+          </button>
+        </div>
+      </section>
+
+      {/* Katalog */}
+      <section>
+        <h3 className="font-headline text-base font-semibold text-on-surface mb-3">
+          Katalog ({catalog.length})
+        </h3>
+        {catalog.length === 0 ? (
+          <p className="text-sm text-on-surface-variant">Noch keine Produkte.</p>
+        ) : (
+          <div className="bg-surface-container rounded-2xl border border-surface-container-high overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-surface-container text-on-surface-variant text-left">
+                    <th className="px-4 py-3 font-medium">Name</th>
+                    <th className="px-4 py-3 font-medium">kcal</th>
+                    <th className="px-4 py-3 font-medium">P/KH/F</th>
+                    <th className="px-4 py-3 font-medium">Quelle</th>
+                    <th className="px-4 py-3 font-medium"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {catalog.map((f) => (
+                    <tr
+                      key={f.id}
+                      className={`border-b border-surface-container last:border-0 ${f.isActive ? '' : 'opacity-50'}`}
+                    >
+                      <td className="px-4 py-3 text-on-surface">
+                        {f.name}
+                        {f.brand ? <span className="text-on-surface-variant"> · {f.brand}</span> : ''}
+                        {!f.isActive && <span className="ml-2 text-[10px] uppercase text-on-surface-variant">archiviert</span>}
+                      </td>
+                      <td className="px-4 py-3 text-on-surface tabular-nums">{f.kcal}</td>
+                      <td className="px-4 py-3 text-on-surface-variant tabular-nums">
+                        {f.proteinG}/{f.carbsG}/{f.fatG}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="px-1.5 py-0.5 bg-surface-container-high text-on-surface-variant rounded">
+                          {f.source}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right whitespace-nowrap">
+                        <button
+                          type="button"
+                          onClick={() => setForm(itemToForm(f))}
+                          className="text-on-surface-variant hover:text-on-surface mr-3"
+                        >
+                          Bearbeiten
+                        </button>
+                        {f.isActive ? (
+                          <button
+                            type="button"
+                            onClick={() => remove(f.id)}
+                            disabled={isPending}
+                            className="text-error hover:opacity-80 disabled:opacity-50"
+                          >
+                            Entfernen
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => restore(f.id)}
+                            disabled={isPending}
+                            className="text-primary hover:opacity-80 disabled:opacity-50"
+                          >
+                            Reaktivieren
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/admin/NutritionPhaseForm.tsx
+++ b/src/components/admin/NutritionPhaseForm.tsx
@@ -1,0 +1,350 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  computeEckdaten,
+  type EckdatenInput,
+  type Sex,
+  type PhaseMode,
+  type DeficitMethod,
+} from '@/lib/nutrition/calc'
+import {
+  createPhase,
+  addTargetsVersion,
+  type EckdatenFormData,
+} from '@/app/admin/nutrition/actions'
+
+export interface NutritionPhaseFormInitial {
+  weightKg: string
+  heightCm: string
+  age: string
+  sex: Sex
+  bodyFatPct: string
+  activityFactor: string
+  phaseMode: PhaseMode
+  deficitMethod: DeficitMethod
+  validFrom: string
+}
+
+const ACTIVITY_FACTORS = [
+  { value: '1.2', label: '1,2 — sesshaft' },
+  { value: '1.375', label: '1,375 — wenig aktiv' },
+  { value: '1.55', label: '1,55 — moderat' },
+  { value: '1.725', label: '1,725 — sehr hoch' },
+  { value: '1.9', label: '1,9 — extrem' },
+]
+
+function toNum(s: string): number | null {
+  if (!s.trim()) return null
+  const n = parseFloat(s.replace(',', '.'))
+  return isNaN(n) ? null : n
+}
+
+function Field({
+  label,
+  unit,
+  value,
+  onChange,
+  step = 'any',
+  placeholder = '—',
+}: {
+  label: string
+  unit?: string
+  value: string
+  onChange: (v: string) => void
+  step?: string
+  placeholder?: string
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-on-surface-variant mb-1">
+        {label} {unit && <span className="font-normal">({unit})</span>}
+      </label>
+      <input
+        type="number"
+        inputMode="decimal"
+        step={step}
+        min={0}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
+      />
+    </div>
+  )
+}
+
+function Select({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  options: { value: string; label: string }[]
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-on-surface-variant mb-1">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+function PreviewRow({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1">
+      <span className="text-xs text-on-surface-variant">{label}</span>
+      <span className="text-sm font-medium text-on-surface tabular-nums">
+        {value} {sub && <span className="text-on-surface-variant font-normal">{sub}</span>}
+      </span>
+    </div>
+  )
+}
+
+export function NutritionPhaseForm({ initial }: { initial: NutritionPhaseFormInitial }) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const [weightKg, setWeightKg] = useState(initial.weightKg)
+  const [heightCm, setHeightCm] = useState(initial.heightCm)
+  const [age, setAge] = useState(initial.age)
+  const [sex, setSex] = useState<Sex>(initial.sex)
+  const [bodyFatPct, setBodyFatPct] = useState(initial.bodyFatPct)
+  const [activityFactor, setActivityFactor] = useState(initial.activityFactor)
+  const [phaseMode, setPhaseMode] = useState<PhaseMode>(initial.phaseMode)
+  const [deficitMethod, setDeficitMethod] = useState<DeficitMethod>(initial.deficitMethod)
+  const [validFrom, setValidFrom] = useState(initial.validFrom)
+  const [note, setNote] = useState('')
+
+  // Live-Vorschau: gleiche reine Rechenlogik wie serverseitig
+  const preview = useMemo(() => {
+    const w = toNum(weightKg)
+    const h = toNum(heightCm)
+    const a = toNum(age)
+    const af = toNum(activityFactor)
+    if (w === null || h === null || a === null || af === null || w <= 0 || h <= 0 || a <= 0) {
+      return null
+    }
+    const input: EckdatenInput = {
+      weightKg: w,
+      heightCm: h,
+      age: a,
+      sex,
+      bodyFatPct: toNum(bodyFatPct),
+      activityFactor: af,
+      phaseMode,
+      deficitMethod,
+    }
+    return computeEckdaten(input)
+  }, [weightKg, heightCm, age, sex, bodyFatPct, activityFactor, phaseMode, deficitMethod])
+
+  function buildData(): EckdatenFormData {
+    return {
+      weightKg,
+      heightCm,
+      age,
+      sex,
+      bodyFatPct,
+      activityFactor,
+      phaseMode,
+      deficitMethod,
+      validFrom,
+      note,
+    }
+  }
+
+  function run(
+    action: (d: EckdatenFormData) => Promise<{ error?: string; success?: boolean }>,
+    okMsg: string,
+  ) {
+    setError(null)
+    setSuccess(null)
+    startTransition(async () => {
+      const result = await action(buildData())
+      if (result.error) {
+        setError(result.error)
+      } else {
+        setSuccess(okMsg)
+        router.refresh()
+      }
+    })
+  }
+
+  const isDeficit = phaseMode === 'DEFICIT'
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Eingaben */}
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 space-y-4">
+        <h3 className="font-headline text-sm font-semibold text-on-surface">Eingaben</h3>
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          <Field label="Gewicht" unit="kg" value={weightKg} onChange={setWeightKg} step="0.1" />
+          <Field label="Grösse" unit="cm" value={heightCm} onChange={setHeightCm} step="0.5" />
+          <Field label="Alter" unit="J." value={age} onChange={setAge} step="1" />
+          <Field label="Körperfett" unit="%" value={bodyFatPct} onChange={setBodyFatPct} step="0.1" />
+          <Select
+            label="Geschlecht"
+            value={sex}
+            onChange={(v) => setSex(v as Sex)}
+            options={[
+              { value: 'MALE', label: '♂ männlich' },
+              { value: 'FEMALE', label: '♀ weiblich' },
+            ]}
+          />
+          <Select
+            label="Aktivitätsfaktor"
+            value={activityFactor}
+            onChange={setActivityFactor}
+            options={ACTIVITY_FACTORS}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Select
+            label="Phasen-Modus"
+            value={phaseMode}
+            onChange={(v) => setPhaseMode(v as PhaseMode)}
+            options={[
+              { value: 'DEFICIT', label: 'Defizit' },
+              { value: 'MAINTENANCE', label: 'Erhalt' },
+              { value: 'SURPLUS', label: 'Leichter Überschuss' },
+            ]}
+          />
+          <Select
+            label="Defizit-Methode"
+            value={deficitMethod}
+            onChange={(v) => setDeficitMethod(v as DeficitMethod)}
+            options={[
+              { value: 'MODERATE', label: 'Moderat (× 0,8)' },
+              { value: 'AGGRESSIVE', label: 'Aggressiv (× 0,7)' },
+              { value: 'SIMPLE', label: 'Einfach (− 500)' },
+            ]}
+          />
+        </div>
+        {!isDeficit && (
+          <p className="text-xs text-on-surface-variant">
+            Defizit-Methode wird bei Erhalt/Überschuss ignoriert.
+          </p>
+        )}
+
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">
+            Gültig ab / Phasenstart
+          </label>
+          <input
+            type="date"
+            value={validFrom}
+            onChange={(e) => setValidFrom(e.target.value)}
+            className="border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">
+            Notiz (optional)
+          </label>
+          <input
+            type="text"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="z. B. Diätblock 1"
+            className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
+          />
+        </div>
+      </div>
+
+      {/* Vorschau + Aktionen */}
+      <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 space-y-4">
+        <h3 className="font-headline text-sm font-semibold text-on-surface">
+          Errechnete Eckdaten (Vorschau)
+        </h3>
+
+        {preview ? (
+          <div className="space-y-3">
+            <div className="rounded-xl bg-surface-container-high p-4">
+              <div className="flex items-baseline justify-between">
+                <span className="text-xs uppercase tracking-widest text-on-surface-variant">
+                  Ziel-Kalorien
+                </span>
+                <span className="font-headline text-2xl font-bold text-primary tabular-nums">
+                  {preview.targetKcal}
+                  <span className="text-sm font-normal text-on-surface-variant"> kcal</span>
+                </span>
+              </div>
+            </div>
+
+            <div className="divide-y divide-surface-container-high">
+              <PreviewRow label="Protein" value={`${preview.proteinG} g`} sub={`· ${preview.proteinG * 4} kcal`} />
+              <PreviewRow label="Fett" value={`${preview.fatG} g`} sub={`· ${preview.fatG * 9} kcal`} />
+              <PreviewRow label="Kohlenhydrate" value={`${preview.carbsG} g`} sub={`· ${preview.carbsG * 4} kcal`} />
+              <PreviewRow label="Mahlzeiten / Tag" value={`${preview.mealsPerDay}`} />
+            </div>
+
+            <div className="pt-1 divide-y divide-surface-container-high text-on-surface-variant">
+              <PreviewRow label="BMR Ø (HB #1 / #2)" value={`${preview.bmrAvg}`} sub={`(${preview.bmr1} / ${preview.bmr2})`} />
+              <PreviewRow label="Erhaltungskalorien (TDEE)" value={`${preview.tdee} kcal`} />
+              <PreviewRow
+                label="Protein-Bezug"
+                value={`${preview.proteinReferenceKg} kg`}
+                sub={preview.highBodyFatCorrection ? '(FFM, KF-Korrektur)' : '(Körpergewicht)'}
+              />
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-on-surface-variant">
+            Gewicht, Grösse, Alter und Aktivitätsfaktor eingeben für die Vorschau.
+          </p>
+        )}
+
+        {error && (
+          <div className="p-3 bg-error/10 border border-error/30 rounded-lg text-sm text-error">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="p-3 bg-primary/10 border border-primary/30 rounded-lg text-sm text-primary">
+            {success}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2 pt-1">
+          <button
+            type="button"
+            disabled={isPending || !preview}
+            onClick={() => run(createPhase, 'Neue Phase angelegt.')}
+            className="px-6 py-2.5 bg-primary text-on-primary rounded-xl text-sm font-medium hover:bg-primary-container disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isPending ? 'Speichern…' : 'Neue Phase anlegen'}
+          </button>
+          <button
+            type="button"
+            disabled={isPending || !preview}
+            onClick={() =>
+              run(addTargetsVersion, 'Eckdaten-Version gespeichert (aktive Phase).')
+            }
+            className="px-6 py-2.5 border border-surface-container-high text-on-surface rounded-xl text-sm font-medium hover:border-outline disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            Eckdaten neu berechnen (Version für aktive Phase)
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/RefeedRuleForm.tsx
+++ b/src/components/admin/RefeedRuleForm.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { saveRefeedRuleAction } from '@/app/admin/nutrition/actions'
+
+const WEEKDAYS = [
+  { iso: 1, label: 'Mo' },
+  { iso: 2, label: 'Di' },
+  { iso: 3, label: 'Mi' },
+  { iso: 4, label: 'Do' },
+  { iso: 5, label: 'Fr' },
+  { iso: 6, label: 'Sa' },
+  { iso: 7, label: 'So' },
+]
+
+interface Props {
+  initialWeekdays: number[]
+  derivedSoll: { kcal: number; proteinG: number; fatG: number; carbsG: number } | null
+}
+
+export function RefeedRuleForm({ initialWeekdays, derivedSoll }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [selected, setSelected] = useState<Set<number>>(new Set(initialWeekdays))
+  const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+
+  function toggle(iso: number) {
+    setSelected((s) => {
+      const next = new Set(s)
+      if (next.has(iso)) next.delete(iso)
+      else next.add(iso)
+      return next
+    })
+  }
+
+  function save() {
+    setMsg(null)
+    startTransition(async () => {
+      const r = await saveRefeedRuleAction([...selected])
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else {
+        setMsg({ kind: 'ok', text: 'Refeed-Regel gespeichert.' })
+        router.refresh()
+      }
+    })
+  }
+
+  return (
+    <div className="bg-surface-container rounded-2xl border border-surface-container-high p-5 space-y-4">
+      <div>
+        <p className="text-xs font-medium text-on-surface-variant mb-2">Wiederkehrende Refeed-Wochentage</p>
+        <div className="flex flex-wrap gap-1.5">
+          {WEEKDAYS.map((w) => (
+            <button
+              key={w.iso}
+              type="button"
+              onClick={() => toggle(w.iso)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                selected.has(w.iso)
+                  ? 'bg-tertiary/20 text-tertiary border border-tertiary/40'
+                  : 'border border-surface-container-high text-on-surface-variant hover:text-on-surface'
+              }`}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {derivedSoll ? (
+        <p className="text-xs text-on-surface-variant">
+          Refeed-SOLL (abgeleitet): <span className="text-on-surface">{derivedSoll.kcal} kcal</span> ·
+          P {derivedSoll.proteinG} g · F {derivedSoll.fatG} g · KH {derivedSoll.carbsG} g
+        </p>
+      ) : (
+        <p className="text-xs text-on-surface-variant">Eckdaten nötig für die SOLL-Ableitung.</p>
+      )}
+
+      {msg && (
+        <div className={`p-2.5 rounded-lg text-sm ${msg.kind === 'ok' ? 'bg-primary/10 border border-primary/30 text-primary' : 'bg-error/10 border border-error/30 text-error'}`}>
+          {msg.text}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-on-surface-variant">Leere Auswahl = keine wiederkehrenden Refeed-Tage.</p>
+        <button
+          type="button"
+          onClick={save}
+          disabled={isPending}
+          className="px-5 py-2 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors"
+        >
+          {isPending ? 'Speichern…' : 'Speichern'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/habits/HabitsDashboard.tsx
+++ b/src/components/habits/HabitsDashboard.tsx
@@ -46,7 +46,7 @@ export async function HabitsDashboard() {
     const e = entryMap.get(date)
     return {
       date,
-      level: e ? (e.sickDay ? SICK_LEVEL : getNutritionLevel(e.habits.nutrition, e.mealScore)) : -1,
+      level: e ? (e.sickDay ? SICK_LEVEL : getNutritionLevel(e.habits.nutrition, e.mealScore, e.nutritionStatus)) : -1,
     }
   })
   const smokingDays = allDates.map((date) => {
@@ -60,7 +60,7 @@ export async function HabitsDashboard() {
   // Krankheitstage zählen weder in Zähler noch Nenner der Erfüllungsquoten
   const activeEntries = entries.filter((e) => !e.sickDay)
   const movementFulfilled = activeEntries.filter((e) => isMovementFulfilled(e.habits.movement)).length
-  const nutritionFulfilled = activeEntries.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)).length
+  const nutritionFulfilled = activeEntries.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore, e.nutritionStatus)).length
   const smokingFulfilled = activeEntries.filter((e) => isSmokingFulfilled(e.habits.smoking)).length
 
   // Letzte 30 Tage (Tage mit Eintrag, max 30 jüngste)
@@ -70,7 +70,7 @@ export async function HabitsDashboard() {
   const recent = activeEntries.filter((e) => e.date >= cutoffISO)
   const recentTotal = recent.length
   const movementRecent = recent.filter((e) => isMovementFulfilled(e.habits.movement)).length
-  const nutritionRecent = recent.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore)).length
+  const nutritionRecent = recent.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore, e.nutritionStatus)).length
   const smokingRecent = recent.filter((e) => isSmokingFulfilled(e.habits.smoking)).length
 
   return (

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -744,7 +744,7 @@ export async function LiveStatus() {
   }
 
   const movementBools  = entries.map((e) => isMovementFulfilled(e.habits.movement))
-  const nutritionBools = entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore))
+  const nutritionBools = entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.mealScore, e.nutritionStatus))
   const smokingBools   = entries.map((e) => isSmokingFulfilled(e.habits.smoking))
 
   const totalEntries = entries.length

--- a/src/components/journal/HabitBadges.tsx
+++ b/src/components/journal/HabitBadges.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from 'next-intl'
+import type { FulfillmentStatus } from '@prisma/client'
 import type { HabitsFrontmatter } from '@/lib/journal'
 import { isMovementFulfilled, isNutritionFulfilled, isSmokingFulfilled } from '@/lib/habits'
 import { Icon } from '@/components/ui/Icon'
@@ -9,6 +10,9 @@ interface HabitBadgesProps {
    * the nutrition badge shows the score (e.g. `9.6 / 10`) instead of the
    * meal-count label, and fulfillment is computed from the score. */
   mealScore?: number | null
+  /** Erfüllungsstatus aus dem neuen Nutrition-System (N-08) — hat Vorrang
+   * vor mealScore/Enum bei der Erfüllung. */
+  nutritionStatus?: FulfillmentStatus | null
   /** Sick day: replaces the three pillar badges with a single neutral
    * "sick day" badge — habits are recorded but statistically paused. */
   sickDay?: boolean
@@ -38,7 +42,7 @@ function HabitBadge({ label, fulfilled, colorClass, dimClass, icon, title }: Bad
   )
 }
 
-export function HabitBadges({ habits, mealScore, sickDay = false }: HabitBadgesProps) {
+export function HabitBadges({ habits, mealScore, nutritionStatus, sickDay = false }: HabitBadgesProps) {
   const t = useTranslations('HabitBadges')
 
   if (sickDay) {
@@ -75,7 +79,7 @@ export function HabitBadges({ habits, mealScore, sickDay = false }: HabitBadgesP
       <HabitBadge
         label={nutritionLabel}
         title={nutritionTitle}
-        fulfilled={isNutritionFulfilled(habits.nutrition, mealScore)}
+        fulfilled={isNutritionFulfilled(habits.nutrition, mealScore, nutritionStatus)}
         icon="restaurant"
         colorClass="bg-nutrition-600/20 text-nutrition-400 border-nutrition-600/30"
         dimClass="bg-surface-container border-outline-variant/20 text-on-surface-variant"

--- a/src/components/journal/JournalCard.tsx
+++ b/src/components/journal/JournalCard.tsx
@@ -21,7 +21,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
   const excerpt = entry.excerpt ?? ''
   const dayNumber = getDayNumber(entry.date, startDate)
   const sick = entry.sickDay
-  const perfect = !sick && isPerfectDay(entry.habits, entry.mealScore)
+  const perfect = !sick && isPerfectDay(entry.habits, entry.mealScore, entry.nutritionStatus)
   const isFiller = entry.entryType === 'filler'
 
   const sickBadge = sick ? (
@@ -96,7 +96,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
           )}
 
           <div className="pt-2 border-t border-outline-variant/10">
-            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} sickDay={sick} />
+            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} nutritionStatus={entry.nutritionStatus} sickDay={sick} />
           </div>
         </div>
       </article>
@@ -156,7 +156,7 @@ export async function JournalCard({ entry }: JournalCardProps) {
           )}
 
           <div className="flex items-center justify-between gap-4 pt-2 border-t border-outline-variant/10">
-            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} sickDay={sick} />
+            <HabitBadges habits={entry.habits} mealScore={entry.mealScore} nutritionStatus={entry.nutritionStatus} sickDay={sick} />
             <span className="inline-flex items-center gap-1 text-xs font-label font-bold tracking-widest uppercase text-primary shrink-0 group-hover:gap-1.5 transition-all duration-150">
               {t('readMore')}
               <Icon name="arrow_forward" size={12} />

--- a/src/components/journal/JournalCardCompact.tsx
+++ b/src/components/journal/JournalCardCompact.tsx
@@ -21,7 +21,7 @@ export async function JournalCardCompact({ entry }: JournalCardCompactProps) {
   const dayNumber = getDayNumber(entry.date, startDate)
 
   const movementOk = isMovementFulfilled(entry.habits.movement)
-  const nutritionOk = isNutritionFulfilled(entry.habits.nutrition, entry.mealScore)
+  const nutritionOk = isNutritionFulfilled(entry.habits.nutrition, entry.mealScore, entry.nutritionStatus)
   const smokingOk = isSmokingFulfilled(entry.habits.smoking)
   const allOk = movementOk && nutritionOk && smokingOk
 

--- a/src/components/journal/JournalCardHome.tsx
+++ b/src/components/journal/JournalCardHome.tsx
@@ -19,7 +19,7 @@ export async function JournalCardHome({ entry }: JournalCardHomeProps) {
 
   const dayNumber = getDayNumber(entry.date, startDate)
   const sick = entry.sickDay
-  const perfect = !sick && isPerfectDay(entry.habits, entry.mealScore)
+  const perfect = !sick && isPerfectDay(entry.habits, entry.mealScore, entry.nutritionStatus)
   const isFiller = entry.entryType === 'filler'
 
   const sickBadge = sick ? (

--- a/src/components/journal/JournalPost.tsx
+++ b/src/components/journal/JournalPost.tsx
@@ -85,7 +85,7 @@ export async function JournalPost({ entry, isTranslated = false }: JournalPostPr
       )}
 
       <div className="flex flex-col gap-3 mb-8">
-        <HabitBadges habits={entry.habits} mealScore={entry.mealScore} sickDay={entry.sickDay} />
+        <HabitBadges habits={entry.habits} mealScore={entry.mealScore} nutritionStatus={entry.nutritionStatus} sickDay={entry.sickDay} />
         {entry.tags && entry.tags.length > 0 && (
           <ul className="flex flex-wrap gap-2">
             {entry.tags.map((tag) => (

--- a/src/components/nutrition/BarcodeScanner.tsx
+++ b/src/components/nutrition/BarcodeScanner.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { IScannerControls } from '@zxing/browser'
+
+interface BarcodeScannerProps {
+  /** Wird mit dem erkannten (oder manuell eingegebenen) Barcode aufgerufen. */
+  onDetected: (barcode: string) => void
+  onClose?: () => void
+}
+
+type Status = 'starting' | 'scanning' | 'error'
+
+/**
+ * Mobile-first Barcode-Scanner (Handy-Kamera) auf Basis von @zxing/browser.
+ * Der Reader wird dynamisch importiert (nur im Browser), damit die Komponente
+ * SSR-sicher bleibt. Fallback: manuelle Eingabe des Barcodes.
+ */
+export function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const controlsRef = useRef<IScannerControls | null>(null)
+  const doneRef = useRef(false)
+
+  const [status, setStatus] = useState<Status>('starting')
+  const [error, setError] = useState<string | null>(null)
+  const [manual, setManual] = useState('')
+
+  function stop() {
+    controlsRef.current?.stop()
+    controlsRef.current = null
+  }
+
+  function handleCode(code: string) {
+    if (doneRef.current) return
+    doneRef.current = true
+    stop()
+    onDetected(code)
+  }
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function start() {
+      try {
+        const { BrowserMultiFormatReader } = await import('@zxing/browser')
+        if (cancelled) return
+        const reader = new BrowserMultiFormatReader()
+        const controls = await reader.decodeFromConstraints(
+          { video: { facingMode: { ideal: 'environment' } } },
+          videoRef.current!,
+          (result) => {
+            if (result) handleCode(result.getText())
+          },
+        )
+        if (cancelled) {
+          controls.stop()
+          return
+        }
+        controlsRef.current = controls
+        setStatus('scanning')
+      } catch (e) {
+        if (cancelled) return
+        const err = e as { name?: string }
+        if (err.name === 'NotAllowedError') {
+          setError('Kamerazugriff verweigert. Barcode unten manuell eingeben.')
+        } else if (err.name === 'NotFoundError' || err.name === 'OverconstrainedError') {
+          setError('Keine passende Kamera gefunden. Barcode unten manuell eingeben.')
+        } else {
+          setError('Scanner nicht verfügbar. Barcode unten manuell eingeben.')
+        }
+        setStatus('error')
+      }
+    }
+
+    start()
+    return () => {
+      cancelled = true
+      stop()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div className="rounded-2xl border border-surface-container-high bg-surface-container p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="font-headline text-sm font-semibold text-on-surface">Barcode scannen</h4>
+        {onClose && (
+          <button
+            type="button"
+            onClick={() => {
+              stop()
+              onClose()
+            }}
+            className="text-xs text-on-surface-variant hover:text-on-surface"
+          >
+            Schliessen
+          </button>
+        )}
+      </div>
+
+      {status !== 'error' && (
+        <div className="relative overflow-hidden rounded-xl bg-black aspect-[4/3] max-w-sm mx-auto">
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            ref={videoRef}
+            className="h-full w-full object-cover"
+            playsInline
+            muted
+            autoPlay
+          />
+          {/* Ziel-Rahmen */}
+          <div className="pointer-events-none absolute inset-x-8 top-1/2 h-0.5 -translate-y-1/2 bg-primary/70" />
+          {status === 'starting' && (
+            <div className="absolute inset-0 grid place-items-center text-xs text-white/70">
+              Kamera wird gestartet…
+            </div>
+          )}
+        </div>
+      )}
+
+      {error && <p className="text-sm text-on-surface-variant text-center">{error}</p>}
+      {status === 'scanning' && (
+        <p className="text-xs text-on-surface-variant text-center">
+          Barcode in den Rahmen halten.
+        </p>
+      )}
+
+      {/* Fallback: manuelle Eingabe */}
+      <div className="flex gap-2 pt-1">
+        <input
+          value={manual}
+          onChange={(e) => setManual(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && manual.trim() && handleCode(manual.trim())}
+          inputMode="numeric"
+          placeholder="Barcode manuell eingeben…"
+          className="w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container"
+        />
+        <button
+          type="button"
+          onClick={() => manual.trim() && handleCode(manual.trim())}
+          disabled={!manual.trim()}
+          className="flex-none px-4 py-1.5 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors"
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/nutrition/DishManager.tsx
+++ b/src/components/nutrition/DishManager.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import type { FoodItem } from '@prisma/client'
+import { dishSnapshot } from '@/lib/nutrition/snapshot'
+import type { DishWithItems } from '@/lib/nutrition/dishes'
+import {
+  saveDish,
+  deleteDishAction,
+  toggleDishFavorite,
+  type DishFormData,
+} from '@/app/admin/dishes/actions'
+
+interface Props {
+  dishes: DishWithItems[]
+  catalog: FoodItem[]
+  favoriteDishIds: string[]
+}
+
+interface Row {
+  foodItemId: string
+  amount: string
+  unit: string
+}
+
+const inputCls =
+  'w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container'
+
+export function DishManager({ dishes, catalog, favoriteDishIds }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+
+  const foodById = useMemo(() => new Map(catalog.map((f) => [f.id, f])), [catalog])
+  const favSet = useMemo(() => new Set(favoriteDishIds), [favoriteDishIds])
+
+  const [id, setId] = useState<string | undefined>(undefined)
+  const [name, setName] = useState('')
+  const [note, setNote] = useState('')
+  const [rows, setRows] = useState<Row[]>([{ foodItemId: '', amount: '', unit: 'g' }])
+
+  const editing = Boolean(id)
+
+  function reset() {
+    setId(undefined); setName(''); setNote(''); setRows([{ foodItemId: '', amount: '', unit: 'g' }])
+  }
+
+  function loadDish(d: DishWithItems) {
+    setId(d.id); setName(d.name); setNote(d.note ?? '')
+    setRows(d.items.map((i) => ({ foodItemId: i.foodItemId, amount: String(i.amount), unit: i.unit })))
+    if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  // Live-Nährwertsumme
+  const preview = useMemo(() => {
+    const components = rows
+      .filter((r) => r.foodItemId && parseFloat(r.amount.replace(',', '.')) > 0)
+      .map((r) => ({ food: foodById.get(r.foodItemId)!, amount: parseFloat(r.amount.replace(',', '.')) }))
+      .filter((c) => c.food)
+    return components.length ? dishSnapshot(components) : null
+  }, [rows, foodById])
+
+  function updateRow(i: number, patch: Partial<Row>) {
+    setRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
+  }
+  function addRow() { setRows((rs) => [...rs, { foodItemId: '', amount: '', unit: 'g' }]) }
+  function removeRow(i: number) { setRows((rs) => rs.filter((_, idx) => idx !== i)) }
+
+  function save() {
+    setMsg(null)
+    const data: DishFormData = {
+      id, name, note,
+      items: rows.map((r) => ({ foodItemId: r.foodItemId, amount: r.amount, unit: r.unit })),
+    }
+    startTransition(async () => {
+      const r = await saveDish(data)
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else { setMsg({ kind: 'ok', text: editing ? 'Gespeichert.' : 'Gericht angelegt.' }); reset(); router.refresh() }
+    })
+  }
+
+  function run(fn: () => Promise<{ error?: string; success?: boolean; info?: string }>) {
+    startTransition(async () => {
+      const r = await fn()
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else { if (r.info) setMsg({ kind: 'ok', text: r.info }); router.refresh() }
+    })
+  }
+
+  return (
+    <div className="space-y-8">
+      {msg && (
+        <div className={`p-3 rounded-lg text-sm ${msg.kind === 'ok' ? 'bg-primary/10 border border-primary/30 text-primary' : 'bg-error/10 border border-error/30 text-error'}`}>
+          {msg.text}
+        </div>
+      )}
+
+      {/* Formular */}
+      <section className="bg-surface-container rounded-2xl border border-surface-container-high p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="font-headline text-sm font-semibold text-on-surface">
+            {editing ? 'Gericht bearbeiten' : 'Gericht anlegen'}
+          </h3>
+          {editing && <button type="button" onClick={reset} className="text-xs text-on-surface-variant hover:text-on-surface">Abbrechen</button>}
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="sm:col-span-2">
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Name</label>
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="z. B. Mein Frühstück" className={inputCls} />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-on-surface-variant mb-1">Notiz</label>
+            <input value={note} onChange={(e) => setNote(e.target.value)} className={inputCls} />
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs font-medium text-on-surface-variant mb-2">Zutaten</p>
+          {catalog.length === 0 ? (
+            <p className="text-sm text-on-surface-variant">Erst Lebensmittel im Katalog anlegen.</p>
+          ) : (
+            <div className="space-y-2">
+              {rows.map((r, i) => (
+                <div key={i} className="flex gap-2">
+                  <select value={r.foodItemId} onChange={(e) => updateRow(i, { foodItemId: e.target.value, unit: foodById.get(e.target.value)?.baseUnit ?? 'g' })} className={inputCls}>
+                    <option value="">– Lebensmittel –</option>
+                    {catalog.map((f) => <option key={f.id} value={f.id}>{f.name}{f.brand ? ` · ${f.brand}` : ''}</option>)}
+                  </select>
+                  <input type="number" inputMode="decimal" value={r.amount} onChange={(e) => updateRow(i, { amount: e.target.value })}
+                    placeholder="Menge" className="w-28 border border-surface-container-high rounded-lg px-2 py-1.5 text-sm text-on-surface bg-surface-container focus:outline-none" />
+                  <span className="flex items-center text-xs text-on-surface-variant w-10">{r.unit}</span>
+                  <button type="button" onClick={() => removeRow(i)} className="flex-none text-on-surface-variant hover:text-error px-2">✕</button>
+                </div>
+              ))}
+              <button type="button" onClick={addRow} className="text-xs text-primary hover:opacity-80">+ Zutat</button>
+            </div>
+          )}
+        </div>
+
+        {preview && (
+          <div className="rounded-xl bg-surface-container-high p-3 text-sm text-on-surface">
+            Summe: <span className="font-bold text-primary">{preview.kcal} kcal</span>
+            <span className="text-on-surface-variant"> · P {preview.proteinG} g · KH {preview.carbsG} g · F {preview.fatG} g</span>
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <button type="button" onClick={save} disabled={isPending}
+            className="px-6 py-2.5 bg-primary text-on-primary rounded-xl text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors">
+            {isPending ? 'Speichern…' : editing ? 'Änderungen speichern' : 'Gericht anlegen'}
+          </button>
+        </div>
+      </section>
+
+      {/* Liste */}
+      <section>
+        <h3 className="font-headline text-base font-semibold text-on-surface mb-3">Gerichte ({dishes.length})</h3>
+        {dishes.length === 0 ? (
+          <p className="text-sm text-on-surface-variant">Noch keine Gerichte.</p>
+        ) : (
+          <ul className="space-y-2">
+            {dishes.map((d) => {
+              const totals = dishSnapshot(d.items.map((i) => ({ food: i.foodItem, amount: i.amount })))
+              const isFav = favSet.has(d.id)
+              return (
+                <li key={d.id} className={`rounded-xl border border-surface-container-high bg-surface-container p-3 ${d.isActive ? '' : 'opacity-50'}`}>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm text-on-surface">
+                        {d.name}
+                        {!d.isActive && <span className="ml-2 text-[10px] uppercase text-on-surface-variant">archiviert</span>}
+                      </p>
+                      <p className="text-xs text-on-surface-variant">
+                        {d.items.length} Zutaten · {totals.kcal} kcal · P{totals.proteinG} KH{totals.carbsG} F{totals.fatG}
+                      </p>
+                    </div>
+                    <div className="flex flex-none items-center gap-3 text-xs">
+                      <button type="button" onClick={() => run(() => toggleDishFavorite(d.id, !isFav))} disabled={isPending}
+                        className={isFav ? 'text-primary' : 'text-on-surface-variant hover:text-on-surface'} title="Favorit" aria-label="Favorit">
+                        {isFav ? '★' : '☆'}
+                      </button>
+                      <button type="button" onClick={() => loadDish(d)} className="text-on-surface-variant hover:text-on-surface">Bearbeiten</button>
+                      <button type="button" onClick={() => run(() => deleteDishAction(d.id))} disabled={isPending} className="text-error hover:opacity-80 disabled:opacity-50">Entfernen</button>
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/nutrition/MealLogger.tsx
+++ b/src/components/nutrition/MealLogger.tsx
@@ -1,0 +1,393 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import type { FoodItem } from '@prisma/client'
+import { MEAL_SLOTS, type MealSlot } from '@/lib/nutrition/constants'
+import type { MealEntryResolved, DayTotals } from '@/lib/nutrition/meals'
+import type { FavoriteResolved } from '@/lib/nutrition/favorites'
+import type { DishWithItems } from '@/lib/nutrition/dishes'
+import { BarcodeScanner } from '@/components/nutrition/BarcodeScanner'
+import {
+  logFoodEntry,
+  logDishEntry,
+  quickLogFavorite,
+  logScannedBarcode,
+  removeEntry,
+} from '@/app/admin/log/actions'
+
+interface Props {
+  date: string
+  entries: MealEntryResolved[]
+  favorites: FavoriteResolved[]
+  dishes: DishWithItems[]
+  totals: DayTotals
+  targetKcal: number | null
+}
+
+const inputCls =
+  'w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container'
+
+function defaultSlot(): MealSlot {
+  const h = new Date().getHours()
+  if (h < 11) return 'Frühstück'
+  if (h < 15) return 'Mittag'
+  if (h < 21) return 'Abend'
+  return 'Snack'
+}
+
+type Tab = 'katalog' | 'gericht' | 'scan'
+
+export function MealLogger({ date, entries, favorites, dishes, totals, targetKcal }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+  const [slot, setSlot] = useState<MealSlot>(defaultSlot())
+  const [tab, setTab] = useState<Tab>('katalog')
+
+  function go(fn: () => Promise<{ error?: string; success?: boolean }>, ok: string) {
+    setMsg(null)
+    startTransition(async () => {
+      const r = await fn()
+      if (r.error) setMsg({ kind: 'err', text: r.error })
+      else {
+        setMsg({ kind: 'ok', text: ok })
+        router.refresh()
+      }
+    })
+  }
+
+  // --- Datum-Navigation -----------------------------------------------------
+  function shiftDay(delta: number) {
+    const d = new Date(`${date}T00:00:00Z`)
+    d.setUTCDate(d.getUTCDate() + delta)
+    router.push(`/admin/log?date=${d.toISOString().slice(0, 10)}`)
+  }
+
+  // --- Katalog-Suche --------------------------------------------------------
+  const [query, setQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [localResults, setLocalResults] = useState<FoodItem[] | null>(null)
+  const [selected, setSelected] = useState<FoodItem | null>(null)
+  const [amount, setAmount] = useState('100')
+
+  async function search() {
+    if (query.trim().length < 2) return
+    setSearching(true)
+    try {
+      const res = await fetch(`/api/nutrition/food/search?q=${encodeURIComponent(query.trim())}`)
+      const data = (await res.json()) as { local: FoodItem[] }
+      setLocalResults(data.local ?? [])
+    } catch {
+      setMsg({ kind: 'err', text: 'Suche fehlgeschlagen.' })
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  // --- Gericht --------------------------------------------------------------
+  const [dishId, setDishId] = useState('')
+  const [multiplier, setMultiplier] = useState('1')
+
+  // --- Scan -----------------------------------------------------------------
+  const [scanCode, setScanCode] = useState<string | null>(null)
+  const [scanAmount, setScanAmount] = useState('100')
+
+  // --- Tagesliste gruppiert -------------------------------------------------
+  const grouped = useMemo(() => {
+    const map = new Map<string, MealEntryResolved[]>()
+    for (const s of MEAL_SLOTS) map.set(s, [])
+    const other: MealEntryResolved[] = []
+    for (const e of entries) {
+      const key = e.mealSlot && map.has(e.mealSlot) ? e.mealSlot : null
+      if (key) map.get(key)!.push(e)
+      else other.push(e)
+    }
+    return { map, other }
+  }, [entries])
+
+  const remaining = targetKcal != null ? Math.round((targetKcal - totals.kcal) * 10) / 10 : null
+
+  return (
+    <div className="space-y-6">
+      {/* Datum + Slot */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={() => shiftDay(-1)} className="px-2 py-1 rounded-lg border border-surface-container-high text-on-surface-variant hover:text-on-surface">‹</button>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => router.push(`/admin/log?date=${e.target.value}`)}
+            className="border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface bg-surface-container focus:outline-none"
+          />
+          <button type="button" onClick={() => shiftDay(1)} className="px-2 py-1 rounded-lg border border-surface-container-high text-on-surface-variant hover:text-on-surface">›</button>
+        </div>
+        <div className="flex gap-1">
+          {MEAL_SLOTS.map((sName) => (
+            <button
+              key={sName}
+              type="button"
+              onClick={() => setSlot(sName)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                slot === sName
+                  ? 'bg-primary text-on-primary'
+                  : 'border border-surface-container-high text-on-surface-variant hover:text-on-surface'
+              }`}
+            >
+              {sName}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {msg && (
+        <div className={`p-3 rounded-lg text-sm ${msg.kind === 'ok' ? 'bg-primary/10 border border-primary/30 text-primary' : 'bg-error/10 border border-error/30 text-error'}`}>
+          {msg.text}
+        </div>
+      )}
+
+      {/* Favoriten — 1-Klick in aktiven Slot */}
+      <section>
+        <h3 className="text-xs uppercase tracking-widest text-on-surface-variant mb-2">
+          Favoriten → {slot}
+        </h3>
+        {favorites.length === 0 ? (
+          <p className="text-sm text-on-surface-variant">
+            Noch keine Favoriten. Lebensmittel/Gerichte mit ★ markieren.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {favorites.map((f) => {
+              const label = f.foodItem?.name ?? f.dish?.name ?? '—'
+              return (
+                <button
+                  key={f.id}
+                  type="button"
+                  disabled={isPending}
+                  onClick={() =>
+                    go(() => quickLogFavorite({ favoriteId: f.id, date, mealSlot: slot }), `„${label}" geloggt.`)
+                  }
+                  className="px-3 py-2 rounded-xl bg-surface-container border border-surface-container-high text-sm text-on-surface hover:border-primary disabled:opacity-50 transition-colors"
+                >
+                  <span className="text-primary mr-1">＋</span>
+                  {label}
+                  <span className="text-on-surface-variant text-xs ml-1">
+                    {f.foodItem ? 'Lebensmittel' : 'Gericht'}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* Hinzufügen */}
+      <section className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <div className="flex gap-1 mb-4">
+          {(['katalog', 'gericht', 'scan'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={`px-3 py-1.5 rounded-lg text-sm capitalize transition-colors ${
+                tab === t ? 'bg-surface-container-high text-on-surface' : 'text-on-surface-variant hover:text-on-surface'
+              }`}
+            >
+              {t === 'katalog' ? 'Katalog' : t === 'gericht' ? 'Gericht' : 'Scan'}
+            </button>
+          ))}
+        </div>
+
+        {tab === 'katalog' && (
+          <div className="space-y-3">
+            <div className="flex gap-2">
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && search()}
+                placeholder="Katalog durchsuchen…"
+                className={inputCls}
+              />
+              <button type="button" onClick={search} disabled={searching || query.trim().length < 2}
+                className="flex-none px-4 py-1.5 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors">
+                {searching ? '…' : 'Suchen'}
+              </button>
+            </div>
+
+            {selected ? (
+              <div className="rounded-xl bg-surface-container-high p-3 flex flex-wrap items-end gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-on-surface truncate">{selected.name}</p>
+                  <p className="text-xs text-on-surface-variant">{selected.kcal} kcal / 100 {selected.baseUnit}</p>
+                </div>
+                <div>
+                  <label className="block text-xs text-on-surface-variant mb-1">Menge ({selected.baseUnit})</label>
+                  <input type="number" inputMode="decimal" value={amount} onChange={(e) => setAmount(e.target.value)}
+                    className="w-24 border border-surface-container-high rounded-lg px-2 py-1.5 text-sm text-on-surface bg-surface-container focus:outline-none" />
+                </div>
+                <button type="button" disabled={isPending}
+                  onClick={() => go(
+                    () => logFoodEntry({ date, foodItemId: selected.id, amount: parseFloat(amount.replace(',', '.')), mealSlot: slot }),
+                    `„${selected.name}" geloggt.`,
+                  )}
+                  className="px-4 py-2 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors">
+                  Loggen
+                </button>
+                <button type="button" onClick={() => setSelected(null)} className="text-xs text-on-surface-variant hover:text-on-surface">Andere</button>
+              </div>
+            ) : (
+              localResults && (
+                localResults.length === 0 ? (
+                  <p className="text-sm text-on-surface-variant">Nichts im Katalog — über Lebensmittel anlegen oder scannen.</p>
+                ) : (
+                  <ul className="space-y-1">
+                    {localResults.map((r) => (
+                      <li key={r.id}>
+                        <button type="button" onClick={() => { setSelected(r); setAmount('100') }}
+                          className="w-full text-left rounded-lg px-3 py-2 hover:bg-surface-container-high transition-colors">
+                          <span className="text-sm text-on-surface">{r.name}</span>
+                          {r.brand && <span className="text-xs text-on-surface-variant"> · {r.brand}</span>}
+                          <span className="text-xs text-on-surface-variant"> — {r.kcal} kcal</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )
+              )
+            )}
+          </div>
+        )}
+
+        {tab === 'gericht' && (
+          <div className="space-y-3">
+            {dishes.length === 0 ? (
+              <p className="text-sm text-on-surface-variant">Noch keine Gerichte — unter Gerichte anlegen.</p>
+            ) : (
+              <div className="flex flex-wrap items-end gap-3">
+                <div className="flex-1 min-w-[12rem]">
+                  <label className="block text-xs text-on-surface-variant mb-1">Gericht</label>
+                  <select value={dishId} onChange={(e) => setDishId(e.target.value)} className={inputCls}>
+                    <option value="">– wählen –</option>
+                    {dishes.map((d) => <option key={d.id} value={d.id}>{d.name}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-on-surface-variant mb-1">Portionen</label>
+                  <input type="number" inputMode="decimal" step="0.25" value={multiplier} onChange={(e) => setMultiplier(e.target.value)}
+                    className="w-24 border border-surface-container-high rounded-lg px-2 py-1.5 text-sm text-on-surface bg-surface-container focus:outline-none" />
+                </div>
+                <button type="button" disabled={isPending || !dishId}
+                  onClick={() => go(
+                    () => logDishEntry({ date, dishId, multiplier: parseFloat(multiplier.replace(',', '.')) || 1, mealSlot: slot }),
+                    'Gericht geloggt.',
+                  )}
+                  className="px-4 py-2 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors">
+                  Loggen
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {tab === 'scan' && (
+          <div className="space-y-3">
+            {!scanCode ? (
+              <BarcodeScanner onDetected={(code) => setScanCode(code)} />
+            ) : (
+              <div className="rounded-xl bg-surface-container-high p-3 flex flex-wrap items-end gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-on-surface">Barcode {scanCode}</p>
+                  <p className="text-xs text-on-surface-variant">Wird aus Katalog/OFF geladen und geloggt.</p>
+                </div>
+                <div>
+                  <label className="block text-xs text-on-surface-variant mb-1">Menge (g)</label>
+                  <input type="number" inputMode="decimal" value={scanAmount} onChange={(e) => setScanAmount(e.target.value)}
+                    className="w-24 border border-surface-container-high rounded-lg px-2 py-1.5 text-sm text-on-surface bg-surface-container focus:outline-none" />
+                </div>
+                <button type="button" disabled={isPending}
+                  onClick={() => go(
+                    () => logScannedBarcode({ barcode: scanCode, date, amount: parseFloat(scanAmount.replace(',', '.')), mealSlot: slot }),
+                    'Gescanntes Produkt geloggt.',
+                  )}
+                  className="px-4 py-2 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors">
+                  Loggen
+                </button>
+                <button type="button" onClick={() => setScanCode(null)} className="text-xs text-on-surface-variant hover:text-on-surface">Erneut scannen</button>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+
+      {/* Tagesbilanz */}
+      <section className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
+        <div className="flex flex-wrap items-baseline justify-between gap-3 mb-1">
+          <h3 className="font-headline text-sm font-semibold text-on-surface">Tagesbilanz (IST)</h3>
+          <div className="text-sm text-on-surface tabular-nums">
+            <span className="font-bold text-primary">{totals.kcal}</span>
+            {targetKcal != null && <span className="text-on-surface-variant"> / {targetKcal} kcal</span>}
+          </div>
+        </div>
+        <p className="text-xs text-on-surface-variant">
+          P {totals.proteinG} g · KH {totals.carbsG} g · F {totals.fatG} g
+          {remaining != null && <> · Rest {remaining} kcal</>}
+        </p>
+      </section>
+
+      {/* Einträge gruppiert */}
+      <section className="space-y-4">
+        {entries.length === 0 && <p className="text-sm text-on-surface-variant">Noch nichts geloggt.</p>}
+        {MEAL_SLOTS.map((sName) => {
+          const rows = grouped.map.get(sName)!
+          if (rows.length === 0) return null
+          return <SlotGroup key={sName} title={sName} rows={rows} isPending={isPending} onDelete={(id) => go(() => removeEntry(id), 'Entfernt.')} />
+        })}
+        {grouped.other.length > 0 && (
+          <SlotGroup title="Ohne Slot" rows={grouped.other} isPending={isPending} onDelete={(id) => go(() => removeEntry(id), 'Entfernt.')} />
+        )}
+      </section>
+    </div>
+  )
+}
+
+function SlotGroup({
+  title, rows, isPending, onDelete,
+}: {
+  title: string
+  rows: MealEntryResolved[]
+  isPending: boolean
+  onDelete: (id: string) => void
+}) {
+  const kcal = Math.round(rows.reduce((a, e) => a + e.kcal, 0) * 10) / 10
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-1">
+        <h4 className="text-xs uppercase tracking-widest text-on-surface-variant">{title}</h4>
+        <span className="text-xs text-on-surface-variant tabular-nums">{kcal} kcal</span>
+      </div>
+      <ul className="rounded-xl border border-surface-container-high overflow-hidden divide-y divide-surface-container-high">
+        {rows.map((e) => (
+          <li key={e.id} className="flex items-center justify-between gap-3 px-3 py-2 bg-surface-container">
+            <div className="min-w-0">
+              <p className="text-sm text-on-surface truncate">
+                {e.foodItem?.name ?? e.dish?.name ?? e.externalName ?? 'Eintrag'}
+              </p>
+              <p className="text-xs text-on-surface-variant tabular-nums">
+                {e.amount} {e.unit} · {e.kcal} kcal · P{e.proteinG} KH{e.carbsG} F{e.fatG}
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={() => onDelete(e.id)}
+              className="flex-none text-xs text-error hover:opacity-80 disabled:opacity-50"
+              aria-label="Löschen"
+            >
+              ✕
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/nutrition/MealLogger.tsx
+++ b/src/components/nutrition/MealLogger.tsx
@@ -4,9 +4,10 @@ import { useMemo, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import type { FoodItem } from '@prisma/client'
 import { MEAL_SLOTS, type MealSlot } from '@/lib/nutrition/constants'
-import type { MealEntryResolved, DayTotals } from '@/lib/nutrition/meals'
+import type { MealEntryResolved } from '@/lib/nutrition/meals'
 import type { FavoriteResolved } from '@/lib/nutrition/favorites'
 import type { DishWithItems } from '@/lib/nutrition/dishes'
+import type { DaySummary } from '@/lib/nutrition/day-aggregate'
 import { BarcodeScanner } from '@/components/nutrition/BarcodeScanner'
 import { PhotoEstimator } from '@/components/nutrition/PhotoEstimator'
 import {
@@ -15,6 +16,7 @@ import {
   quickLogFavorite,
   logScannedBarcode,
   removeEntry,
+  toggleRefeedDay,
 } from '@/app/admin/log/actions'
 
 interface Props {
@@ -22,8 +24,13 @@ interface Props {
   entries: MealEntryResolved[]
   favorites: FavoriteResolved[]
   dishes: DishWithItems[]
-  totals: DayTotals
-  targetKcal: number | null
+  summary: DaySummary
+}
+
+const STATUS_LABEL: Record<string, { text: string; cls: string }> = {
+  FULFILLED: { text: 'Erfüllt', cls: 'bg-primary/15 text-primary border-primary/30' },
+  NOT_FULFILLED: { text: 'Nicht erfüllt', cls: 'bg-error/15 text-error border-error/30' },
+  OPEN: { text: 'Offen', cls: 'bg-surface-container-high text-on-surface-variant border-outline-variant/30' },
 }
 
 const inputCls =
@@ -39,7 +46,7 @@ function defaultSlot(): MealSlot {
 
 type Tab = 'katalog' | 'gericht' | 'scan' | 'foto'
 
-export function MealLogger({ date, entries, favorites, dishes, totals, targetKcal }: Props) {
+export function MealLogger({ date, entries, favorites, dishes, summary }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
@@ -107,7 +114,9 @@ export function MealLogger({ date, entries, favorites, dishes, totals, targetKca
     return { map, other }
   }, [entries])
 
-  const remaining = targetKcal != null ? Math.round((targetKcal - totals.kcal) * 10) / 10 : null
+  const { soll, ist } = summary
+  const remaining = soll ? Math.round((soll.kcal - ist.kcal) * 10) / 10 : null
+  const status = STATUS_LABEL[summary.fulfillmentStatus] ?? STATUS_LABEL.OPEN
 
   return (
     <div className="space-y-6">
@@ -331,19 +340,47 @@ export function MealLogger({ date, entries, favorites, dishes, totals, targetKca
         )}
       </section>
 
-      {/* Tagesbilanz */}
+      {/* Tagesbilanz: SOLL / IST + Erfüllung */}
       <section className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
-        <div className="flex flex-wrap items-baseline justify-between gap-3 mb-1">
-          <h3 className="font-headline text-sm font-semibold text-on-surface">Tagesbilanz (IST)</h3>
-          <div className="text-sm text-on-surface tabular-nums">
-            <span className="font-bold text-primary">{totals.kcal}</span>
-            {targetKcal != null && <span className="text-on-surface-variant"> / {targetKcal} kcal</span>}
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+          <h3 className="font-headline text-sm font-semibold text-on-surface">
+            Tagesbilanz
+            {summary.isRefeed && (
+              <span className="ml-2 text-[10px] uppercase tracking-widest text-tertiary">Refeed</span>
+            )}
+          </h3>
+          <div className="flex items-center gap-2">
+            <span className={`px-2 py-0.5 rounded-full text-xs font-medium border ${status.cls}`}>
+              {status.text}
+            </span>
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={() => go(() => toggleRefeedDay(date, !summary.isRefeed), summary.isRefeed ? 'Als Normaltag gesetzt.' : 'Als Refeed-Tag gesetzt.')}
+              className="text-xs text-on-surface-variant hover:text-on-surface disabled:opacity-50"
+            >
+              {summary.isRefeed ? '→ Normaltag' : '→ Refeed-Tag'}
+            </button>
           </div>
         </div>
-        <p className="text-xs text-on-surface-variant">
-          P {totals.proteinG} g · KH {totals.carbsG} g · F {totals.fatG} g
-          {remaining != null && <> · Rest {remaining} kcal</>}
-        </p>
+
+        {soll ? (
+          <div className="grid grid-cols-4 gap-2 text-center">
+            <Macro label="kcal" ist={ist.kcal} soll={soll.kcal} accent />
+            <Macro label="Protein" ist={ist.proteinG} soll={soll.proteinG} unit="g" />
+            <Macro label="KH" ist={ist.carbsG} soll={soll.carbsG} unit="g" />
+            <Macro label="Fett" ist={ist.fatG} soll={soll.fatG} unit="g" />
+          </div>
+        ) : (
+          <p className="text-sm text-on-surface-variant">
+            Kein SOLL — für diesen Tag sind keine Eckdaten hinterlegt (Phase anlegen).
+          </p>
+        )}
+        {remaining != null && (
+          <p className="text-xs text-on-surface-variant mt-2">
+            {remaining >= 0 ? `Noch ${remaining} kcal bis SOLL.` : `${Math.abs(remaining)} kcal über SOLL.`}
+          </p>
+        )}
       </section>
 
       {/* Einträge gruppiert */}
@@ -358,6 +395,20 @@ export function MealLogger({ date, entries, favorites, dishes, totals, targetKca
           <SlotGroup title="Ohne Slot" rows={grouped.other} isPending={isPending} onDelete={(id) => go(() => removeEntry(id), 'Entfernt.')} />
         )}
       </section>
+    </div>
+  )
+}
+
+function Macro({
+  label, ist, soll, unit = '', accent,
+}: {
+  label: string; ist: number; soll: number; unit?: string; accent?: boolean
+}) {
+  return (
+    <div className="rounded-xl bg-surface-container-high py-2">
+      <p className="text-[10px] uppercase tracking-widest text-on-surface-variant">{label}</p>
+      <p className={`text-sm font-bold tabular-nums ${accent ? 'text-primary' : 'text-on-surface'}`}>{ist}</p>
+      <p className="text-[10px] text-on-surface-variant tabular-nums">/ {soll}{unit}</p>
     </div>
   )
 }

--- a/src/components/nutrition/MealLogger.tsx
+++ b/src/components/nutrition/MealLogger.tsx
@@ -8,6 +8,7 @@ import type { MealEntryResolved, DayTotals } from '@/lib/nutrition/meals'
 import type { FavoriteResolved } from '@/lib/nutrition/favorites'
 import type { DishWithItems } from '@/lib/nutrition/dishes'
 import { BarcodeScanner } from '@/components/nutrition/BarcodeScanner'
+import { PhotoEstimator } from '@/components/nutrition/PhotoEstimator'
 import {
   logFoodEntry,
   logDishEntry,
@@ -36,7 +37,7 @@ function defaultSlot(): MealSlot {
   return 'Snack'
 }
 
-type Tab = 'katalog' | 'gericht' | 'scan'
+type Tab = 'katalog' | 'gericht' | 'scan' | 'foto'
 
 export function MealLogger({ date, entries, favorites, dishes, totals, targetKcal }: Props) {
   const router = useRouter()
@@ -184,7 +185,7 @@ export function MealLogger({ date, entries, favorites, dishes, totals, targetKca
       {/* Hinzufügen */}
       <section className="bg-surface-container rounded-2xl border border-surface-container-high p-5">
         <div className="flex gap-1 mb-4">
-          {(['katalog', 'gericht', 'scan'] as Tab[]).map((t) => (
+          {(['katalog', 'gericht', 'scan', 'foto'] as Tab[]).map((t) => (
             <button
               key={t}
               type="button"
@@ -193,7 +194,7 @@ export function MealLogger({ date, entries, favorites, dishes, totals, targetKca
                 tab === t ? 'bg-surface-container-high text-on-surface' : 'text-on-surface-variant hover:text-on-surface'
               }`}
             >
-              {t === 'katalog' ? 'Katalog' : t === 'gericht' ? 'Gericht' : 'Scan'}
+              {t === 'katalog' ? 'Katalog' : t === 'gericht' ? 'Gericht' : t === 'scan' ? 'Scan' : 'Foto'}
             </button>
           ))}
         </div>
@@ -316,6 +317,17 @@ export function MealLogger({ date, entries, favorites, dishes, totals, targetKca
               </div>
             )}
           </div>
+        )}
+
+        {tab === 'foto' && (
+          <PhotoEstimator
+            date={date}
+            mealSlot={slot}
+            onLogged={(name) => {
+              setMsg({ kind: 'ok', text: `„${name}" geloggt.` })
+              router.refresh()
+            }}
+          />
         )}
       </section>
 

--- a/src/components/nutrition/PhotoEstimator.tsx
+++ b/src/components/nutrition/PhotoEstimator.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+interface AiEstimate {
+  dishName: string
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  confidence: number
+  note: string
+  raw: unknown
+}
+
+interface Props {
+  date: string
+  mealSlot: string
+  onLogged: (name: string) => void
+}
+
+const inputCls =
+  'w-full border border-surface-container-high rounded-lg px-3 py-1.5 text-sm text-on-surface focus:outline-none focus:border-on-surface-variant bg-surface-container'
+
+/**
+ * Foto→AI-Flow: Teller-(+ optional Speisekarten-)Foto + Titel → Schätzung →
+ * Werte prüfen/korrigieren → loggen. Persistiert erst beim Bestätigen.
+ */
+export function PhotoEstimator({ date, mealSlot, onLogged }: Props) {
+  const plateRef = useRef<HTMLInputElement>(null)
+  const menuRef = useRef<HTMLInputElement>(null)
+
+  const [title, setTitle] = useState('')
+  const [busy, setBusy] = useState<null | 'estimate' | 'log'>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [estimate, setEstimate] = useState<AiEstimate | null>(null)
+
+  // Editierbare Werte (Bestätigen/Korrigieren)
+  const [dishName, setDishName] = useState('')
+  const [kcal, setKcal] = useState('')
+  const [proteinG, setProteinG] = useState('')
+  const [carbsG, setCarbsG] = useState('')
+  const [fatG, setFatG] = useState('')
+
+  function currentFiles(): { plate: File | null; menu: File | null } {
+    return {
+      plate: plateRef.current?.files?.[0] ?? null,
+      menu: menuRef.current?.files?.[0] ?? null,
+    }
+  }
+
+  async function estimateNow() {
+    setError(null)
+    const { plate, menu } = currentFiles()
+    if (!plate) {
+      setError('Bitte ein Teller-Foto wählen.')
+      return
+    }
+    const fd = new FormData()
+    fd.append('plate', plate)
+    if (menu) fd.append('menu', menu)
+    if (title.trim()) fd.append('title', title.trim())
+
+    setBusy('estimate')
+    try {
+      const res = await fetch('/api/nutrition/photo-estimate', { method: 'POST', body: fd })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Schätzung fehlgeschlagen')
+      const e = data.estimate as AiEstimate
+      setEstimate(e)
+      setDishName(e.dishName)
+      setKcal(String(e.kcal))
+      setProteinG(String(e.proteinG))
+      setCarbsG(String(e.carbsG))
+      setFatG(String(e.fatG))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Schätzung fehlgeschlagen')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function logNow() {
+    setError(null)
+    const { plate, menu } = currentFiles()
+    if (!plate) {
+      setError('Teller-Foto fehlt (bitte erneut wählen).')
+      return
+    }
+    const fd = new FormData()
+    fd.append('plate', plate)
+    if (menu) fd.append('menu', menu)
+    fd.append('date', date)
+    fd.append('mealSlot', mealSlot)
+    fd.append('dishName', dishName)
+    fd.append('kcal', kcal)
+    fd.append('proteinG', proteinG)
+    fd.append('carbsG', carbsG)
+    fd.append('fatG', fatG)
+    if (estimate) {
+      fd.append('confidence', String(estimate.confidence))
+      fd.append('aiRaw', JSON.stringify(estimate.raw))
+    }
+
+    setBusy('log')
+    try {
+      const res = await fetch('/api/nutrition/photo-log', { method: 'POST', body: fd })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Loggen fehlgeschlagen')
+      // Reset
+      setEstimate(null)
+      setTitle('')
+      if (plateRef.current) plateRef.current.value = ''
+      if (menuRef.current) menuRef.current.value = ''
+      onLogged(dishName)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Loggen fehlgeschlagen')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">
+            Teller-Foto *
+          </label>
+          <input ref={plateRef} type="file" accept="image/jpeg,image/png,image/webp" capture="environment"
+            className="block w-full text-xs text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-xs file:bg-surface-container-high file:text-on-surface" />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">
+            Speisekarte (optional)
+          </label>
+          <input ref={menuRef} type="file" accept="image/jpeg,image/png,image/webp" capture="environment"
+            className="block w-full text-xs text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-xs file:bg-surface-container-high file:text-on-surface" />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-on-surface-variant mb-1">
+          Gerichtstitel (optional)
+        </label>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="z. B. Pad Thai mit Huhn" className={inputCls} />
+      </div>
+
+      <button type="button" onClick={estimateNow} disabled={busy !== null}
+        className="px-5 py-2 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors">
+        {busy === 'estimate' ? 'Schätze…' : 'Nährwerte schätzen'}
+      </button>
+
+      {error && (
+        <div className="p-3 bg-error/10 border border-error/30 rounded-lg text-sm text-error">{error}</div>
+      )}
+
+      {estimate && (
+        <div className="rounded-xl bg-surface-container-high p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs uppercase tracking-widest text-on-surface-variant">
+              Schätzung — prüfen &amp; korrigieren
+            </p>
+            <span className="text-xs text-on-surface-variant">
+              Konfidenz {Math.round(estimate.confidence * 100)} %
+            </span>
+          </div>
+
+          <div>
+            <label className="block text-xs text-on-surface-variant mb-1">Gericht</label>
+            <input value={dishName} onChange={(e) => setDishName(e.target.value)} className={inputCls} />
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <NumField label="Kalorien" unit="kcal" value={kcal} onChange={setKcal} />
+            <NumField label="Protein" unit="g" value={proteinG} onChange={setProteinG} />
+            <NumField label="Kohlenhydrate" unit="g" value={carbsG} onChange={setCarbsG} />
+            <NumField label="Fett" unit="g" value={fatG} onChange={setFatG} />
+          </div>
+          {estimate.note && <p className="text-xs text-on-surface-variant">Annahme: {estimate.note}</p>}
+
+          <button type="button" onClick={logNow} disabled={busy !== null}
+            className="px-5 py-2 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors">
+            {busy === 'log' ? 'Logge…' : `In ${mealSlot} loggen`}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NumField({
+  label, unit, value, onChange,
+}: {
+  label: string; unit: string; value: string; onChange: (v: string) => void
+}) {
+  return (
+    <div>
+      <label className="block text-xs text-on-surface-variant mb-1">{label} ({unit})</label>
+      <input type="number" inputMode="decimal" min={0} value={value} onChange={(e) => onChange(e.target.value)}
+        className="w-full border border-surface-container-high rounded-lg px-2 py-1.5 text-sm text-on-surface bg-surface-container focus:outline-none" />
+    </div>
+  )
+}

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -4,6 +4,7 @@ import {
   isMovementFulfilled,
   isNutritionFulfilled,
   isSmokingFulfilled,
+  getNutritionLevel,
   calculateStreak,
   MOVEMENT_ENUM_MAP,
   NUTRITION_ENUM_MAP,
@@ -230,5 +231,35 @@ describe('calculateStreak', () => {
 
   it('all null returns 0/0', () => {
     expect(calculateStreak([null, null, null])).toEqual({ current: 0, longest: 0 })
+  })
+})
+
+// =============================================
+// N-08: Vorrang von Day.fulfillmentStatus (neues Nutrition-System)
+// =============================================
+describe('isNutritionFulfilled — nutritionStatus-Vorrang (N-08)', () => {
+  it('FULFILLED gewinnt über Enum/Score', () => {
+    expect(isNutritionFulfilled('none', 0, 'FULFILLED')).toBe(true)
+    expect(isNutritionFulfilled('none', null, 'FULFILLED')).toBe(true)
+  })
+  it('NOT_FULFILLED gewinnt über Enum/Score', () => {
+    expect(isNutritionFulfilled('three_meals', 10, 'NOT_FULFILLED')).toBe(false)
+  })
+  it('OPEN/null fällt auf Legacy zurück (Score, dann Enum)', () => {
+    expect(isNutritionFulfilled('three_meals', null, 'OPEN')).toBe(true)
+    expect(isNutritionFulfilled('none', 8.0, 'OPEN')).toBe(true)
+    expect(isNutritionFulfilled('none', null, null)).toBe(false)
+  })
+})
+
+describe('getNutritionLevel — nutritionStatus-Vorrang (N-08)', () => {
+  it('FULFILLED → 3, NOT_FULFILLED → 0', () => {
+    expect(getNutritionLevel('none', null, 'FULFILLED')).toBe(3)
+    expect(getNutritionLevel('three_meals', 9, 'NOT_FULFILLED')).toBe(0)
+  })
+  it('ohne Status: Legacy-Verhalten (Score/Enum)', () => {
+    expect(getNutritionLevel('three_meals')).toBe(3)
+    expect(getNutritionLevel('one_meal')).toBe(1)
+    expect(getNutritionLevel('none', 5.0)).toBe(2)
   })
 })

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -1,4 +1,4 @@
-import { MovementLevel, NutritionLevel, SmokingStatus } from '@prisma/client'
+import { MovementLevel, NutritionLevel, SmokingStatus, type FulfillmentStatus } from '@prisma/client'
 import { getAllEntries, type MovementValue, type NutritionValue, type SmokingValue } from './journal'
 
 // =============================================
@@ -16,14 +16,20 @@ export function isMovementFulfilled(movement: MovementValue): boolean {
 }
 
 /**
- * Nutrition goal met for the day. When a meal-log score is present (preferred,
- * authoritative), score ≥ 8.0 = fulfilled. Without a score we fall back to the
- * enum threshold so historical entries that pre-date the meal-log still count.
+ * Nutrition goal met for the day. Precedence (Nutrition-Umbau, N-08):
+ *  1. `nutritionStatus` aus dem neuen System (Day.fulfillmentStatus) —
+ *     FULFILLED/NOT_FULFILLED gewinnt (greift ab Cut-over pro Tag mit Log).
+ *  2. Legacy meal-log score ≥ 8.0.
+ *  3. Enum-Fallback (`three_meals`) für Alt-Einträge ohne Score.
+ * OPEN/undefined fällt durch auf die Legacy-Logik.
  */
 export function isNutritionFulfilled(
   nutrition: NutritionValue,
   mealScore?: number | null,
+  nutritionStatus?: FulfillmentStatus | null,
 ): boolean {
+  if (nutritionStatus === 'FULFILLED') return true
+  if (nutritionStatus === 'NOT_FULFILLED') return false
   if (mealScore !== null && mealScore !== undefined) {
     return mealScore >= NUTRITION_SCORE_THRESHOLD
   }
@@ -117,7 +123,14 @@ export function getMovementLevel(m: MovementValue): number {
   return 0
 }
 
-export function getNutritionLevel(n: NutritionValue, mealScore?: number | null): number {
+export function getNutritionLevel(
+  n: NutritionValue,
+  mealScore?: number | null,
+  nutritionStatus?: FulfillmentStatus | null,
+): number {
+  // Neues System (Day.fulfillmentStatus) hat Vorrang: binär erfüllt/nicht.
+  if (nutritionStatus === 'FULFILLED') return 3
+  if (nutritionStatus === 'NOT_FULFILLED') return 0
   if (mealScore !== null && mealScore !== undefined) {
     if (mealScore >= 8.0) return 3
     if (mealScore >= 5.0) return 2
@@ -146,7 +159,7 @@ export async function getMovementStreak(): Promise<StreakResult> {
 export async function getNutritionStreak(): Promise<StreakResult> {
   const entries = await getAllEntries()
   return calculateStreak(
-    entries.map((e) => (e.sickDay ? null : isNutritionFulfilled(e.habits.nutrition, e.mealScore))),
+    entries.map((e) => (e.sickDay ? null : isNutritionFulfilled(e.habits.nutrition, e.mealScore, e.nutritionStatus))),
   )
 }
 

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -1,5 +1,5 @@
 import { MovementLevel, NutritionLevel, SmokingStatus, EntryType } from '@prisma/client'
-import type { JournalEntry as PrismaJournalEntry } from '@prisma/client'
+import type { JournalEntry as PrismaJournalEntry, FulfillmentStatus } from '@prisma/client'
 import { prisma } from './db'
 
 /** @deprecated Use getProjectStartDate() from lib/project-config instead */
@@ -48,6 +48,13 @@ export interface JournalEntry {
    * enum threshold (`three_meals`) only for entries without a meal log.
    */
   mealScore?: number | null
+  /**
+   * Erfüllungsstatus aus dem neuen Nutrition-System (Day.fulfillmentStatus),
+   * sofern für den Tag ein Log existiert. Hat in der öffentlichen Anzeige
+   * Vorrang vor `mealScore`/Enum (N-08). Nur FULFILLED/NOT_FULFILLED wird
+   * gesetzt; OPEN/kein Log bleibt `null` → Legacy-Fallback greift.
+   */
+  nutritionStatus?: FulfillmentStatus | null
 }
 
 export type JournalEntryMeta = Omit<JournalEntry, 'content'>
@@ -85,12 +92,20 @@ function toDateString(date: Date): string {
   return date.toISOString().slice(0, 10)
 }
 
-export function isPerfectDay(habits: HabitsFrontmatter, mealScore?: number | null): boolean {
+export function isPerfectDay(
+  habits: HabitsFrontmatter,
+  mealScore?: number | null,
+  nutritionStatus?: FulfillmentStatus | null,
+): boolean {
   const movementGood = habits.movement === 'steps_only' || habits.movement === 'trained_only' || habits.movement === 'steps_trained'
   const nutritionGood =
-    mealScore !== null && mealScore !== undefined
-      ? mealScore >= 8.0
-      : habits.nutrition === 'three_meals'
+    nutritionStatus === 'FULFILLED'
+      ? true
+      : nutritionStatus === 'NOT_FULFILLED'
+        ? false
+        : mealScore !== null && mealScore !== undefined
+          ? mealScore >= 8.0
+          : habits.nutrition === 'three_meals'
   const smokingGood = habits.smoking === 'nicotine_replacement' || habits.smoking === 'smoke_free'
   return movementGood && nutritionGood && smokingGood
 }
@@ -145,15 +160,36 @@ async function getMealScoreMapForDates(dates: Date[]): Promise<Map<string, numbe
   )
 }
 
+/**
+ * Nutrition-Umbau (N-08): `date → Day.fulfillmentStatus` für die neue Erfüllung.
+ * Nur FULFILLED/NOT_FULFILLED wird zurückgegeben (OPEN → Legacy-Fallback).
+ * Liest ausschliesslich date + Status — keine Detail-/Privatdaten.
+ */
+async function getNutritionStatusMapForDates(
+  dates: Date[],
+): Promise<Map<string, FulfillmentStatus>> {
+  if (dates.length === 0) return new Map()
+  const rows = await prisma.day.findMany({
+    where: { date: { in: dates }, fulfillmentStatus: { in: ['FULFILLED', 'NOT_FULFILLED'] } },
+    select: { date: true, fulfillmentStatus: true },
+  })
+  return new Map(rows.map((r) => [toDateString(r.date), r.fulfillmentStatus]))
+}
+
 export async function getAllEntries(): Promise<JournalEntryMeta[]> {
   const entries = await prisma.journalEntry.findMany({
     where: { published: true },
     orderBy: { date: 'desc' },
   })
-  const scores = await getMealScoreMapForDates(entries.map((e) => e.date))
+  const dates = entries.map((e) => e.date)
+  const [scores, nutritionStatuses] = await Promise.all([
+    getMealScoreMapForDates(dates),
+    getNutritionStatusMapForDates(dates),
+  ])
   return entries.map((entry) => ({
     ...toMeta(entry),
     mealScore: scores.get(toDateString(entry.date)) ?? null,
+    nutritionStatus: nutritionStatuses.get(toDateString(entry.date)) ?? null,
   }))
 }
 
@@ -165,12 +201,17 @@ export async function getAllEntriesForLocale(locale: string): Promise<JournalEnt
     orderBy: { date: 'desc' },
     include: { translations: { where: { locale } } },
   })
-  const scores = await getMealScoreMapForDates(entries.map((e) => e.date))
+  const dates = entries.map((e) => e.date)
+  const [scores, nutritionStatuses] = await Promise.all([
+    getMealScoreMapForDates(dates),
+    getNutritionStatusMapForDates(dates),
+  ])
 
   return entries.map((entry) => {
     const meta: JournalEntryMeta = {
       ...toMeta(entry),
       mealScore: scores.get(toDateString(entry.date)) ?? null,
+      nutritionStatus: nutritionStatuses.get(toDateString(entry.date)) ?? null,
     }
     const translation = entry.translations[0] ?? null
     if (translation) {
@@ -185,8 +226,15 @@ export async function getAllEntriesForLocale(locale: string): Promise<JournalEnt
 export async function getEntryBySlug(slug: string): Promise<JournalEntry | null> {
   const entry = await prisma.journalEntry.findUnique({ where: { slug } })
   if (!entry || !entry.published) return null
-  const scores = await getMealScoreMapForDates([entry.date])
-  return { ...toFull(entry), mealScore: scores.get(toDateString(entry.date)) ?? null }
+  const [scores, nutritionStatuses] = await Promise.all([
+    getMealScoreMapForDates([entry.date]),
+    getNutritionStatusMapForDates([entry.date]),
+  ])
+  return {
+    ...toFull(entry),
+    mealScore: scores.get(toDateString(entry.date)) ?? null,
+    nutritionStatus: nutritionStatuses.get(toDateString(entry.date)) ?? null,
+  }
 }
 
 export async function getEntryBySlugWithTranslation(
@@ -199,10 +247,14 @@ export async function getEntryBySlugWithTranslation(
   })
   if (!row || !row.published) return null
 
-  const scores = await getMealScoreMapForDates([row.date])
+  const [scores, nutritionStatuses] = await Promise.all([
+    getMealScoreMapForDates([row.date]),
+    getNutritionStatusMapForDates([row.date]),
+  ])
   const entry: JournalEntry = {
     ...toFull(row),
     mealScore: scores.get(toDateString(row.date)) ?? null,
+    nutritionStatus: nutritionStatuses.get(toDateString(row.date)) ?? null,
   }
   const t = row.translations[0] ?? null
   const translation = t

--- a/src/lib/nutrition/calc.test.ts
+++ b/src/lib/nutrition/calc.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeEckdaten,
+  computeRefeedTargets,
+  bmrMifflin,
+  bmrHarrisBenedict,
+  targetKcalFromTdee,
+  isHighBodyFat,
+  type EckdatenInput,
+} from './calc'
+
+// Referenz-Eingaben aus der Fibel-Eckdaten-Page (Dom, Stand 2026-07-08)
+const DOM: EckdatenInput = {
+  weightKg: 94,
+  heightCm: 170,
+  age: 43,
+  sex: 'MALE',
+  bodyFatPct: 27,
+  activityFactor: 1.55,
+  phaseMode: 'DEFICIT',
+  deficitMethod: 'MODERATE',
+}
+
+describe('BMR-Formeln', () => {
+  it('Mifflin-St-Jeor (♂) reproduziert 1793', () => {
+    expect(Math.round(bmrMifflin(94, 170, 43, 'MALE'))).toBe(1793)
+  })
+
+  it('Harris-Benedict überarbeitet (♂) reproduziert 1919', () => {
+    expect(Math.round(bmrHarrisBenedict(94, 170, 43, 'MALE'))).toBe(1919)
+  })
+
+  it('Frauen-Formeln weichen ab (−161 bzw. eigene Konstanten)', () => {
+    expect(bmrMifflin(60, 165, 30, 'FEMALE')).toBeCloseTo(10 * 60 + 6.25 * 165 - 5 * 30 - 161, 3)
+    expect(bmrHarrisBenedict(60, 165, 30, 'FEMALE')).toBeGreaterThan(1300)
+  })
+})
+
+describe('computeEckdaten — Fibel-Referenzbeispiel', () => {
+  const r = computeEckdaten(DOM)
+
+  it('BMR-Mittel = 1856', () => expect(r.bmrAvg).toBe(1856))
+  it('TDEE (Erhaltungskalorien) = 2877', () => expect(r.tdee).toBe(2877))
+  it('Ziel-kcal (20 % Defizit) = 2301', () => expect(r.targetKcal).toBe(2301))
+  it('Protein = 185 g (Zielgewicht/FFM-Korrektur bei hohem KF)', () =>
+    expect(r.proteinG).toBe(185))
+  it('Fett = 51 g (20 %, > Minimum 47 g)', () => expect(r.fatG).toBe(51))
+  it('Kohlenhydrate = 275 g (Rest)', () => expect(r.carbsG).toBe(275))
+  it('Mahlzeiten = 4', () => expect(r.mealsPerDay).toBe(4))
+  it('KF-Korrektur greift und bezieht sich auf ~69 kg fettfreie Masse', () => {
+    expect(r.highBodyFatCorrection).toBe(true)
+    expect(r.proteinReferenceKg).toBe(69) // 94 × (1 − 0,27) = 68,62 → 69
+  })
+  it('Makro-kcal summieren ~ auf Ziel-kcal (Rundungstoleranz)', () => {
+    const macroKcal = r.proteinG * 4 + r.fatG * 9 + r.carbsG * 4
+    expect(Math.abs(macroKcal - r.targetKcal)).toBeLessThanOrEqual(6)
+  })
+})
+
+describe('Defizit-Methoden & Phasen-Modi', () => {
+  it('aggressiv = TDEE × 0,7', () => {
+    expect(targetKcalFromTdee(2877, 'DEFICIT', 'AGGRESSIVE')).toBeCloseTo(2013.9, 1)
+  })
+  it('einfach = TDEE − 500', () => {
+    expect(targetKcalFromTdee(2877, 'DEFICIT', 'SIMPLE')).toBe(2377)
+  })
+  it('Erhalt = TDEE (Defizit-Methode ignoriert)', () => {
+    expect(targetKcalFromTdee(2877, 'MAINTENANCE', 'MODERATE')).toBe(2877)
+  })
+  it('leichter Überschuss = TDEE × 1,1', () => {
+    expect(targetKcalFromTdee(2877, 'SURPLUS', 'MODERATE')).toBeCloseTo(3164.7, 1)
+  })
+  it('Erhalt-Phase liefert Ziel = Erhaltungskalorien', () => {
+    const r = computeEckdaten({ ...DOM, phaseMode: 'MAINTENANCE' })
+    expect(r.targetKcal).toBe(r.tdee)
+  })
+})
+
+describe('Protein-Korrektur & Fett-Minimum', () => {
+  it('ohne KF-Angabe: Protein auf volles Körpergewicht (2,2 g/kg)', () => {
+    const r = computeEckdaten({ ...DOM, bodyFatPct: null })
+    expect(r.highBodyFatCorrection).toBe(false)
+    expect(r.proteinReferenceKg).toBe(94)
+    expect(r.proteinG).toBe(Math.round(2.2 * 94)) // 207
+  })
+  it('niedriger KF (unter Schwelle): keine Korrektur', () => {
+    expect(isHighBodyFat('MALE', 18)).toBe(false)
+    const r = computeEckdaten({ ...DOM, bodyFatPct: 18 })
+    expect(r.highBodyFatCorrection).toBe(false)
+  })
+  it('Fett-Minimum 0,5 g/kg greift bei sehr niedrigem Fett-Prozentsatz', () => {
+    const r = computeEckdaten({ ...DOM, fatPctOfKcal: 0.05 })
+    expect(r.fatG).toBeGreaterThanOrEqual(Math.round(0.5 * DOM.weightKg)) // >= 47
+  })
+})
+
+describe('computeRefeedTargets — Fibel-Formel', () => {
+  it('reproduziert Dom-Beispiel: 2877 kcal → 150 P / 47 F / 464 KH', () => {
+    const r = computeRefeedTargets(2877, 94)
+    expect(r.kcal).toBe(2877)
+    expect(r.proteinG).toBe(150) // 1,6 × 94
+    expect(r.fatG).toBe(47) // 0,5 × 94
+    expect(r.carbsG).toBe(464) // Rest
+  })
+})

--- a/src/lib/nutrition/calc.ts
+++ b/src/lib/nutrition/calc.ts
@@ -1,0 +1,212 @@
+// =============================================================================
+// Eckdaten-Rechenlogik (Nutrition-Umbau, N-02)
+//
+// Bildet die Fibel-Methodik (Sjard Roscher, „Die Fettverlust Fibel") ab:
+//   BMR (HB #1 + #2, gemittelt) → TDEE (× Aktivitätsfaktor) → Ziel-kcal
+//   (Defizit × 0,8 / 0,7 / −500, Erhalt = TDEE, leichter Überschuss × 1,1)
+//   → Makros (Protein g/kg mit Zielgewicht-/FFM-Korrektur bei hohem KF,
+//   Fett 15–25 % der kcal bzw. min. 0,5 g/kg, Kohlenhydrate = Rest).
+//
+// Reine, DB-freie Funktionen — auch clientseitig für die Live-Vorschau nutzbar.
+// Referenz-Beispiel (Dom, Stand 2026-07-08): 94 kg / 170 cm / 43 J. / ♂ /
+// ~27 % KF / AF 1,55 / moderat  →  2'301 kcal / 185 g P / 51 g F / 275 g KH.
+// =============================================================================
+
+export type Sex = 'MALE' | 'FEMALE'
+export type PhaseMode = 'DEFICIT' | 'MAINTENANCE' | 'SURPLUS'
+export type DeficitMethod = 'MODERATE' | 'AGGRESSIVE' | 'SIMPLE'
+
+export interface EckdatenInput {
+  weightKg: number
+  heightCm: number
+  age: number
+  sex: Sex
+  bodyFatPct?: number | null
+  activityFactor: number
+  phaseMode: PhaseMode
+  /** Nur relevant bei phaseMode === 'DEFICIT'. */
+  deficitMethod: DeficitMethod
+  // --- Makro-Parameter (Defaults bilden das Fibel-Beispiel ab) --------------
+  /** Protein g pro kg (Normalfall, auf Körpergewicht). Default 2,2. */
+  proteinPerKg?: number
+  /** Protein g pro kg fettfreier Masse bei hohem KF. Default 2,7. */
+  proteinPerKgLean?: number
+  /** Fett-Anteil an den Ziel-kcal (♂ 15–25 %, ♀ 25–35 %). Default 0,20. */
+  fatPctOfKcal?: number
+  /** Mahlzeiten pro Tag. Default 4. */
+  mealsPerDay?: number
+}
+
+export interface EckdatenResult {
+  bmr1: number // Mifflin-St-Jeor
+  bmr2: number // Harris-Benedict (überarbeitet)
+  bmrAvg: number
+  tdee: number // Erhaltungskalorien
+  maintenanceKcal: number // == tdee (explizit für Refeed/Erhalt)
+  targetKcal: number
+  proteinG: number
+  fatG: number
+  carbsG: number
+  mealsPerDay: number
+  /** Gewicht (kg), auf das die Protein-Menge bezogen wurde. */
+  proteinReferenceKg: number
+  /** true, wenn wegen hohem KF auf die fettfreie Masse korrigiert wurde. */
+  highBodyFatCorrection: boolean
+  /** Menschenlesbare Herleitung — landet in NutritionTargets.calcNote. */
+  calcNote: string
+}
+
+const round = (n: number) => Math.round(n)
+
+/** KF-Schwelle, ab der die Protein-Korrektur auf fettfreie Masse greift. */
+export function isHighBodyFat(sex: Sex, bodyFatPct?: number | null): boolean {
+  if (bodyFatPct == null) return false
+  return sex === 'MALE' ? bodyFatPct > 25 : bodyFatPct > 32
+}
+
+/** BMR #1 — Mifflin-St-Jeor. */
+export function bmrMifflin(weightKg: number, heightCm: number, age: number, sex: Sex): number {
+  const base = 10 * weightKg + 6.25 * heightCm - 5 * age
+  return sex === 'MALE' ? base + 5 : base - 161
+}
+
+/** BMR #2 — überarbeitete Harris-Benedict-Formel. */
+export function bmrHarrisBenedict(
+  weightKg: number,
+  heightCm: number,
+  age: number,
+  sex: Sex,
+): number {
+  return sex === 'MALE'
+    ? 88.362 + 13.397 * weightKg + 4.799 * heightCm - 5.677 * age
+    : 447.593 + 9.247 * weightKg + 3.098 * heightCm - 4.33 * age
+}
+
+/** Ziel-kcal aus Erhaltungskalorien je nach Phasen-Modus/Defizit-Methode. */
+export function targetKcalFromTdee(
+  tdee: number,
+  phaseMode: PhaseMode,
+  deficitMethod: DeficitMethod,
+): number {
+  switch (phaseMode) {
+    case 'MAINTENANCE':
+      return tdee
+    case 'SURPLUS':
+      return tdee * 1.1 // leichter Überschuss (~+10 %)
+    case 'DEFICIT':
+    default:
+      switch (deficitMethod) {
+        case 'AGGRESSIVE':
+          return tdee * 0.7
+        case 'SIMPLE':
+          return tdee - 500
+        case 'MODERATE':
+        default:
+          return tdee * 0.8
+      }
+  }
+}
+
+/**
+ * Vollständige Eckdaten-Berechnung nach Fibel-Methodik.
+ * Zwischenwerte werden präzise gerechnet und erst am Ende gerundet; die Makros
+ * beziehen sich auf die gerundeten Ziel-kcal (wie im Fibel-Eckdaten-Rechner).
+ */
+export function computeEckdaten(input: EckdatenInput): EckdatenResult {
+  const {
+    weightKg,
+    heightCm,
+    age,
+    sex,
+    bodyFatPct = null,
+    activityFactor,
+    phaseMode,
+    deficitMethod,
+    proteinPerKg = 2.2,
+    proteinPerKgLean = 2.7,
+    fatPctOfKcal = 0.2,
+    mealsPerDay = 4,
+  } = input
+
+  const bmr1 = bmrMifflin(weightKg, heightCm, age, sex)
+  const bmr2 = bmrHarrisBenedict(weightKg, heightCm, age, sex)
+  const bmrAvg = (bmr1 + bmr2) / 2
+  const tdee = bmrAvg * activityFactor
+  const targetKcalRounded = round(targetKcalFromTdee(tdee, phaseMode, deficitMethod))
+
+  // --- Protein: bei hohem KF auf fettfreie Masse korrigiert -----------------
+  const highBF = isHighBodyFat(sex, bodyFatPct)
+  const leanMassKg = bodyFatPct != null ? weightKg * (1 - bodyFatPct / 100) : weightKg
+  const proteinReferenceKg = highBF ? leanMassKg : weightKg
+  const proteinFactor = highBF ? proteinPerKgLean : proteinPerKg
+  const proteinG = round(proteinFactor * proteinReferenceKg)
+  const proteinKcal = proteinG * 4
+
+  // --- Fett: Anteil der kcal, aber mindestens 0,5 g/kg ----------------------
+  const fatFromPctG = (targetKcalRounded * fatPctOfKcal) / 9
+  const fatMinG = 0.5 * weightKg
+  const fatPreciseG = Math.max(fatFromPctG, fatMinG)
+  const fatKcal = fatPreciseG * 9
+  const fatG = round(fatPreciseG)
+
+  // --- Kohlenhydrate: Rest --------------------------------------------------
+  const carbsG = Math.max(0, round((targetKcalRounded - proteinKcal - fatKcal) / 4))
+
+  const calcNote =
+    `BMR Mifflin ${round(bmr1)} + BMR Harris-Benedict ${round(bmr2)} → Ø ${round(bmrAvg)} ` +
+    `× AF ${activityFactor} = TDEE ${round(tdee)} kcal → ${phaseModeLabel(phaseMode, deficitMethod)} ` +
+    `= ${targetKcalRounded} kcal. ` +
+    `Protein ${proteinFactor} g/kg auf ${round(proteinReferenceKg)} kg ` +
+    `${highBF ? '(fettfreie Masse, KF-Korrektur)' : '(Körpergewicht)'} = ${proteinG} g. ` +
+    `Fett ${Math.round(fatPctOfKcal * 100)} % / min. ${round(fatMinG)} g = ${fatG} g. KH = Rest ${carbsG} g.`
+
+  return {
+    bmr1: round(bmr1),
+    bmr2: round(bmr2),
+    bmrAvg: round(bmrAvg),
+    tdee: round(tdee),
+    maintenanceKcal: round(tdee),
+    targetKcal: targetKcalRounded,
+    proteinG,
+    fatG,
+    carbsG,
+    mealsPerDay,
+    proteinReferenceKg: round(proteinReferenceKg),
+    highBodyFatCorrection: highBF,
+    calcNote,
+  }
+}
+
+function phaseModeLabel(mode: PhaseMode, method: DeficitMethod): string {
+  if (mode === 'MAINTENANCE') return 'Erhalt (× 1,0)'
+  if (mode === 'SURPLUS') return 'leichter Überschuss (× 1,1)'
+  switch (method) {
+    case 'AGGRESSIVE':
+      return 'Defizit aggressiv (× 0,7)'
+    case 'SIMPLE':
+      return 'Defizit einfach (− 500)'
+    default:
+      return 'Defizit moderat (× 0,8)'
+  }
+}
+
+// =============================================================================
+// Refeed-SOLL (Fibel): kcal = Erhaltungskalorien, Protein 1,6 g/kg,
+// Fett 0,5 g/kg, Kohlenhydrate = Rest. Skaliert mit dem Körpergewicht.
+// (Wird in N-07 für Refeed-Tage genutzt; hier zentral definiert.)
+// =============================================================================
+
+export interface RefeedTargets {
+  kcal: number
+  proteinG: number
+  fatG: number
+  carbsG: number
+}
+
+export function computeRefeedTargets(maintenanceKcal: number, weightKg: number): RefeedTargets {
+  const kcal = round(maintenanceKcal)
+  const proteinG = round(1.6 * weightKg)
+  const fatG = round(0.5 * weightKg)
+  const carbsG = Math.max(0, round((kcal - proteinG * 4 - fatG * 9) / 4))
+  return { kcal, proteinG, fatG, carbsG }
+}

--- a/src/lib/nutrition/constants.ts
+++ b/src/lib/nutrition/constants.ts
@@ -1,0 +1,4 @@
+// Gemeinsame Nutrition-Konstanten (client- und serverseitig nutzbar).
+
+export const MEAL_SLOTS = ['Frühstück', 'Mittag', 'Abend', 'Snack'] as const
+export type MealSlot = (typeof MEAL_SLOTS)[number]

--- a/src/lib/nutrition/day-aggregate.ts
+++ b/src/lib/nutrition/day-aggregate.ts
@@ -1,0 +1,121 @@
+// =============================================================================
+// Tages-Aggregation & Erfüllung (N-07)
+//
+// recomputeDay() bildet den IST (Summe der MealEntry-Snapshots), löst den SOLL
+// (Phase/Eckdaten + Tag-Typ) auf, bewertet die Erfüllung tag-typ-abhängig und
+// persistiert alles am Day (inkl. fulfillmentStatus — Basis der Blog-Kopplung
+// in N-08). Wird nach jeder Log-Änderung aufgerufen.
+// =============================================================================
+
+import type { FulfillmentStatus } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { getOrCreateDay, dateOnly } from './day'
+import { listDayEntries, sumEntries } from './meals'
+import { resolveTargetsForDate } from './targets'
+import { deriveRefeedSoll } from './refeed'
+import { effectiveIsRefeed, evaluateFulfillment, isoWeekday } from './fulfillment'
+
+export interface SollIst {
+  kcal: number
+  proteinG: number
+  fatG: number
+  carbsG: number
+}
+
+export interface DaySummary {
+  date: Date
+  phaseMode: string | null
+  isRefeed: boolean
+  soll: SollIst | null
+  ist: SollIst & { count: number }
+  fulfillmentStatus: FulfillmentStatus
+}
+
+/**
+ * Berechnet SOLL/IST + Erfüllung eines Tages neu und speichert sie am Day.
+ */
+export async function recomputeDay(date: Date): Promise<DaySummary> {
+  const d = dateOnly(date)
+  const day = await getOrCreateDay(d)
+
+  const [entries, targets, phase] = await Promise.all([
+    listDayEntries(d),
+    resolveTargetsForDate(d),
+    day.phaseId
+      ? prisma.phase.findUnique({ where: { id: day.phaseId }, include: { refeedRules: true } })
+      : Promise.resolve(null),
+  ])
+
+  const ist = sumEntries(entries)
+  const rules = phase?.refeedRules ?? []
+  const isRefeed = effectiveIsRefeed(day.dayType === 'REFEED', isoWeekday(d), rules)
+  const phaseMode = phase?.mode ?? null
+
+  // --- SOLL bestimmen -------------------------------------------------------
+  let soll: SollIst | null = null
+  if (targets) {
+    if (isRefeed) {
+      const activeRule = rules.find((r) => r.active)
+      if (activeRule) {
+        soll = {
+          kcal: activeRule.refeedKcal,
+          proteinG: activeRule.refeedProteinG,
+          fatG: activeRule.refeedFatG,
+          carbsG: activeRule.refeedCarbsG,
+        }
+      } else {
+        const derived = deriveRefeedSoll(targets)
+        soll = { kcal: derived.kcal, proteinG: derived.proteinG, fatG: derived.fatG, carbsG: derived.carbsG }
+      }
+    } else {
+      soll = {
+        kcal: targets.targetKcal,
+        proteinG: targets.proteinG,
+        fatG: targets.fatG,
+        carbsG: targets.carbsG,
+      }
+    }
+  }
+
+  const isDeficitDay = phaseMode === 'DEFICIT' && !isRefeed
+  const fulfillmentStatus = evaluateFulfillment({
+    istKcal: ist.kcal,
+    sollKcal: soll?.kcal ?? null,
+    isDeficitDay,
+    hasEntries: ist.count > 0,
+  })
+
+  await prisma.day.update({
+    where: { id: day.id },
+    data: {
+      targetKcal: soll?.kcal ?? null,
+      targetProteinG: soll?.proteinG ?? null,
+      targetFatG: soll?.fatG ?? null,
+      targetCarbsG: soll?.carbsG ?? null,
+      actualKcal: ist.kcal,
+      actualProteinG: ist.proteinG,
+      actualFatG: ist.fatG,
+      actualCarbsG: ist.carbsG,
+      fulfillmentStatus,
+    },
+  })
+
+  return {
+    date: d,
+    phaseMode,
+    isRefeed,
+    soll,
+    ist: { kcal: ist.kcal, proteinG: ist.proteinG, fatG: ist.fatG, carbsG: ist.carbsG, count: ist.count },
+    fulfillmentStatus,
+  }
+}
+
+/** Ad-hoc: einen Tag als Refeed (oder zurück auf Normal) markieren. */
+export async function setDayRefeed(date: Date, refeed: boolean): Promise<DaySummary> {
+  const day = await getOrCreateDay(dateOnly(date))
+  await prisma.day.update({
+    where: { id: day.id },
+    data: { dayType: refeed ? 'REFEED' : 'NORMAL' },
+  })
+  return recomputeDay(date)
+}

--- a/src/lib/nutrition/day.ts
+++ b/src/lib/nutrition/day.ts
@@ -1,0 +1,29 @@
+// =============================================================================
+// Day-Auflösung (N-05) — legt bei Bedarf einen Kalendertag an und verknüpft
+// ihn mit der aktiven Phase. SOLL-Snapshot, IST-Aggregat und Erfüllung setzt
+// N-07; hier wird der Tag nur als Container für MealEntries sichergestellt.
+// =============================================================================
+
+import type { Day } from '@prisma/client'
+import { prisma } from '@/lib/db'
+
+/** 'YYYY-MM-DD' → UTC-Mitternacht (passend zu @db.Date). */
+export function dateOnly(input: string | Date): Date {
+  if (input instanceof Date) {
+    return new Date(Date.UTC(input.getUTCFullYear(), input.getUTCMonth(), input.getUTCDate()))
+  }
+  return new Date(`${input}T00:00:00.000Z`)
+}
+
+export async function getOrCreateDay(date: Date): Promise<Day> {
+  const d = dateOnly(date)
+  const existing = await prisma.day.findUnique({ where: { date: d } })
+  if (existing) return existing
+  const active = await prisma.phase.findFirst({
+    where: { status: 'ACTIVE' },
+    orderBy: { startDate: 'desc' },
+  })
+  return prisma.day.create({
+    data: { date: d, phaseId: active?.id ?? null, dayType: 'NORMAL' },
+  })
+}

--- a/src/lib/nutrition/dishes.ts
+++ b/src/lib/nutrition/dishes.ts
@@ -1,0 +1,110 @@
+// =============================================================================
+// Gerichte (Dish/DishItem) — CRUD & Nährwert-Summe (N-05)
+//
+// Ein Gericht ist eine benannte Kombination mehrerer FoodItems mit
+// Standardmengen (z. B. „Mein Frühstück"). Beim Loggen als Ganzes wird die
+// Nährwert-Summe (× Portions-Multiplikator) als MealEntry-Snapshot gespeichert.
+// =============================================================================
+
+import type { Dish, DishItem, FoodItem, Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { dishSnapshot, type NutrientSnapshot } from './snapshot'
+
+export type DishWithItems = Dish & {
+  items: (DishItem & { foodItem: FoodItem })[]
+}
+
+export interface DishItemInput {
+  foodItemId: string
+  amount: number
+  unit: string
+}
+
+export interface DishInput {
+  name: string
+  note: string | null
+  items: DishItemInput[]
+}
+
+const withItems = {
+  items: { include: { foodItem: true }, orderBy: { id: 'asc' as const } },
+}
+
+export function listDishes(includeArchived = false): Promise<DishWithItems[]> {
+  return prisma.dish.findMany({
+    where: includeArchived ? undefined : { isActive: true },
+    orderBy: [{ isActive: 'desc' }, { name: 'asc' }],
+    include: withItems,
+  })
+}
+
+export function getDish(id: string): Promise<DishWithItems | null> {
+  return prisma.dish.findUnique({ where: { id }, include: withItems })
+}
+
+export async function createDish(input: DishInput): Promise<DishWithItems> {
+  const dish = await prisma.dish.create({
+    data: {
+      name: input.name,
+      note: input.note,
+      items: {
+        create: input.items.map((i) => ({
+          foodItemId: i.foodItemId,
+          amount: i.amount,
+          unit: i.unit,
+        })),
+      },
+    },
+    include: withItems,
+  })
+  return dish
+}
+
+export async function updateDish(id: string, input: DishInput): Promise<DishWithItems> {
+  // Zutaten werden komplett ersetzt (delete + recreate) — einfach & konsistent.
+  await prisma.$transaction([
+    prisma.dishItem.deleteMany({ where: { dishId: id } }),
+    prisma.dish.update({
+      where: { id },
+      data: {
+        name: input.name,
+        note: input.note,
+        items: {
+          create: input.items.map((i) => ({
+            foodItemId: i.foodItemId,
+            amount: i.amount,
+            unit: i.unit,
+          })),
+        },
+      },
+    }),
+  ])
+  return (await getDish(id))!
+}
+
+/** Archiviert bei Referenzierung (MealEntry/Favorite), sonst Hard-Delete. */
+export async function removeDish(id: string): Promise<'archived' | 'deleted'> {
+  const [meals, favs] = await prisma.$transaction([
+    prisma.mealEntry.count({ where: { dishId: id } }),
+    prisma.favorite.count({ where: { dishId: id } }),
+  ])
+  if (meals > 0 || favs > 0) {
+    await prisma.dish.update({ where: { id }, data: { isActive: false } })
+    return 'archived'
+  }
+  await prisma.$transaction([
+    prisma.dishItem.deleteMany({ where: { dishId: id } }),
+    prisma.dish.delete({ where: { id } }),
+  ])
+  return 'deleted'
+}
+
+/** Nährwert-Summe eines Gerichts (× Multiplikator). */
+export function dishTotals(dish: DishWithItems, multiplier = 1): NutrientSnapshot {
+  return dishSnapshot(
+    dish.items.map((i) => ({ food: i.foodItem, amount: i.amount })),
+    multiplier,
+  )
+}
+
+export type { Prisma }

--- a/src/lib/nutrition/favorites.ts
+++ b/src/lib/nutrition/favorites.ts
@@ -1,0 +1,66 @@
+// =============================================================================
+// Favoriten (N-05) — Schnellzugriff auf FoodItem ODER Dish für die
+// 1-Klick-Wiederholung im Logging.
+// =============================================================================
+
+import type { Favorite, FoodItem, Dish, DishItem } from '@prisma/client'
+import { prisma } from '@/lib/db'
+
+export type FavoriteResolved = Favorite & {
+  foodItem: FoodItem | null
+  dish: (Dish & { items: (DishItem & { foodItem: FoodItem })[] }) | null
+}
+
+const include = {
+  foodItem: true,
+  dish: { include: { items: { include: { foodItem: true } } } },
+}
+
+export function listFavorites(): Promise<FavoriteResolved[]> {
+  return prisma.favorite.findMany({
+    orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+    include,
+  })
+}
+
+async function nextSortOrder(): Promise<number> {
+  const last = await prisma.favorite.findFirst({ orderBy: { sortOrder: 'desc' } })
+  return (last?.sortOrder ?? -1) + 1
+}
+
+export async function addFoodFavorite(foodItemId: string): Promise<Favorite | null> {
+  const existing = await prisma.favorite.findFirst({ where: { foodItemId } })
+  if (existing) return existing
+  return prisma.favorite.create({
+    data: { targetType: 'food', foodItemId, sortOrder: await nextSortOrder() },
+  })
+}
+
+export async function addDishFavorite(dishId: string): Promise<Favorite | null> {
+  const existing = await prisma.favorite.findFirst({ where: { dishId } })
+  if (existing) return existing
+  return prisma.favorite.create({
+    data: { targetType: 'dish', dishId, sortOrder: await nextSortOrder() },
+  })
+}
+
+export async function removeFavorite(id: string): Promise<void> {
+  await prisma.favorite.delete({ where: { id } })
+}
+
+export async function removeFoodFavorite(foodItemId: string): Promise<void> {
+  await prisma.favorite.deleteMany({ where: { foodItemId } })
+}
+
+export async function removeDishFavorite(dishId: string): Promise<void> {
+  await prisma.favorite.deleteMany({ where: { dishId } })
+}
+
+/** IDs der aktuell favorisierten Foods/Dishes (für Toggle-Zustände in der UI). */
+export async function favoriteIdSets(): Promise<{ foods: Set<string>; dishes: Set<string> }> {
+  const favs = await prisma.favorite.findMany({ select: { foodItemId: true, dishId: true } })
+  return {
+    foods: new Set(favs.map((f) => f.foodItemId).filter((v): v is string => !!v)),
+    dishes: new Set(favs.map((f) => f.dishId).filter((v): v is string => !!v)),
+  }
+}

--- a/src/lib/nutrition/food-provider.ts
+++ b/src/lib/nutrition/food-provider.ts
@@ -1,0 +1,54 @@
+// =============================================================================
+// Food-Provider-Interface (Nutrition-Umbau, N-03)
+//
+// Kapselt externe Lebensmittel-Datenbanken hinter einer einheitlichen
+// Schnittstelle. Erst-Implementierung: Open Food Facts (kostenlos, kein Key).
+// Weitere Provider (z. B. FatSecret, key-basiert) sind später zuschaltbar —
+// deshalb wird ausschliesslich über dieses Interface gearbeitet, und die
+// Abfragen laufen serverseitig über Route Handler (Keys nie im Client).
+// =============================================================================
+
+import type { FoodSource } from '@prisma/client'
+
+/**
+ * Auf das interne FoodItem-Format normalisiertes Ergebnis eines Providers.
+ * Nährwerte beziehen sich auf 100 Basiseinheiten (g/ml). Makros sind Pflicht
+ * (fehlend → 0, im UI korrigierbar); Mikros sind best-effort und nullable.
+ */
+export interface NormalizedFood {
+  name: string
+  brand: string | null
+  barcode: string | null
+  baseUnit: string // 'g' | 'ml' | 'stück'
+  source: FoodSource
+  externalDbId: string | null
+
+  // Makros je 100 Basiseinheiten
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+
+  // Fokussierter Mikro-Satz je 100 Basiseinheiten (nullable)
+  fiberG: number | null
+  sugarG: number | null
+  saturatedFatG: number | null
+  sodiumMg: number | null
+  potassiumMg: number | null
+  ironMg: number | null
+  magnesiumMg: number | null
+  calciumMg: number | null
+  zincMg: number | null
+  vitaminDUg: number | null
+  vitaminB12Ug: number | null
+  vitaminCMg: number | null
+}
+
+export interface FoodProvider {
+  /** Stabile Kennung (z. B. 'openfoodfacts'). */
+  readonly id: string
+  /** Freitext-Suche → Trefferliste (normalisiert). */
+  searchByText(query: string, limit?: number): Promise<NormalizedFood[]>
+  /** Barcode-Lookup → einzelnes Produkt oder null. */
+  lookupByBarcode(barcode: string): Promise<NormalizedFood | null>
+}

--- a/src/lib/nutrition/food.ts
+++ b/src/lib/nutrition/food.ts
@@ -1,0 +1,145 @@
+// =============================================================================
+// FoodItem-Katalog — CRUD, Import & Dedup (N-03)
+//
+// Dedup läuft über den (uniquen) Barcode: ein Import mit vorhandenem Barcode
+// legt kein Duplikat an, sondern liefert den bestehenden Eintrag. FoodItems
+// werden bei Referenzierung nie hart gelöscht, sondern archiviert (isActive).
+// =============================================================================
+
+import type { FoodItem, Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import type { NormalizedFood } from './food-provider'
+
+/** Eingabe für manuelles Anlegen/Bearbeiten eines FoodItems. */
+export interface FoodItemInput {
+  name: string
+  brand: string | null
+  barcode: string | null
+  baseUnit: string
+  source: FoodItem['source']
+  externalDbId: string | null
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  fiberG: number | null
+  sugarG: number | null
+  saturatedFatG: number | null
+  sodiumMg: number | null
+  potassiumMg: number | null
+  ironMg: number | null
+  magnesiumMg: number | null
+  calciumMg: number | null
+  zincMg: number | null
+  vitaminDUg: number | null
+  vitaminB12Ug: number | null
+  vitaminCMg: number | null
+}
+
+function toData(input: FoodItemInput): Prisma.FoodItemCreateInput {
+  return {
+    name: input.name,
+    brand: input.brand,
+    barcode: input.barcode || null,
+    baseUnit: input.baseUnit,
+    source: input.source,
+    externalDbId: input.externalDbId,
+    kcal: input.kcal,
+    proteinG: input.proteinG,
+    carbsG: input.carbsG,
+    fatG: input.fatG,
+    fiberG: input.fiberG,
+    sugarG: input.sugarG,
+    saturatedFatG: input.saturatedFatG,
+    sodiumMg: input.sodiumMg,
+    potassiumMg: input.potassiumMg,
+    ironMg: input.ironMg,
+    magnesiumMg: input.magnesiumMg,
+    calciumMg: input.calciumMg,
+    zincMg: input.zincMg,
+    vitaminDUg: input.vitaminDUg,
+    vitaminB12Ug: input.vitaminB12Ug,
+    vitaminCMg: input.vitaminCMg,
+  }
+}
+
+export function normalizedToInput(f: NormalizedFood): FoodItemInput {
+  return { ...f }
+}
+
+/** Findet ein aktives FoodItem anhand des Barcodes (oder null). */
+export function findByBarcode(barcode: string): Promise<FoodItem | null> {
+  return prisma.foodItem.findUnique({ where: { barcode } })
+}
+
+/**
+ * Import eines normalisierten Produkts. Dedup über Barcode:
+ * existiert bereits ein FoodItem mit dem Barcode, wird dieses zurückgegeben
+ * (kein Duplikat). Ohne Barcode wird immer neu angelegt.
+ */
+export async function importFood(
+  f: NormalizedFood,
+): Promise<{ item: FoodItem; created: boolean }> {
+  if (f.barcode) {
+    const existing = await prisma.foodItem.findUnique({ where: { barcode: f.barcode } })
+    if (existing) return { item: existing, created: false }
+  }
+  const item = await prisma.foodItem.create({ data: toData(normalizedToInput(f)) })
+  return { item, created: true }
+}
+
+export function createFoodItem(input: FoodItemInput): Promise<FoodItem> {
+  return prisma.foodItem.create({ data: toData(input) })
+}
+
+export function updateFoodItem(id: string, input: FoodItemInput): Promise<FoodItem> {
+  return prisma.foodItem.update({ where: { id }, data: toData(input) })
+}
+
+/**
+ * Archiviert oder löscht ein FoodItem. Referenziert (DishItem/MealEntry/
+ * Favorite) → nur archivieren (isActive=false); sonst hart löschbar.
+ */
+export async function removeFoodItem(id: string): Promise<'archived' | 'deleted'> {
+  const refs = await prisma.$transaction([
+    prisma.dishItem.count({ where: { foodItemId: id } }),
+    prisma.mealEntry.count({ where: { foodItemId: id } }),
+    prisma.favorite.count({ where: { foodItemId: id } }),
+  ])
+  const referenced = refs.some((c) => c > 0)
+  if (referenced) {
+    await prisma.foodItem.update({ where: { id }, data: { isActive: false } })
+    return 'archived'
+  }
+  await prisma.foodItem.delete({ where: { id } })
+  return 'deleted'
+}
+
+export function reactivateFoodItem(id: string): Promise<FoodItem> {
+  return prisma.foodItem.update({ where: { id }, data: { isActive: true } })
+}
+
+export function listFoodItems(includeArchived = false): Promise<FoodItem[]> {
+  return prisma.foodItem.findMany({
+    where: includeArchived ? undefined : { isActive: true },
+    orderBy: [{ isActive: 'desc' }, { name: 'asc' }],
+  })
+}
+
+/** Lokale Katalog-Suche (Name/Marke/Barcode), nur aktive Einträge. */
+export function searchLocalFoodItems(query: string, limit = 20): Promise<FoodItem[]> {
+  const q = query.trim()
+  if (!q) return Promise.resolve([])
+  return prisma.foodItem.findMany({
+    where: {
+      isActive: true,
+      OR: [
+        { name: { contains: q, mode: 'insensitive' } },
+        { brand: { contains: q, mode: 'insensitive' } },
+        { barcode: { contains: q } },
+      ],
+    },
+    orderBy: { name: 'asc' },
+    take: limit,
+  })
+}

--- a/src/lib/nutrition/fulfillment.test.ts
+++ b/src/lib/nutrition/fulfillment.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  evaluateFulfillment,
+  isoWeekday,
+  matchesRecurringRefeed,
+  effectiveIsRefeed,
+} from './fulfillment'
+
+describe('isoWeekday', () => {
+  it('Montag = 1, Sonntag = 7', () => {
+    expect(isoWeekday(new Date('2026-07-06'))).toBe(1) // Mo
+    expect(isoWeekday(new Date('2026-07-08'))).toBe(3) // Mi
+    expect(isoWeekday(new Date('2026-07-12'))).toBe(7) // So
+  })
+})
+
+describe('Refeed-Erkennung', () => {
+  const rules = [{ active: true, recurringWeekdays: [3, 7] }] // Mi + So
+  it('matcht wiederkehrende Wochentage', () => {
+    expect(matchesRecurringRefeed(3, rules)).toBe(true)
+    expect(matchesRecurringRefeed(7, rules)).toBe(true)
+    expect(matchesRecurringRefeed(1, rules)).toBe(false)
+  })
+  it('inaktive Regeln zählen nicht', () => {
+    expect(matchesRecurringRefeed(3, [{ active: false, recurringWeekdays: [3] }])).toBe(false)
+  })
+  it('ad-hoc-Markierung erzwingt Refeed', () => {
+    expect(effectiveIsRefeed(true, 1, rules)).toBe(true) // Mo, aber ad-hoc
+    expect(effectiveIsRefeed(false, 3, rules)).toBe(true) // Mi über Regel
+    expect(effectiveIsRefeed(false, 1, rules)).toBe(false)
+  })
+})
+
+describe('evaluateFulfillment — Defizit-Tag (IST ≤ SOLL × 1,05)', () => {
+  const base = { sollKcal: 2301, isDeficitDay: true, hasEntries: true }
+  it('unter SOLL → erfüllt', () => {
+    expect(evaluateFulfillment({ ...base, istKcal: 2000 })).toBe('FULFILLED')
+  })
+  it('exakt an der +5%-Grenze → erfüllt', () => {
+    expect(evaluateFulfillment({ ...base, istKcal: Math.round(2301 * 1.05) })).toBe('FULFILLED')
+  })
+  it('deutlich über SOLL → nicht erfüllt', () => {
+    expect(evaluateFulfillment({ ...base, istKcal: 2600 })).toBe('NOT_FULFILLED')
+  })
+})
+
+describe('evaluateFulfillment — Band-Tag (Erhalt/Refeed, SOLL ±5%)', () => {
+  const base = { sollKcal: 2877, isDeficitDay: false, hasEntries: true }
+  it('im Band → erfüllt', () => {
+    expect(evaluateFulfillment({ ...base, istKcal: 2877 })).toBe('FULFILLED')
+    expect(evaluateFulfillment({ ...base, istKcal: 2750 })).toBe('FULFILLED')
+  })
+  it('unter dem Band → nicht erfüllt (anders als Defizit!)', () => {
+    expect(evaluateFulfillment({ ...base, istKcal: 2000 })).toBe('NOT_FULFILLED')
+  })
+  it('über dem Band → nicht erfüllt', () => {
+    expect(evaluateFulfillment({ ...base, istKcal: 3200 })).toBe('NOT_FULFILLED')
+  })
+})
+
+describe('evaluateFulfillment — OFFEN', () => {
+  it('keine Einträge → OFFEN', () => {
+    expect(evaluateFulfillment({ istKcal: 0, sollKcal: 2301, isDeficitDay: true, hasEntries: false })).toBe('OPEN')
+  })
+  it('keine gültigen Eckdaten (SOLL null) → OFFEN', () => {
+    expect(evaluateFulfillment({ istKcal: 1500, sollKcal: null, isDeficitDay: true, hasEntries: true })).toBe('OPEN')
+  })
+})

--- a/src/lib/nutrition/fulfillment.ts
+++ b/src/lib/nutrition/fulfillment.ts
@@ -1,0 +1,65 @@
+// =============================================================================
+// Erfüllungs-Logik (Nutrition-Umbau, N-07) — rein & testbar.
+//
+// Tag-typ-abhängig mit Toleranz ±5 % der Ziel-kcal (Notion-Spec Teil 3):
+//   • Defizit-Tag:            erfüllt, wenn IST ≤ SOLL × 1,05
+//   • Erhalt/Überschuss/Refeed: erfüllt, wenn IST im Band SOLL ±5 %
+//   • Ohne geloggte Einträge oder ohne gültige Eckdaten: OFFEN
+// =============================================================================
+
+export type FulfillmentStatus = 'FULFILLED' | 'NOT_FULFILLED' | 'OPEN'
+
+/** Toleranz der Ziel-kcal. */
+export const KCAL_TOLERANCE = 0.05
+
+/** JS getUTCDay() (0=So..6=Sa) → ISO-Wochentag (1=Mo..7=So). */
+export function isoWeekday(date: Date): number {
+  return ((date.getUTCDay() + 6) % 7) + 1
+}
+
+export interface RefeedRuleLike {
+  active: boolean
+  recurringWeekdays: number[]
+}
+
+/** Trifft der Wochentag eine aktive, wiederkehrende Refeed-Regel? */
+export function matchesRecurringRefeed(weekdayIso: number, rules: RefeedRuleLike[]): boolean {
+  return rules.some((r) => r.active && r.recurringWeekdays.includes(weekdayIso))
+}
+
+/**
+ * Effektiver Refeed-Status: ad-hoc (Tag explizit als Refeed markiert) ODER
+ * ein wiederkehrender Wochentag einer aktiven Regel.
+ */
+export function effectiveIsRefeed(
+  dayMarkedRefeed: boolean,
+  weekdayIso: number,
+  rules: RefeedRuleLike[],
+): boolean {
+  return dayMarkedRefeed || matchesRecurringRefeed(weekdayIso, rules)
+}
+
+export interface FulfillmentArgs {
+  istKcal: number
+  sollKcal: number | null
+  /** true nur bei echtem Defizit-Tag (Phase DEFICIT und KEIN Refeed). */
+  isDeficitDay: boolean
+  hasEntries: boolean
+}
+
+export function evaluateFulfillment({
+  istKcal,
+  sollKcal,
+  isDeficitDay,
+  hasEntries,
+}: FulfillmentArgs): FulfillmentStatus {
+  if (!hasEntries || sollKcal == null || sollKcal <= 0) return 'OPEN'
+
+  if (isDeficitDay) {
+    return istKcal <= sollKcal * (1 + KCAL_TOLERANCE) ? 'FULFILLED' : 'NOT_FULFILLED'
+  }
+  // Band-Logik für Erhalt / Überschuss / Refeed
+  const lo = sollKcal * (1 - KCAL_TOLERANCE)
+  const hi = sollKcal * (1 + KCAL_TOLERANCE)
+  return istKcal >= lo && istKcal <= hi ? 'FULFILLED' : 'NOT_FULFILLED'
+}

--- a/src/lib/nutrition/meal-photos.ts
+++ b/src/lib/nutrition/meal-photos.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// Speicherung der Mahlzeiten-Fotos (N-06)
+// Bilder liegen ausserhalb von public/ → nur über geschützte Route abrufbar.
+// =============================================================================
+
+import { writeFile, mkdir, readFile } from 'fs/promises'
+import path from 'path'
+import crypto from 'crypto'
+import type { VisionMediaType } from './vision'
+
+export const MEAL_PHOTO_DIR = path.join(process.cwd(), 'private', 'meal-photos')
+
+export const ALLOWED_IMAGE_TYPES: Record<string, { ext: string; media: VisionMediaType }> = {
+  'image/jpeg': { ext: '.jpg', media: 'image/jpeg' },
+  'image/jpg': { ext: '.jpg', media: 'image/jpeg' },
+  'image/png': { ext: '.png', media: 'image/png' },
+  'image/webp': { ext: '.webp', media: 'image/webp' },
+}
+
+export const MAX_IMAGE_BYTES = 12 * 1024 * 1024 // 12 MB
+
+export const MIME_BY_EXT: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+}
+
+/** Persistiert eine hochgeladene Bilddatei und gibt den Dateinamen zurück. */
+export async function saveMealPhoto(file: File): Promise<string> {
+  const spec = ALLOWED_IMAGE_TYPES[file.type]
+  if (!spec) throw new Error('Nur JPEG, PNG oder WebP werden unterstützt')
+  if (file.size > MAX_IMAGE_BYTES) throw new Error('Bild darf maximal 12 MB gross sein')
+
+  const filename = `${crypto.randomUUID()}${spec.ext}`
+  await mkdir(MEAL_PHOTO_DIR, { recursive: true })
+  const bytes = Buffer.from(await file.arrayBuffer())
+  await writeFile(path.join(MEAL_PHOTO_DIR, filename), bytes)
+  return filename
+}
+
+/** Liest eine gespeicherte Datei (mit Path-Traversal-Schutz). */
+export async function readMealPhoto(filename: string): Promise<{ buffer: Buffer; contentType: string } | null> {
+  const filePath = path.resolve(MEAL_PHOTO_DIR, filename)
+  if (!filePath.startsWith(MEAL_PHOTO_DIR + path.sep)) return null
+  try {
+    const buffer = await readFile(filePath)
+    const ext = path.extname(filename).toLowerCase()
+    return { buffer, contentType: MIME_BY_EXT[ext] ?? 'application/octet-stream' }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/nutrition/meals.ts
+++ b/src/lib/nutrition/meals.ts
@@ -6,7 +6,7 @@
 // Einträge nicht (Snapshot-Prinzip, Notion-Spec Teil 3).
 // =============================================================================
 
-import type { MealEntry, FoodItem, Dish, MealSource } from '@prisma/client'
+import type { MealEntry, FoodItem, Dish, MealSource, PhotoType, Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { getOrCreateDay } from './day'
 import { scaleNutrients } from './snapshot'
@@ -107,6 +107,55 @@ export async function logFavorite(args: {
     })
   }
   throw new Error('Favorit ohne Ziel')
+}
+
+export interface PhotoInput {
+  filename: string
+  photoType: PhotoType
+  aiAnalysis?: unknown
+  aiConfidence?: number | null
+}
+
+export interface LogPhotoMealArgs {
+  date: Date
+  mealSlot?: string | null
+  externalName: string
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  photos: PhotoInput[]
+}
+
+/**
+ * Loggt eine per Foto→AI geschätzte Mahlzeit. Der (ggf. korrigierte) Snapshot
+ * bezieht sich auf die ganze Portion (amount 1). Fotos werden als MealPhoto
+ * mit roher AI-Analyse verknüpft.
+ */
+export async function logPhotoMeal(args: LogPhotoMealArgs): Promise<MealEntry> {
+  const day = await getOrCreateDay(args.date)
+  return prisma.mealEntry.create({
+    data: {
+      dayId: day.id,
+      sourceType: 'PHOTO_AI',
+      externalName: args.externalName,
+      amount: 1,
+      unit: 'Portion',
+      mealSlot: args.mealSlot ?? null,
+      kcal: args.kcal,
+      proteinG: args.proteinG,
+      carbsG: args.carbsG,
+      fatG: args.fatG,
+      photos: {
+        create: args.photos.map((p) => ({
+          imagePath: p.filename,
+          photoType: p.photoType,
+          aiAnalysis: (p.aiAnalysis ?? undefined) as Prisma.InputJsonValue | undefined,
+          aiConfidence: p.aiConfidence ?? null,
+        })),
+      },
+    },
+  })
 }
 
 export async function deleteMealEntry(id: string): Promise<void> {

--- a/src/lib/nutrition/meals.ts
+++ b/src/lib/nutrition/meals.ts
@@ -158,8 +158,12 @@ export async function logPhotoMeal(args: LogPhotoMealArgs): Promise<MealEntry> {
   })
 }
 
-export async function deleteMealEntry(id: string): Promise<void> {
+/** Löscht einen Eintrag und gibt das Datum seines Tages zurück (für Recompute). */
+export async function deleteMealEntry(id: string): Promise<Date | null> {
+  const entry = await prisma.mealEntry.findUnique({ where: { id }, include: { day: true } })
+  if (!entry) return null
   await prisma.mealEntry.delete({ where: { id } })
+  return entry.day.date
 }
 
 export function listDayEntries(date: Date): Promise<MealEntryResolved[]> {

--- a/src/lib/nutrition/meals.ts
+++ b/src/lib/nutrition/meals.ts
@@ -1,0 +1,151 @@
+// =============================================================================
+// Mahlzeit-Logging (N-05) — MealEntry mit immutablem Nährwert-Snapshot.
+//
+// Beim Loggen wird der Snapshot aus FoodItem/Dish × Menge berechnet und fest
+// am MealEntry gespeichert. Spätere Katalog-Korrekturen ändern bestehende
+// Einträge nicht (Snapshot-Prinzip, Notion-Spec Teil 3).
+// =============================================================================
+
+import type { MealEntry, FoodItem, Dish, MealSource } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { getOrCreateDay } from './day'
+import { scaleNutrients } from './snapshot'
+import { dishTotals, getDish } from './dishes'
+
+/** Standardmenge für die 1-Klick-Wiederholung eines Food-Favoriten. */
+export const DEFAULT_FOOD_AMOUNT = 100
+
+export type MealEntryResolved = MealEntry & {
+  foodItem: FoodItem | null
+  dish: Dish | null
+}
+
+const include = { foodItem: true, dish: true }
+
+export interface LogFoodArgs {
+  date: Date
+  foodItemId: string
+  amount: number
+  mealSlot?: string | null
+  sourceType?: MealSource
+}
+
+export async function logFood(args: LogFoodArgs): Promise<MealEntry> {
+  const food = await prisma.foodItem.findUnique({ where: { id: args.foodItemId } })
+  if (!food) throw new Error('FoodItem nicht gefunden')
+  if (args.amount <= 0) throw new Error('Menge muss > 0 sein')
+
+  const day = await getOrCreateDay(args.date)
+  const snap = scaleNutrients(food, args.amount)
+
+  return prisma.mealEntry.create({
+    data: {
+      dayId: day.id,
+      foodItemId: food.id,
+      amount: args.amount,
+      unit: food.baseUnit,
+      mealSlot: args.mealSlot ?? null,
+      sourceType: args.sourceType ?? 'MANUAL',
+      ...snap,
+    },
+  })
+}
+
+export interface LogDishArgs {
+  date: Date
+  dishId: string
+  multiplier?: number
+  mealSlot?: string | null
+}
+
+export async function logDish(args: LogDishArgs): Promise<MealEntry> {
+  const dish = await getDish(args.dishId)
+  if (!dish) throw new Error('Gericht nicht gefunden')
+  const multiplier = args.multiplier && args.multiplier > 0 ? args.multiplier : 1
+
+  const day = await getOrCreateDay(args.date)
+  const snap = dishTotals(dish, multiplier)
+
+  return prisma.mealEntry.create({
+    data: {
+      dayId: day.id,
+      dishId: dish.id,
+      amount: multiplier,
+      unit: 'Portion',
+      mealSlot: args.mealSlot ?? null,
+      sourceType: 'DISH',
+      ...snap,
+    },
+  })
+}
+
+/** 1-Klick-Wiederholung: Favorit auf einen Tag loggen (Menge optional). */
+export async function logFavorite(args: {
+  favoriteId: string
+  date: Date
+  mealSlot?: string | null
+  amount?: number
+}): Promise<MealEntry> {
+  const fav = await prisma.favorite.findUnique({ where: { id: args.favoriteId } })
+  if (!fav) throw new Error('Favorit nicht gefunden')
+
+  if (fav.foodItemId) {
+    return logFood({
+      date: args.date,
+      foodItemId: fav.foodItemId,
+      amount: args.amount ?? DEFAULT_FOOD_AMOUNT,
+      mealSlot: args.mealSlot,
+      sourceType: 'FAVORITE',
+    })
+  }
+  if (fav.dishId) {
+    return logDish({
+      date: args.date,
+      dishId: fav.dishId,
+      multiplier: args.amount ?? 1,
+      mealSlot: args.mealSlot,
+    })
+  }
+  throw new Error('Favorit ohne Ziel')
+}
+
+export async function deleteMealEntry(id: string): Promise<void> {
+  await prisma.mealEntry.delete({ where: { id } })
+}
+
+export function listDayEntries(date: Date): Promise<MealEntryResolved[]> {
+  return prisma.mealEntry.findMany({
+    where: { day: { date } },
+    orderBy: { loggedAt: 'asc' },
+    include,
+  })
+}
+
+export interface DayTotals {
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  count: number
+}
+
+/** IST-Tagessumme aus den MealEntry-Snapshots (Vorstufe zur N-07-Aggregation). */
+export function sumEntries(entries: Pick<MealEntry, 'kcal' | 'proteinG' | 'carbsG' | 'fatG'>[]): DayTotals {
+  const t = entries.reduce(
+    (acc, e) => ({
+      kcal: acc.kcal + e.kcal,
+      proteinG: acc.proteinG + e.proteinG,
+      carbsG: acc.carbsG + e.carbsG,
+      fatG: acc.fatG + e.fatG,
+    }),
+    { kcal: 0, proteinG: 0, carbsG: 0, fatG: 0 },
+  )
+  const r1 = (n: number) => Math.round(n * 10) / 10
+  return {
+    kcal: r1(t.kcal),
+    proteinG: r1(t.proteinG),
+    carbsG: r1(t.carbsG),
+    fatG: r1(t.fatG),
+    count: entries.length,
+  }
+}

--- a/src/lib/nutrition/providers/open-food-facts.test.ts
+++ b/src/lib/nutrition/providers/open-food-facts.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { mapOffProduct } from './open-food-facts'
+
+const SAMPLE = {
+  code: '4008400202037',
+  product_name: 'Testprodukt',
+  brands: 'MarkeA, MarkeB',
+  nutriments: {
+    'energy-kcal_100g': 250,
+    proteins_100g: 12,
+    carbohydrates_100g: 30,
+    fat_100g: 8,
+    fiber_100g: 3,
+    sugars_100g: 5,
+    'saturated-fat_100g': 2,
+    sodium_100g: 0.5, // g → 500 mg
+    potassium_100g: 0.35, // g → 350 mg
+    iron_100g: 0.0014, // g → 1,4 mg
+    magnesium_100g: 0.025, // g → 25 mg
+    calcium_100g: 0.12, // g → 120 mg
+    zinc_100g: 0.004, // g → 4 mg
+    'vitamin-d_100g': 0.0000051, // g → 5,1 µg
+    'vitamin-b12_100g': 0.0000024, // g → 2,4 µg
+    'vitamin-c_100g': 0.0533, // g → 53,3 mg
+  },
+}
+
+describe('mapOffProduct', () => {
+  const f = mapOffProduct(SAMPLE)!
+
+  it('übernimmt Name, erste Marke, Barcode und Quelle', () => {
+    expect(f.name).toBe('Testprodukt')
+    expect(f.brand).toBe('MarkeA')
+    expect(f.barcode).toBe('4008400202037')
+    expect(f.source).toBe('EXTERNAL_DB')
+    expect(f.externalDbId).toBe('4008400202037')
+    expect(f.baseUnit).toBe('g')
+  })
+
+  it('übernimmt Makros je 100 g', () => {
+    expect(f.kcal).toBe(250)
+    expect(f.proteinG).toBe(12)
+    expect(f.carbsG).toBe(30)
+    expect(f.fatG).toBe(8)
+  })
+
+  it('übernimmt Sub-Makros (g)', () => {
+    expect(f.fiberG).toBe(3)
+    expect(f.sugarG).toBe(5)
+    expect(f.saturatedFatG).toBe(2)
+  })
+
+  it('rechnet Mineralstoffe von g auf mg um', () => {
+    expect(f.sodiumMg).toBe(500)
+    expect(f.potassiumMg).toBe(350)
+    expect(f.ironMg).toBe(1.4)
+    expect(f.magnesiumMg).toBe(25)
+    expect(f.calciumMg).toBe(120)
+    expect(f.zincMg).toBe(4)
+  })
+
+  it('rechnet Vitamine korrekt um (D/B12 → µg, C → mg)', () => {
+    expect(f.vitaminDUg).toBe(5.1)
+    expect(f.vitaminB12Ug).toBe(2.4)
+    expect(f.vitaminCMg).toBe(53.3)
+  })
+
+  it('setzt fehlende Mikros auf null', () => {
+    const g = mapOffProduct({
+      code: '111',
+      product_name: 'Nur Makros',
+      nutriments: { 'energy-kcal_100g': 100, proteins_100g: 5, carbohydrates_100g: 10, fat_100g: 2 },
+    })!
+    expect(g.fiberG).toBeNull()
+    expect(g.calciumMg).toBeNull()
+    expect(g.vitaminDUg).toBeNull()
+  })
+
+  it('rechnet Energie aus kJ um, wenn kcal fehlt', () => {
+    const g = mapOffProduct({
+      code: '222',
+      product_name: 'kJ only',
+      nutriments: { energy_100g: 1046, proteins_100g: 0, carbohydrates_100g: 0, fat_100g: 0 },
+    })!
+    expect(g.kcal).toBeCloseTo(250, 0)
+  })
+
+  it('fehlende Makros → 0 (im UI korrigierbar)', () => {
+    const g = mapOffProduct({ code: '333', product_name: 'Leer', nutriments: {} })!
+    expect(g.kcal).toBe(0)
+    expect(g.proteinG).toBe(0)
+  })
+
+  it('ohne Name und Barcode → null', () => {
+    expect(mapOffProduct({ nutriments: {} })).toBeNull()
+  })
+
+  it('Barcode ohne Name → Fallback-Name', () => {
+    const g = mapOffProduct({ code: '999', nutriments: {} })!
+    expect(g.name).toContain('999')
+  })
+})

--- a/src/lib/nutrition/providers/open-food-facts.ts
+++ b/src/lib/nutrition/providers/open-food-facts.ts
@@ -1,0 +1,144 @@
+// =============================================================================
+// Open Food Facts Provider (N-03)
+//
+// OFF liefert Nährwerte im `nutriments`-Objekt je 100 g/ml. Massenährstoffe
+// (`*_100g`) sind in GRAMM normalisiert — Mikros werden daher auf mg/µg
+// umgerechnet. Energie separat als `energy-kcal_100g` (kcal).
+//
+// Kein API-Key nötig. OFF bittet um einen aussagekräftigen User-Agent.
+// =============================================================================
+
+import type { FoodProvider, NormalizedFood } from '../food-provider'
+
+const OFF_BASE = 'https://world.openfoodfacts.org'
+const USER_AGENT = 'Project365/1.0 (https://project365.dom42.ch)'
+
+// Nur benötigte Felder anfordern (kleinere Payload)
+const FIELDS = [
+  'code',
+  'product_name',
+  'generic_name',
+  'brands',
+  'quantity',
+  'nutriments',
+].join(',')
+
+interface OffProduct {
+  code?: string
+  product_name?: string
+  generic_name?: string
+  brands?: string
+  quantity?: string
+  nutriments?: Record<string, unknown>
+}
+
+/** Roh-Wert eines Nutriments als Zahl (oder null). */
+function num(nutriments: Record<string, unknown>, key: string): number | null {
+  const v = nutriments[key]
+  if (v === undefined || v === null || v === '') return null
+  const n = typeof v === 'number' ? v : parseFloat(String(v))
+  return isNaN(n) ? null : n
+}
+
+/** Gramm → mg (× 1000). */
+function gToMg(g: number | null): number | null {
+  return g === null ? null : Math.round(g * 1000 * 100) / 100
+}
+/** Gramm → µg (× 1_000_000). */
+function gToUg(g: number | null): number | null {
+  return g === null ? null : Math.round(g * 1_000_000 * 100) / 100
+}
+/** Auf 2 Nachkommastellen runden (oder null). */
+function r2(n: number | null): number | null {
+  return n === null ? null : Math.round(n * 100) / 100
+}
+
+function firstBrand(brands?: string): string | null {
+  if (!brands) return null
+  const first = brands.split(',')[0]?.trim()
+  return first || null
+}
+
+/**
+ * Reine Abbildung eines OFF-Produkts auf das interne NormalizedFood-Format.
+ * Gibt null zurück, wenn weder Name noch Barcode brauchbar sind.
+ */
+export function mapOffProduct(product: OffProduct): NormalizedFood | null {
+  const name = (product.product_name || product.generic_name || '').trim()
+  const barcode = product.code?.trim() || null
+  if (!name && !barcode) return null
+
+  const n = product.nutriments ?? {}
+
+  // Energie: bevorzugt kcal-Feld, sonst aus kJ umrechnen
+  let kcal = num(n, 'energy-kcal_100g')
+  if (kcal === null) {
+    const kj = num(n, 'energy_100g')
+    kcal = kj === null ? 0 : Math.round((kj / 4.184) * 10) / 10
+  }
+
+  return {
+    name: name || `Produkt ${barcode}`,
+    brand: firstBrand(product.brands),
+    barcode,
+    baseUnit: 'g', // OFF unterscheidet g/ml nicht zuverlässig → Default, im UI korrigierbar
+    source: 'EXTERNAL_DB',
+    externalDbId: barcode,
+
+    kcal: kcal ?? 0,
+    proteinG: r2(num(n, 'proteins_100g')) ?? 0,
+    carbsG: r2(num(n, 'carbohydrates_100g')) ?? 0,
+    fatG: r2(num(n, 'fat_100g')) ?? 0,
+
+    fiberG: r2(num(n, 'fiber_100g')),
+    sugarG: r2(num(n, 'sugars_100g')),
+    saturatedFatG: r2(num(n, 'saturated-fat_100g')),
+    sodiumMg: gToMg(num(n, 'sodium_100g')),
+    potassiumMg: gToMg(num(n, 'potassium_100g')),
+    ironMg: gToMg(num(n, 'iron_100g')),
+    magnesiumMg: gToMg(num(n, 'magnesium_100g')),
+    calciumMg: gToMg(num(n, 'calcium_100g')),
+    zincMg: gToMg(num(n, 'zinc_100g')),
+    vitaminDUg: gToUg(num(n, 'vitamin-d_100g')),
+    vitaminB12Ug: gToUg(num(n, 'vitamin-b12_100g')),
+    vitaminCMg: gToMg(num(n, 'vitamin-c_100g')),
+  }
+}
+
+async function offFetch(url: string): Promise<unknown> {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+    // OFF-Daten sind wenig volatil; kurzer Cache entlastet die API
+    next: { revalidate: 3600 },
+  })
+  if (!res.ok) throw new Error(`OFF request failed: ${res.status}`)
+  return res.json()
+}
+
+export class OpenFoodFactsProvider implements FoodProvider {
+  readonly id = 'openfoodfacts'
+
+  async searchByText(query: string, limit = 20): Promise<NormalizedFood[]> {
+    const q = query.trim()
+    if (!q) return []
+    const url =
+      `${OFF_BASE}/cgi/search.pl?search_terms=${encodeURIComponent(q)}` +
+      `&search_simple=1&action=process&json=1&page_size=${limit}&fields=${FIELDS}`
+    const data = (await offFetch(url)) as { products?: OffProduct[] }
+    const products = Array.isArray(data.products) ? data.products : []
+    return products
+      .map(mapOffProduct)
+      .filter((f): f is NormalizedFood => f !== null)
+  }
+
+  async lookupByBarcode(barcode: string): Promise<NormalizedFood | null> {
+    const code = barcode.trim()
+    if (!code) return null
+    const url = `${OFF_BASE}/api/v2/product/${encodeURIComponent(code)}.json?fields=${FIELDS}`
+    const data = (await offFetch(url)) as { status?: number; product?: OffProduct }
+    if (data.status !== 1 || !data.product) return null
+    return mapOffProduct(data.product)
+  }
+}
+
+export const openFoodFacts = new OpenFoodFactsProvider()

--- a/src/lib/nutrition/refeed.ts
+++ b/src/lib/nutrition/refeed.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// Refeed-Regeln (N-07) — wiederkehrende Refeed-Wochentage je Phase + Refeed-SOLL.
+//
+// Refeed-SOLL (Fibel): kcal = Erhaltungskalorien, Protein 1,6 g/kg, Fett
+// 0,5 g/kg, KH = Rest. Ist keine Regel konfiguriert, wird das SOLL aus den
+// gültigen Eckdaten abgeleitet (Erhaltungskalorien = TDEE aus computeEckdaten).
+// =============================================================================
+
+import type { NutritionTargets, RefeedRule } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { computeEckdaten, computeRefeedTargets, type RefeedTargets } from './calc'
+
+/** Erhaltungskalorien (TDEE) aus einem Eckdaten-Satz. */
+export function maintenanceKcalFromTargets(t: NutritionTargets): number {
+  return computeEckdaten({
+    weightKg: t.baseWeightKg,
+    heightCm: t.heightCm,
+    age: t.age,
+    sex: t.sex,
+    bodyFatPct: t.bodyFatPct,
+    activityFactor: t.activityFactor,
+    phaseMode: 'DEFICIT',
+    deficitMethod: t.deficitMode,
+  }).maintenanceKcal
+}
+
+/** Refeed-SOLL aus Eckdaten ableiten (wenn keine explizite Regel greift). */
+export function deriveRefeedSoll(t: NutritionTargets): RefeedTargets {
+  return computeRefeedTargets(maintenanceKcalFromTargets(t), t.baseWeightKg)
+}
+
+export function listRefeedRules(phaseId: string): Promise<RefeedRule[]> {
+  return prisma.refeedRule.findMany({ where: { phaseId }, orderBy: { createdAt: 'asc' } })
+}
+
+export function getActiveRefeedRule(phaseId: string): Promise<RefeedRule | null> {
+  return prisma.refeedRule.findFirst({ where: { phaseId, active: true } })
+}
+
+/**
+ * Setzt die (eine) aktive Refeed-Regel einer Phase: wiederkehrende Wochentage
+ * + Refeed-SOLL. Leere Wochentagsliste deaktiviert die Regel.
+ */
+export async function saveRefeedRule(args: {
+  phaseId: string
+  recurringWeekdays: number[]
+  soll: RefeedTargets
+}): Promise<RefeedRule> {
+  const existing = await prisma.refeedRule.findFirst({ where: { phaseId: args.phaseId } })
+  const data = {
+    recurringWeekdays: args.recurringWeekdays,
+    refeedKcal: args.soll.kcal,
+    refeedProteinG: args.soll.proteinG,
+    refeedFatG: args.soll.fatG,
+    refeedCarbsG: args.soll.carbsG,
+    active: args.recurringWeekdays.length > 0,
+  }
+  if (existing) {
+    return prisma.refeedRule.update({ where: { id: existing.id }, data })
+  }
+  return prisma.refeedRule.create({ data: { phaseId: args.phaseId, ...data } })
+}

--- a/src/lib/nutrition/snapshot.test.ts
+++ b/src/lib/nutrition/snapshot.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { scaleNutrients, dishSnapshot, type NutrientSource } from './snapshot'
+
+// Magerquark je 100 g
+const QUARK: NutrientSource = {
+  kcal: 67,
+  proteinG: 12,
+  carbsG: 4,
+  fatG: 0.3,
+  calciumMg: 92,
+  sodiumMg: 40,
+  vitaminB12Ug: 0.8,
+  // restliche Mikros absichtlich weggelassen (undefined → null)
+}
+
+// Haferflocken je 100 g
+const OATS: NutrientSource = {
+  kcal: 372,
+  proteinG: 13.5,
+  carbsG: 59,
+  fatG: 7,
+  fiberG: 10,
+  ironMg: 4.6,
+}
+
+describe('scaleNutrients — Einzel-Lebensmittel', () => {
+  it('skaliert linear mit der Menge (250 g Quark)', () => {
+    const s = scaleNutrients(QUARK, 250)
+    expect(s.kcal).toBe(167.5) // 67 × 2,5
+    expect(s.proteinG).toBe(30) // 12 × 2,5
+    expect(s.carbsG).toBe(10)
+    expect(s.fatG).toBe(0.8) // 0,3 × 2,5 = 0,75 → 0,8
+    expect(s.calciumMg).toBe(230) // 92 × 2,5
+    expect(s.vitaminB12Ug).toBe(2) // 0,8 × 2,5
+  })
+
+  it('100 g = unveränderte Basiswerte', () => {
+    const s = scaleNutrients(QUARK, 100)
+    expect(s.kcal).toBe(67)
+    expect(s.proteinG).toBe(12)
+  })
+
+  it('nicht gesetzte Mikros bleiben null', () => {
+    const s = scaleNutrients(QUARK, 250)
+    expect(s.fiberG).toBeNull()
+    expect(s.ironMg).toBeNull()
+  })
+
+  it('0 g → alles 0 bzw. null', () => {
+    const s = scaleNutrients(QUARK, 0)
+    expect(s.kcal).toBe(0)
+    expect(s.proteinG).toBe(0)
+    expect(s.calciumMg).toBe(0)
+    expect(s.fiberG).toBeNull()
+  })
+})
+
+describe('dishSnapshot — Gericht (Quark + Haferflocken)', () => {
+  const components = [
+    { food: QUARK, amount: 250 }, // 167,5 kcal / 30 P / 10 KH / 0,75 F
+    { food: OATS, amount: 60 }, // 223,2 kcal / 8,1 P / 35,4 KH / 4,2 F
+  ]
+
+  it('summiert die Zutaten korrekt', () => {
+    const s = dishSnapshot(components)
+    expect(s.kcal).toBe(390.7) // 167,5 + 223,2
+    expect(s.proteinG).toBe(38.1) // 30 + 8,1
+    expect(s.carbsG).toBe(45.4) // 10 + 35,4
+    expect(s.fatG).toBe(5) // 0,75 + 4,2 = 4,95 → 5,0
+  })
+
+  it('Mikros null-bewusst: vorhandene Werte summieren, sonst null', () => {
+    const s = dishSnapshot(components)
+    // Ballaststoffe nur in Oats (10 g × 0,6 = 6), Quark liefert nichts → 6
+    expect(s.fiberG).toBe(6)
+    // Calcium nur in Quark (92 × 2,5 = 230), Oats liefert nichts → 230
+    expect(s.calciumMg).toBe(230)
+    // Eisen nur in Oats (4,6 × 0,6 = 2,76)
+    expect(s.ironMg).toBe(2.76)
+    // Magnesium in keiner Zutat → null
+    expect(s.magnesiumMg).toBeNull()
+  })
+
+  it('Portions-Multiplikator skaliert das ganze Gericht', () => {
+    const single = dishSnapshot(components, 1)
+    const dbl = dishSnapshot(components, 2)
+    expect(dbl.kcal).toBe(Math.round(single.kcal * 2 * 10) / 10)
+    expect(dbl.proteinG).toBe(Math.round(single.proteinG * 2 * 10) / 10)
+    expect(dbl.fiberG).toBe(12) // 6 × 2
+  })
+
+  it('leeres Gericht → 0/null', () => {
+    const s = dishSnapshot([])
+    expect(s.kcal).toBe(0)
+    expect(s.fiberG).toBeNull()
+  })
+})

--- a/src/lib/nutrition/snapshot.ts
+++ b/src/lib/nutrition/snapshot.ts
@@ -1,0 +1,156 @@
+// =============================================================================
+// Nährwert-Snapshot (Nutrition-Umbau, N-05)
+//
+// Reine Skalierungs-Mathematik für MealEntry-Snapshots. FoodItem-Nährwerte
+// beziehen sich auf 100 Basiseinheiten (g/ml/stück) → Faktor = Menge / 100.
+// Der berechnete Snapshot wird am MealEntry immutabel gespeichert (Katalog-
+// Korrekturen wirken nur auf zukünftige Logs).
+// =============================================================================
+
+/** Die 12 fokussierten Mikronährstoffe (Reihenfolge = FoodItem-Felder). */
+export const MICRO_KEYS = [
+  'fiberG',
+  'sugarG',
+  'saturatedFatG',
+  'sodiumMg',
+  'potassiumMg',
+  'ironMg',
+  'magnesiumMg',
+  'calciumMg',
+  'zincMg',
+  'vitaminDUg',
+  'vitaminB12Ug',
+  'vitaminCMg',
+] as const
+
+export type MicroKey = (typeof MICRO_KEYS)[number]
+
+/** Makros je 100 Basiseinheiten (Pflicht) + Mikros (nullable). */
+export interface NutrientSource {
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  fiberG?: number | null
+  sugarG?: number | null
+  saturatedFatG?: number | null
+  sodiumMg?: number | null
+  potassiumMg?: number | null
+  ironMg?: number | null
+  magnesiumMg?: number | null
+  calciumMg?: number | null
+  zincMg?: number | null
+  vitaminDUg?: number | null
+  vitaminB12Ug?: number | null
+  vitaminCMg?: number | null
+}
+
+export type NutrientSnapshot = {
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+} & Record<MicroKey, number | null>
+
+interface RawNutrients {
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  micros: Record<MicroKey, number | null>
+}
+
+const r1 = (n: number) => Math.round(n * 10) / 10
+const r2 = (n: number) => Math.round(n * 100) / 100
+
+/** Null-bewusste Addition: null + null = null, sonst als 0 behandeln. */
+function addNullable(a: number | null, b: number | null): number | null {
+  if (a == null && b == null) return null
+  return (a ?? 0) + (b ?? 0)
+}
+
+function rawScale(food: NutrientSource, amount: number): RawNutrients {
+  const f = amount / 100
+  const micros = {} as Record<MicroKey, number | null>
+  for (const k of MICRO_KEYS) {
+    const v = food[k]
+    micros[k] = v == null ? null : v * f
+  }
+  return {
+    kcal: food.kcal * f,
+    proteinG: food.proteinG * f,
+    carbsG: food.carbsG * f,
+    fatG: food.fatG * f,
+    micros,
+  }
+}
+
+function scaleRaw(raw: RawNutrients, factor: number): RawNutrients {
+  const micros = {} as Record<MicroKey, number | null>
+  for (const k of MICRO_KEYS) {
+    const v = raw.micros[k]
+    micros[k] = v == null ? null : v * factor
+  }
+  return {
+    kcal: raw.kcal * factor,
+    proteinG: raw.proteinG * factor,
+    carbsG: raw.carbsG * factor,
+    fatG: raw.fatG * factor,
+    micros,
+  }
+}
+
+function emptyRaw(): RawNutrients {
+  const micros = {} as Record<MicroKey, number | null>
+  for (const k of MICRO_KEYS) micros[k] = null
+  return { kcal: 0, proteinG: 0, carbsG: 0, fatG: 0, micros }
+}
+
+function addRaw(a: RawNutrients, b: RawNutrients): RawNutrients {
+  const micros = {} as Record<MicroKey, number | null>
+  for (const k of MICRO_KEYS) micros[k] = addNullable(a.micros[k], b.micros[k])
+  return {
+    kcal: a.kcal + b.kcal,
+    proteinG: a.proteinG + b.proteinG,
+    carbsG: a.carbsG + b.carbsG,
+    fatG: a.fatG + b.fatG,
+    micros,
+  }
+}
+
+function roundSnapshot(raw: RawNutrients): NutrientSnapshot {
+  const out = {
+    kcal: r1(raw.kcal),
+    proteinG: r1(raw.proteinG),
+    carbsG: r1(raw.carbsG),
+    fatG: r1(raw.fatG),
+  } as NutrientSnapshot
+  for (const k of MICRO_KEYS) {
+    const v = raw.micros[k]
+    out[k] = v == null ? null : r2(v)
+  }
+  return out
+}
+
+/** Einzel-Lebensmittel: Nährwerte für `amount` Basiseinheiten. */
+export function scaleNutrients(food: NutrientSource, amount: number): NutrientSnapshot {
+  return roundSnapshot(rawScale(food, amount))
+}
+
+export interface DishComponent {
+  food: NutrientSource
+  amount: number // in Basiseinheiten des FoodItems
+}
+
+/**
+ * Gericht: Summe aller Zutaten (× optionalem Portions-Multiplikator).
+ * Mikros werden null-bewusst summiert (fehlende Zutat-Werte zählen als 0,
+ * Ergebnis nur null, wenn keine Zutat den Wert liefert).
+ */
+export function dishSnapshot(components: DishComponent[], multiplier = 1): NutrientSnapshot {
+  const total = components.reduce(
+    (acc, c) => addRaw(acc, rawScale(c.food, c.amount)),
+    emptyRaw(),
+  )
+  return roundSnapshot(scaleRaw(total, multiplier))
+}

--- a/src/lib/nutrition/targets.test.ts
+++ b/src/lib/nutrition/targets.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { pickTargetsForDate } from './targets'
+
+const mk = (validFrom: string, id: string) => ({ id, validFrom: new Date(validFrom) })
+
+describe('pickTargetsForDate — Versionsauflösung (letztes validFrom ≤ Datum)', () => {
+  const versions = [
+    mk('2026-07-08', 'a'),
+    mk('2026-08-01', 'b'),
+    mk('2026-09-15', 'c'),
+  ]
+
+  it('wählt die jüngste Version, die am/vor dem Datum gilt', () => {
+    expect(pickTargetsForDate(versions, new Date('2026-08-20'))!.id).toBe('b')
+  })
+
+  it('exakt am validFrom-Tag greift diese Version', () => {
+    expect(pickTargetsForDate(versions, new Date('2026-09-15'))!.id).toBe('c')
+  })
+
+  it('vor der ersten Version → null', () => {
+    expect(pickTargetsForDate(versions, new Date('2026-07-01'))).toBeNull()
+  })
+
+  it('nach der letzten Version → jüngste Version', () => {
+    expect(pickTargetsForDate(versions, new Date('2027-01-01'))!.id).toBe('c')
+  })
+
+  it('Zeitanteil des Datums wird ignoriert (nur Kalendertag zählt)', () => {
+    expect(pickTargetsForDate(versions, new Date('2026-08-01T23:59:59Z'))!.id).toBe('b')
+  })
+
+  it('leere Liste → null', () => {
+    expect(pickTargetsForDate([], new Date('2026-08-01'))).toBeNull()
+  })
+})

--- a/src/lib/nutrition/targets.ts
+++ b/src/lib/nutrition/targets.ts
@@ -1,0 +1,70 @@
+// =============================================================================
+// NutritionTargets & Phase — DB-Zugriff und Versionsauflösung (N-02)
+//
+// NutritionTargets sind versioniert über `validFrom`. Der je Tag geltende Satz
+// ergibt sich aus dem jüngsten validFrom ≤ Tagesdatum. Die Auswahllogik ist als
+// reine Funktion (pickTargetsForDate) ausgelagert und getestet.
+// =============================================================================
+
+import type { NutritionTargets, Phase } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { zurichDayStart } from '@/lib/timezone'
+
+/** Nur Datum vergleichen (Zeitanteil ignorieren). */
+function dayValue(d: Date): number {
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+}
+
+/**
+ * Reine Auflösung: jüngster Target-Satz mit validFrom ≤ date.
+ * Erwartet eine (beliebig sortierte) Liste; gibt null zurück, wenn keiner greift.
+ */
+export function pickTargetsForDate<T extends { validFrom: Date }>(
+  targets: T[],
+  date: Date,
+): T | null {
+  const d = dayValue(date)
+  let best: T | null = null
+  for (const t of targets) {
+    if (dayValue(t.validFrom) <= d) {
+      if (!best || dayValue(t.validFrom) > dayValue(best.validFrom)) {
+        best = t
+      }
+    }
+  }
+  return best
+}
+
+/** DB-Variante: gültige Eckdaten für ein Datum (Default: heute, Europe/Zurich). */
+export async function resolveTargetsForDate(
+  date: Date = zurichDayStart(),
+): Promise<NutritionTargets | null> {
+  return prisma.nutritionTargets.findFirst({
+    where: { validFrom: { lte: date } },
+    orderBy: { validFrom: 'desc' },
+  })
+}
+
+/** Alle Target-Versionen, jüngste zuerst. */
+export function listTargetVersions(): Promise<NutritionTargets[]> {
+  return prisma.nutritionTargets.findMany({ orderBy: { validFrom: 'desc' } })
+}
+
+export type PhaseWithTargets = Phase & { targets: NutritionTargets | null }
+
+/** Aktive Phase inkl. verknüpfter Eckdaten (oder null). */
+export async function getActivePhase(): Promise<PhaseWithTargets | null> {
+  return prisma.phase.findFirst({
+    where: { status: 'ACTIVE' },
+    orderBy: { startDate: 'desc' },
+    include: { targets: true },
+  })
+}
+
+/** Alle Phasen (jüngste zuerst) inkl. Eckdaten — für die Verlaufsanzeige. */
+export function listPhases(): Promise<PhaseWithTargets[]> {
+  return prisma.phase.findMany({
+    orderBy: { startDate: 'desc' },
+    include: { targets: true },
+  })
+}

--- a/src/lib/nutrition/vision.test.ts
+++ b/src/lib/nutrition/vision.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { parseEstimate } from './vision'
+
+describe('parseEstimate — robustes JSON-Parsing der Vision-Antwort', () => {
+  it('parst sauberes JSON', () => {
+    const e = parseEstimate('{"dishName":"Pad Thai","kcal":650,"proteinG":30,"carbsG":80,"fatG":22,"confidence":0.7,"note":"grosse Portion"}')
+    expect(e.dishName).toBe('Pad Thai')
+    expect(e.kcal).toBe(650)
+    expect(e.proteinG).toBe(30)
+    expect(e.confidence).toBe(0.7)
+    expect(e.note).toBe('grosse Portion')
+  })
+
+  it('extrahiert JSON aus Markdown-/Fliesstext-Umgebung', () => {
+    const e = parseEstimate('Hier die Schätzung:\n```json\n{"dishName":"Salat","kcal":320,"proteinG":12,"carbsG":18,"fatG":20,"confidence":0.55}\n```\nViel Erfolg!')
+    expect(e.dishName).toBe('Salat')
+    expect(e.kcal).toBe(320)
+  })
+
+  it('rundet und verhindert negative Werte', () => {
+    const e = parseEstimate('{"dishName":"X","kcal":"512.37","proteinG":-5,"carbsG":40,"fatG":10,"confidence":0.5}')
+    expect(e.kcal).toBe(512.4)
+    expect(e.proteinG).toBe(0) // negativ → 0
+  })
+
+  it('klemmt Konfidenz auf 0..1', () => {
+    expect(parseEstimate('{"dishName":"X","kcal":1,"proteinG":1,"carbsG":1,"fatG":1,"confidence":1.8}').confidence).toBe(1)
+    expect(parseEstimate('{"dishName":"X","kcal":1,"proteinG":1,"carbsG":1,"fatG":1,"confidence":-2}').confidence).toBe(0)
+    expect(parseEstimate('{"dishName":"X","kcal":1,"proteinG":1,"carbsG":1,"fatG":1}').confidence).toBe(0.5) // fehlt → default
+  })
+
+  it('setzt Default-Namen bei fehlendem dishName', () => {
+    const e = parseEstimate('{"kcal":100,"proteinG":5,"carbsG":10,"fatG":3}')
+    expect(e.dishName).toBe('Geschätzte Mahlzeit')
+  })
+
+  it('wirft bei fehlendem JSON', () => {
+    expect(() => parseEstimate('Kein JSON hier.')).toThrow()
+  })
+
+  it('behält die rohe Antwort für die Speicherung (aiAnalysis)', () => {
+    const e = parseEstimate('{"dishName":"Y","kcal":200,"proteinG":8,"carbsG":20,"fatG":6,"confidence":0.6,"foo":"bar"}')
+    expect((e.raw as Record<string, unknown>).foo).toBe('bar')
+  })
+})

--- a/src/lib/nutrition/vision.ts
+++ b/src/lib/nutrition/vision.ts
@@ -1,0 +1,115 @@
+// =============================================================================
+// Foto → AI-Nährwertschätzung (Nutrition-Umbau, N-06)
+//
+// Nutzt die bestehende @anthropic-ai/sdk-Anbindung (Claude mit Vision). Bis zu
+// zwei Bilder (Teller + Speisekarte) plus optionaler Gerichtstitel → geschätzte
+// Nährwerte der GESAMTEN abgebildeten Portion als strukturiertes JSON. Der
+// Nutzer bestätigt/korrigiert anschliessend (N-06-UX), bevor geloggt wird.
+// Keys bleiben serverseitig (nur aus Route Handlers aufrufen).
+// =============================================================================
+
+import Anthropic, { APIError } from '@anthropic-ai/sdk'
+
+// Muss ein Vision-fähiges Modell sein (wie im übrigen Projekt genutzt).
+const MODEL = 'claude-sonnet-4-6'
+
+export type VisionMediaType = 'image/jpeg' | 'image/png' | 'image/webp'
+
+export interface VisionImage {
+  data: string // base64 (ohne data:-Präfix)
+  mediaType: VisionMediaType
+}
+
+export interface AiEstimate {
+  dishName: string
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  confidence: number // 0..1
+  note: string
+  raw: unknown // rohes Modell-JSON → MealPhoto.aiAnalysis
+}
+
+const SYSTEM_PROMPT = `Du bist Ernährungswissenschaftler und schätzt die Nährwerte einer Mahlzeit anhand von Fotos.
+
+Regeln:
+- Schätze die Werte für die GESAMTE abgebildete Portion (so, wie sie serviert wird), nicht pro 100 g.
+- Nutze das Speisekarten-Foto und/oder den Gerichtstitel als Hinweise, wenn vorhanden.
+- Gib eine ehrliche Konfidenz (0.0–1.0). Bei Unsicherheit trotzdem die beste Schätzung, aber niedrigere Konfidenz.
+- Antworte AUSSCHLIESSLICH mit einem einzigen minifizierten JSON-Objekt, ohne Markdown, ohne Erklärtext.
+
+JSON-Schema:
+{"dishName": string (deutsch), "kcal": number, "proteinG": number, "carbsG": number, "fatG": number, "confidence": number (0..1), "note": string (kurz, deutsch, Annahmen)}`
+
+function num(v: unknown): number {
+  const n = typeof v === 'number' ? v : parseFloat(String(v))
+  return isNaN(n) ? 0 : Math.max(0, Math.round(n * 10) / 10)
+}
+
+function clamp01(v: unknown): number {
+  const n = typeof v === 'number' ? v : parseFloat(String(v))
+  if (isNaN(n)) return 0.5
+  return Math.min(1, Math.max(0, n))
+}
+
+/** Robustes Parsen: erstes {...}-Objekt aus der Antwort extrahieren. */
+export function parseEstimate(text: string): AiEstimate {
+  const start = text.indexOf('{')
+  const end = text.lastIndexOf('}')
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('Keine JSON-Antwort vom Modell erhalten')
+  }
+  const raw = JSON.parse(text.slice(start, end + 1)) as Record<string, unknown>
+  return {
+    dishName: typeof raw.dishName === 'string' && raw.dishName.trim() ? raw.dishName.trim() : 'Geschätzte Mahlzeit',
+    kcal: num(raw.kcal),
+    proteinG: num(raw.proteinG),
+    carbsG: num(raw.carbsG),
+    fatG: num(raw.fatG),
+    confidence: clamp01(raw.confidence),
+    note: typeof raw.note === 'string' ? raw.note.trim() : '',
+    raw,
+  }
+}
+
+export interface EstimateArgs {
+  plate: VisionImage
+  menu?: VisionImage | null
+  title?: string | null
+}
+
+export async function estimateFromPhotos({ plate, menu, title }: EstimateArgs): Promise<AiEstimate> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY nicht konfiguriert')
+  }
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+  const content: Anthropic.MessageParam['content'] = [
+    { type: 'text', text: 'Teller-Foto der Mahlzeit:' },
+    { type: 'image', source: { type: 'base64', media_type: plate.mediaType, data: plate.data } },
+  ]
+  if (menu) {
+    content.push({ type: 'text', text: 'Speisekarten-Foto (Kontext):' })
+    content.push({ type: 'image', source: { type: 'base64', media_type: menu.mediaType, data: menu.data } })
+  }
+  if (title && title.trim()) {
+    content.push({ type: 'text', text: `Gerichtstitel: ${title.trim()}` })
+  }
+  content.push({ type: 'text', text: 'Antworte nur mit dem JSON-Objekt.' })
+
+  try {
+    const message = await client.messages.create({
+      model: MODEL,
+      max_tokens: 500,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content }],
+    })
+    const block = message.content[0]
+    if (!block || block.type !== 'text') throw new Error('Unerwartete API-Antwort')
+    return parseEstimate(block.text)
+  } catch (e) {
+    if (e instanceof APIError) throw new Error(`Claude API Fehler: ${e.message}`)
+    throw e
+  }
+}


### PR DESCRIPTION
## Beschreibung

Additiver Aufbau des neuen Nutrition-Tracking-Systems gemäss Notion-Spec (MVP-1). Ersetzt perspektivisch das Score-System durch echtes Ernährungs-Tracking (Kaloriendefizit erreicht = Tag erfüllt). **Dieser PR ist rein additiv** — das bestehende Score-System (`MealLog`/`MealPlan`/`NutritionLevel`) bleibt unangetastet und läuft parallel weiter. Der destruktive Score-Rückbau ist bewusst **nicht** enthalten (folgt separat als N-09 mit DB-Backup).

Enthaltene Arbeitspakete:

- **N-01 – Schema-Fundament:** 10 neue Prisma-Modelle (FoodItem, Dish, DishItem, Favorite, MealEntry, MealPhoto, Day, Phase, NutritionTargets, RefeedRule) + 8 Enums, additive Migration, Seed (erste Eckdaten 2301/185/51/275 + aktive Defizit-Phase).
- **N-02 – Eckdaten & Phase:** reine Fibel-Rechenlogik (BMR HB #1/#2 → TDEE → Defizit → Makros, FFM-Protein-Korrektur), versionierte Targets (Auflösung nach validFrom), Owner-UI `/admin/nutrition` mit Live-Vorschau.
- **N-03 – Food-Katalog + Open Food Facts:** Provider-Interface, OFF-Mapping (Einheitenumrechnung), FoodItem-CRUD mit Barcode-Dedup, serverseitige Route-Handler, Admin-Katalog `/admin/food`.
- **N-04 – Barcode-Scan:** `@zxing/browser` (Rückkamera, SSR-sicher), Fallback manuelle Eingabe, in den Katalog eingebunden.
- **N-05 – Logging + Favoriten/Gerichte:** immutable Nährwert-Snapshots, Dish/DishItem, Favoriten (1-Klick), mobiles Quick-Add `/admin/log`, Gerichte-Verwaltung `/admin/dishes`.
- **N-06 – Foto→AI:** Anthropic-Vision-Endpoint (bis zu 2 Fotos + Titel → JSON), Bestätigen/Korrigieren-UX, MealPhoto-Storage (privat, geschützte Auslieferung).
- **N-07 – Tag & Erfüllung:** Tages-Aggregation (IST), SOLL-Snapshot, tag-typ-abhängige Erfüllung (±5 %, Defizit vs. Band), Refeed-Tage (wiederkehrende Wochentage + ad-hoc), Tagesansicht mit Status-Badge.
- **N-08 – Öffentliche Kopplung:** öffentliche Ernährungs-Säule wird aus `Day.fulfillmentStatus` abgeleitet (Vorrang vor Legacy-Score/Enum, Fallback für Alt-Tage). Join liest nur date + status — keine Detail-/Privatdaten.

## Verknüpftes Issue

Kein GitHub-Issue — Umsetzung nach Notion-Spec „Architektur & Datenmodell (Nutrition-Umbau)", MVP-1. N-09 (Score-Rückbau, Big-Bang) folgt in einem separaten PR mit vorgeschaltetem DB-Backup.

## Art der Änderung

- [ ] 🐛 Bug Fix
- [x] ✨ Neues Feature
- [ ] 🔧 Refactoring
- [ ] 📝 Dokumentation
- [ ] 🎨 Styling
- [ ] ⚡ Performance
- [x] 🧪 Tests
- [ ] 🔨 Chore (Dependencies, Config, etc.)

## Checkliste

- [x] Code folgt den Projektkonventionen (CLAUDE.md)
- [x] TypeScript kompiliert ohne Fehler (`pnpm type-check`)
- [x] Linting bestanden (`pnpm lint` — nur pre-existing Font-Warnings in `layout.tsx`)
- [x] Tests geschrieben und bestanden (`pnpm test` — 178 Tests grün; zusätzlich DB-Integrations- und Build-Checks)
- [ ] Responsive getestet (Mobile + Desktop) — mobile-first gebaut; realer Geräte-/Kamera-Test (Scanner, Foto) steht auf dem Handy gegen die Produktions-Domain aus
- [x] Prisma-Migration erstellt (`20260710063721_add_nutrition_foundation`, rein additiv: 10 CREATE TABLE, 8 CREATE TYPE, kein ALTER/DROP an Bestandstabellen)
- [ ] Umgebungsvariablen dokumentiert — keine neuen Variablen; genutzt werden bestehende `ANTHROPIC_API_KEY` (Foto→AI) und `DATABASE_URL`

## Hinweise zum Deploy

- Rein additiv → sicher zu mergen/deployen, während das alte Score-System weiterläuft.
- Neue Admin-Bereiche: `/admin/log`, `/admin/nutrition`, `/admin/food`, `/admin/dishes` (nur DE, Owner).
- Foto→AI benötigt `ANTHROPIC_API_KEY` zur Laufzeit; Open Food Facts benötigt ausgehenden Zugriff auf `world.openfoodfacts.org` (in der Build-Sandbox durch Egress-Policy geblockt — auf pilab01 zu bestätigen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzGTUQVE1ZWHA3aAmNCNrq)_