### PR TITLE
fix(nutrition): OPEN-Tage neutral behandeln (Ernährungs-Quote startet neu)

### DIFF
--- a/src/components/habits/HabitsDashboard.tsx
+++ b/src/components/habits/HabitsDashboard.tsx
@@ -3,7 +3,7 @@ import { getAllEntries } from '@/lib/journal'
 import { getProjectStartDate } from '@/lib/project-config'
 import {
   isMovementFulfilled,
-  isNutritionFulfilled,
+  nutritionOutcome,
   isSmokingFulfilled,
   getMovementLevel,
   getNutritionLevel,
@@ -46,7 +46,13 @@ export async function HabitsDashboard() {
     const e = entryMap.get(date)
     return {
       date,
-      level: e ? (e.sickDay ? SICK_LEVEL : getNutritionLevel(e.habits.nutrition, e.nutritionStatus)) : -1,
+      level: e
+        ? (e.sickDay
+            ? SICK_LEVEL
+            : nutritionOutcome(e.habits.nutrition, e.nutritionStatus) === null
+              ? -1 // neutral/offen — kein Food-Logging → leere Zelle
+              : getNutritionLevel(e.habits.nutrition, e.nutritionStatus))
+        : -1,
     }
   })
   const smokingDays = allDates.map((date) => {
@@ -60,8 +66,15 @@ export async function HabitsDashboard() {
   // Krankheitstage zählen weder in Zähler noch Nenner der Erfüllungsquoten
   const activeEntries = entries.filter((e) => !e.sickDay)
   const movementFulfilled = activeEntries.filter((e) => isMovementFulfilled(e.habits.movement)).length
-  const nutritionFulfilled = activeEntries.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.nutritionStatus)).length
   const smokingFulfilled = activeEntries.filter((e) => isSmokingFulfilled(e.habits.smoking)).length
+  // Ernährung: neutrale/offene Tage (kein Food-Logging) zählen weder in Zähler
+  // noch Nenner — daher eigener Nenner.
+  const nutritionActive = activeEntries.filter(
+    (e) => nutritionOutcome(e.habits.nutrition, e.nutritionStatus) !== null,
+  )
+  const nutritionFulfilled = nutritionActive.filter(
+    (e) => nutritionOutcome(e.habits.nutrition, e.nutritionStatus) === true,
+  ).length
 
   // Letzte 30 Tage (Tage mit Eintrag, max 30 jüngste)
   const cutoff = new Date()
@@ -70,8 +83,14 @@ export async function HabitsDashboard() {
   const recent = activeEntries.filter((e) => e.date >= cutoffISO)
   const recentTotal = recent.length
   const movementRecent = recent.filter((e) => isMovementFulfilled(e.habits.movement)).length
-  const nutritionRecent = recent.filter((e) => isNutritionFulfilled(e.habits.nutrition, e.nutritionStatus)).length
   const smokingRecent = recent.filter((e) => isSmokingFulfilled(e.habits.smoking)).length
+  // Ernährung 30 T: eigener Nenner (neutrale Tage raus)
+  const nutritionRecentActive = recent.filter(
+    (e) => nutritionOutcome(e.habits.nutrition, e.nutritionStatus) !== null,
+  )
+  const nutritionRecent = nutritionRecentActive.filter(
+    (e) => nutritionOutcome(e.habits.nutrition, e.nutritionStatus) === true,
+  ).length
 
   return (
     <section className="mb-14 space-y-6">
@@ -98,9 +117,9 @@ export async function HabitsDashboard() {
         <HabitPillar
           pillar="nutrition"
           totalFulfilled={nutritionFulfilled}
-          totalEntries={activeEntries.length}
+          totalEntries={nutritionActive.length}
           recentFulfilled={nutritionRecent}
-          recentTotal={recentTotal}
+          recentTotal={nutritionRecentActive.length}
         />
         <HabitPillar
           pillar="smoking"

--- a/src/components/home/LiveStatus.tsx
+++ b/src/components/home/LiveStatus.tsx
@@ -7,7 +7,7 @@ import {
   calculateSweetsStreak,
   computeSweetsRate30d,
   isMovementFulfilled,
-  isNutritionFulfilled,
+  nutritionOutcome,
   isSmokingFulfilled,
 } from '@/lib/habits'
 import {
@@ -555,16 +555,20 @@ export async function LiveStatus() {
   ])
 
   const movementBools  = entries.map((e) => isMovementFulfilled(e.habits.movement))
-  const nutritionBools = entries.map((e) => isNutritionFulfilled(e.habits.nutrition, e.nutritionStatus))
   const smokingBools   = entries.map((e) => isSmokingFulfilled(e.habits.smoking))
+  // Ernährung: neutrale/offene Tage (kein Food-Logging) fliegen ganz raus.
+  const nutritionBools = entries
+    .map((e) => nutritionOutcome(e.habits.nutrition, e.nutritionStatus))
+    .filter((v): v is boolean => v !== null)
 
   const totalEntries = entries.length
+  const nutritionTotal = nutritionBools.length
   const movementFulfilled  = movementBools.filter(Boolean).length
   const nutritionFulfilled = nutritionBools.filter(Boolean).length
   const smokingFulfilled   = smokingBools.filter(Boolean).length
 
   const movementOverallPct  = totalEntries > 0 ? Math.round(movementFulfilled  / totalEntries * 100) : 0
-  const nutritionOverallPct = totalEntries > 0 ? Math.round(nutritionFulfilled / totalEntries * 100) : 0
+  const nutritionOverallPct = nutritionTotal > 0 ? Math.round(nutritionFulfilled / nutritionTotal * 100) : 0
   const smokingOverallPct   = totalEntries > 0 ? Math.round(smokingFulfilled   / totalEntries * 100) : 0
 
   const movementRates  = computeRates(movementBools)
@@ -572,6 +576,7 @@ export async function LiveStatus() {
   const smokingRates   = computeRates(smokingBools)
 
   const recent30Total = Math.min(30, totalEntries)
+  const nutritionRecent30Total = Math.min(30, nutritionTotal)
 
   const sweetsStreak  = calculateSweetsStreak(sweetsHistory)
   const sweetsRate30d = computeSweetsRate30d(sweetsHistory)
@@ -625,8 +630,8 @@ export async function LiveStatus() {
           colorAccent="text-nutrition-400"
           strokeClass="stroke-nutrition-400"
           labelAchieved={t('pillarAchieved')}
-          outOfDaysText={t('pillarOutOfDays', { fulfilled: nutritionFulfilled, total: totalEntries })}
-          last30Text={recent30Total > 0 ? t('pillarLast30', { pct: nutritionRates.pct30d }) : undefined}
+          outOfDaysText={t('pillarOutOfDays', { fulfilled: nutritionFulfilled, total: nutritionTotal })}
+          last30Text={nutritionRecent30Total > 0 ? t('pillarLast30', { pct: nutritionRates.pct30d }) : undefined}
           isPriority={priorityPillar === 'nutrition'}
           pillarKey="nutrition"
         />

--- a/src/lib/habits.test.ts
+++ b/src/lib/habits.test.ts
@@ -3,6 +3,7 @@ import { MovementLevel, SmokingStatus } from '@prisma/client'
 import {
   isMovementFulfilled,
   isNutritionFulfilled,
+  nutritionOutcome,
   isSmokingFulfilled,
   getNutritionLevel,
   calculateStreak,
@@ -197,8 +198,8 @@ describe('isNutritionFulfilled — nutritionStatus-Vorrang', () => {
   it('NOT_FULFILLED gewinnt über den gespeicherten Wert', () => {
     expect(isNutritionFulfilled('fulfilled', 'NOT_FULFILLED')).toBe(false)
   })
-  it('OPEN/null fällt auf den gespeicherten Wert zurück', () => {
-    expect(isNutritionFulfilled('fulfilled', 'OPEN')).toBe(true)
+  it('expliziter OPEN-Status = neutral → nicht erfüllt; null fällt auf gespeicherten Wert zurück', () => {
+    expect(isNutritionFulfilled('fulfilled', 'OPEN')).toBe(false) // OPEN = neutral (Option C)
     expect(isNutritionFulfilled('fulfilled', null)).toBe(true)
     expect(isNutritionFulfilled('not_fulfilled', null)).toBe(false)
   })
@@ -213,5 +214,25 @@ describe('getNutritionLevel — binär (N-09)', () => {
     expect(getNutritionLevel('fulfilled')).toBe(3)
     expect(getNutritionLevel('not_fulfilled')).toBe(0)
     expect(getNutritionLevel('open')).toBe(0)
+  })
+})
+
+// =============================================
+// nutritionOutcome — Drei-Zustand (Option C: OPEN = neutral)
+// =============================================
+describe('nutritionOutcome', () => {
+  it('Day-Status hat Vorrang: FULFILLED→true, NOT_FULFILLED→false, OPEN→null', () => {
+    expect(nutritionOutcome('not_fulfilled', 'FULFILLED')).toBe(true)
+    expect(nutritionOutcome('fulfilled', 'NOT_FULFILLED')).toBe(false)
+    expect(nutritionOutcome('fulfilled', 'OPEN')).toBeNull()
+  })
+  it('ohne Day-Status: gespeicherter Wert (open → neutral null)', () => {
+    expect(nutritionOutcome('fulfilled')).toBe(true)
+    expect(nutritionOutcome('not_fulfilled')).toBe(false)
+    expect(nutritionOutcome('open')).toBeNull()
+  })
+  it('isNutritionFulfilled = outcome===true (neutral zählt als false)', () => {
+    expect(isNutritionFulfilled('open')).toBe(false)
+    expect(isNutritionFulfilled('fulfilled')).toBe(true)
   })
 })

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -13,17 +13,32 @@ export function isMovementFulfilled(movement: MovementValue): boolean {
 }
 
 /**
- * Ernährungsziel erfüllt (Nutrition-Umbau, N-09): Kaloriendefizit erreicht.
+ * Ernährungs-Ergebnis eines Tages als Drei-Zustand (Nutrition-Umbau):
+ *   true  = erfüllt (Kaloriendefizit erreicht)
+ *   false = nicht erfüllt
+ *   null  = neutral/offen — kein Food-Logging vorhanden (zählt weder in Zähler
+ *           noch Nenner der Quoten, pausiert Streaks, wie ein Kranktag)
  * `nutritionStatus` aus dem neuen System (Day.fulfillmentStatus) hat Vorrang;
- * ohne Tages-Log greift der am Eintrag gespeicherte Status (`fulfilled`).
+ * ohne Tages-Log greift der gespeicherte Status (`fulfilled`/`not_fulfilled`/`open`).
  */
+export function nutritionOutcome(
+  nutrition: NutritionValue,
+  nutritionStatus?: FulfillmentStatus | null,
+): boolean | null {
+  if (nutritionStatus === 'FULFILLED') return true
+  if (nutritionStatus === 'NOT_FULFILLED') return false
+  if (nutritionStatus === 'OPEN') return null
+  if (nutrition === 'fulfilled') return true
+  if (nutrition === 'not_fulfilled') return false
+  return null // 'open' → neutral
+}
+
+/** Erfüllt-Prädikat für Einzelanzeigen (neutral zählt als „nicht erfüllt"-Badge). */
 export function isNutritionFulfilled(
   nutrition: NutritionValue,
   nutritionStatus?: FulfillmentStatus | null,
 ): boolean {
-  if (nutritionStatus === 'FULFILLED') return true
-  if (nutritionStatus === 'NOT_FULFILLED') return false
-  return nutrition === 'fulfilled'
+  return nutritionOutcome(nutrition, nutritionStatus) === true
 }
 
 export function isSmokingFulfilled(smoking: SmokingValue): boolean {
@@ -133,7 +148,7 @@ export async function getMovementStreak(): Promise<StreakResult> {
 export async function getNutritionStreak(): Promise<StreakResult> {
   const entries = await getAllEntries()
   return calculateStreak(
-    entries.map((e) => (e.sickDay ? null : isNutritionFulfilled(e.habits.nutrition, e.nutritionStatus))),
+    entries.map((e) => (e.sickDay ? null : nutritionOutcome(e.habits.nutrition, e.nutritionStatus))),
   )
 }
 


### PR DESCRIPTION
## Beschreibung

Fixt die zu hohe Ernährungs-Quote (78 %) nach dem N-09-Cutover. Historische Tage haben keine Kaloriendefizit-Daten und dürfen die öffentliche Quote nicht aufblähen.

**Umsetzung von „Option C" (historisch = neutral):** Ein neuer Drei-Zustand `nutritionOutcome` (`true` / `false` / `null` = neutral). **OPEN** (bzw. ein Day-Status `OPEN`) zählt jetzt **neutral** — fliegt aus **Zähler und Nenner** der Ernährungs-Quote (wie ein Kranktag), **pausiert den Streak** und wird als **leere Heatmap-Zelle** dargestellt. Die Quote baut sich damit ab dem ersten echten Food-Logging neu auf.

### Code
- `habits.ts`: `nutritionOutcome()`; `isNutritionFulfilled = outcome===true`; `getNutritionStreak` pausiert bei neutral.
- `HabitsDashboard`: Nutrition-Säule hat eigenen Nenner (nur Tage mit Logging); neutrale Tage → leere Heatmap-Zelle.
- `LiveStatus`: Ernährungs-Prozent/Rate nur über geloggte Tage.
- Tests aktualisiert + `nutritionOutcome`-Coverage (**168 grün**).

## ⚠️ Gehört dazu: einmaliges Daten-Update (nach dem Deploy)

Die migrierten historischen Werte müssen auf `OPEN` gesetzt werden, damit sie neutral zählen. Auf pilab01 (`cd /container/project365blog/app`), **nach** dem Deploy dieses PRs:

```bash
docker compose exec -T db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
UPDATE "JournalEntry" j SET nutrition = 'OPEN'
WHERE NOT EXISTS (
  SELECT 1 FROM "Day" d
  WHERE d.date = j.date AND d."fulfillmentStatus" IN ('FULFILLED','NOT_FULFILLED')
);
SQL
```

(Setzt nur Tage ohne echtes Food-Logging auf OPEN — echte Log-Tage bleiben.) Danach zeigt die Ernährungs-Säule „0 / 0" bzw. 0 % und wächst mit jedem geloggten Tag. Die Scratch-DB `p365_old` vom Backfill-Versuch kannst du löschen (`DROP DATABASE p365_old;`).

## Checkliste

- [x] `pnpm type-check` (0 Fehler) · [x] `pnpm lint` · [x] `pnpm test` (168 grün) · [x] Production-Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzGTUQVE1ZWHA3aAmNCNrq)_