### PR TITLE
feat(nutrition): Foto-Galerie-Auswahl + Ampel-Farben in der Tagesbilanz

### DIFF
--- a/src/components/nutrition/MealLogger.tsx
+++ b/src/components/nutrition/MealLogger.tsx
@@ -9,6 +9,20 @@ import type { FavoriteResolved } from '@/lib/nutrition/favorites'
 import type { DishWithItems } from '@/lib/nutrition/dishes'
 import type { DaySummary } from '@/lib/nutrition/day-aggregate'
 import { aggregateMicros, microCoverage, MICRO_META } from '@/lib/nutrition/micros'
+import { kcalTone, proteinTone, budgetTone, type Tone } from '@/lib/nutrition/traffic-light'
+
+// Tailwind-Klassen je Ampel-Tone — hier (im gescannten Component-Ordner) statt
+// in lib/, damit der Tailwind-Content-Scan sie nicht wegpurged.
+const TONE_TEXT: Record<Tone, string> = {
+  good: 'text-movement-400',
+  warn: 'text-amber-400',
+  bad: 'text-error',
+}
+const TONE_DOT: Record<Tone, string> = {
+  good: 'bg-movement-400',
+  warn: 'bg-amber-400',
+  bad: 'bg-error',
+}
 import { BarcodeScanner } from '@/components/nutrition/BarcodeScanner'
 import { PhotoEstimator } from '@/components/nutrition/PhotoEstimator'
 import {
@@ -371,10 +385,18 @@ export function MealLogger({ date, entries, favorites, dishes, summary }: Props)
 
         {soll ? (
           <div className="grid grid-cols-4 gap-2 text-center">
-            <Macro label="kcal" ist={ist.kcal} soll={soll.kcal} accent />
-            <Macro label="Protein" ist={ist.proteinG} soll={soll.proteinG} unit="g" />
-            <Macro label="KH" ist={ist.carbsG} soll={soll.carbsG} unit="g" />
-            <Macro label="Fett" ist={ist.fatG} soll={soll.fatG} unit="g" />
+            {(() => {
+              const isDeficitDay = summary.phaseMode === 'DEFICIT' && !summary.isRefeed
+              const hasEntries = ist.count > 0
+              return (
+                <>
+                  <Macro label="kcal" ist={ist.kcal} soll={soll.kcal} tone={hasEntries ? kcalTone(ist.kcal, soll.kcal, isDeficitDay) : undefined} />
+                  <Macro label="Protein" ist={ist.proteinG} soll={soll.proteinG} unit="g" tone={hasEntries ? proteinTone(ist.proteinG, soll.proteinG) : undefined} />
+                  <Macro label="KH" ist={ist.carbsG} soll={soll.carbsG} unit="g" tone={hasEntries ? budgetTone(ist.carbsG, soll.carbsG, isDeficitDay) : undefined} />
+                  <Macro label="Fett" ist={ist.fatG} soll={soll.fatG} unit="g" tone={hasEntries ? budgetTone(ist.fatG, soll.fatG, isDeficitDay) : undefined} />
+                </>
+              )
+            })()}
           </div>
         ) : (
           <p className="text-sm text-on-surface-variant">
@@ -408,14 +430,18 @@ export function MealLogger({ date, entries, favorites, dishes, summary }: Props)
 }
 
 function Macro({
-  label, ist, soll, unit = '', accent,
+  label, ist, soll, unit = '', tone,
 }: {
-  label: string; ist: number; soll: number; unit?: string; accent?: boolean
+  label: string; ist: number; soll: number; unit?: string; tone?: Tone
 }) {
+  const valueColor = tone ? TONE_TEXT[tone] : 'text-on-surface'
   return (
     <div className="rounded-xl bg-surface-container-high py-2">
-      <p className="text-[10px] uppercase tracking-widest text-on-surface-variant">{label}</p>
-      <p className={`text-sm font-bold tabular-nums ${accent ? 'text-primary' : 'text-on-surface'}`}>{ist}</p>
+      <div className="flex items-center justify-center gap-1">
+        <span className={`inline-block w-1.5 h-1.5 rounded-full ${tone ? TONE_DOT[tone] : 'bg-outline-variant/40'}`} aria-hidden="true" />
+        <p className="text-[10px] uppercase tracking-widest text-on-surface-variant">{label}</p>
+      </div>
+      <p className={`text-sm font-bold tabular-nums ${valueColor}`}>{ist}</p>
       <p className="text-[10px] text-on-surface-variant tabular-nums">/ {soll}{unit}</p>
     </div>
   )

--- a/src/components/nutrition/PhotoEstimator.tsx
+++ b/src/components/nutrition/PhotoEstimator.tsx
@@ -127,14 +127,14 @@ export function PhotoEstimator({ date, mealSlot, onLogged }: Props) {
           <label className="block text-xs font-medium text-on-surface-variant mb-1">
             Teller-Foto *
           </label>
-          <input ref={plateRef} type="file" accept="image/jpeg,image/png,image/webp" capture="environment"
+          <input ref={plateRef} type="file" accept="image/jpeg,image/png,image/webp"
             className="block w-full text-xs text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-xs file:bg-surface-container-high file:text-on-surface" />
         </div>
         <div>
           <label className="block text-xs font-medium text-on-surface-variant mb-1">
             Speisekarte (optional)
           </label>
-          <input ref={menuRef} type="file" accept="image/jpeg,image/png,image/webp" capture="environment"
+          <input ref={menuRef} type="file" accept="image/jpeg,image/png,image/webp"
             className="block w-full text-xs text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-xs file:bg-surface-container-high file:text-on-surface" />
         </div>
       </div>

--- a/src/lib/nutrition/traffic-light.test.ts
+++ b/src/lib/nutrition/traffic-light.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { kcalTone, proteinTone, budgetTone } from './traffic-light'
+
+describe('kcalTone', () => {
+  it('deficit: under target is good, within +5% is warn, over is bad', () => {
+    expect(kcalTone(1800, 2000, true)).toBe('good')
+    expect(kcalTone(2000, 2000, true)).toBe('good')
+    expect(kcalTone(2080, 2000, true)).toBe('warn') // +4%
+    expect(kcalTone(2200, 2000, true)).toBe('bad') // +10%
+  })
+
+  it('non-deficit: symmetric band around target', () => {
+    expect(kcalTone(2000, 2000, false)).toBe('good')
+    expect(kcalTone(1850, 2000, false)).toBe('warn') // -7.5%
+    expect(kcalTone(1700, 2000, false)).toBe('bad') // -15%
+    expect(kcalTone(2150, 2000, false)).toBe('warn') // +7.5%
+  })
+
+  it('no target -> warn', () => {
+    expect(kcalTone(1000, 0, true)).toBe('warn')
+  })
+})
+
+describe('proteinTone', () => {
+  it('hitting or exceeding the target is good', () => {
+    expect(proteinTone(185, 185)).toBe('good')
+    expect(proteinTone(220, 185)).toBe('good') // over is fine
+    expect(proteinTone(170, 185)).toBe('good') // 92%
+  })
+  it('moderately under is warn, far under is bad', () => {
+    expect(proteinTone(140, 185)).toBe('warn') // 76%
+    expect(proteinTone(90, 185)).toBe('bad') // 49%
+  })
+})
+
+describe('budgetTone', () => {
+  it('deficit: under or near budget is good, moderately over warn, far over bad', () => {
+    expect(budgetTone(200, 275, true)).toBe('good')
+    expect(budgetTone(280, 275, true)).toBe('good') // +2%
+    expect(budgetTone(310, 275, true)).toBe('warn') // +13%
+    expect(budgetTone(360, 275, true)).toBe('bad') // +31%
+  })
+  it('non-deficit: symmetric band', () => {
+    expect(budgetTone(275, 275, false)).toBe('good')
+    expect(budgetTone(240, 275, false)).toBe('warn') // -13%
+    expect(budgetTone(180, 275, false)).toBe('bad') // -35%
+  })
+})

--- a/src/lib/nutrition/traffic-light.ts
+++ b/src/lib/nutrition/traffic-light.ts
@@ -1,0 +1,59 @@
+// =============================================================================
+// Ampel-Indikator für die Tagesbilanz (Loggen-Seite).
+//
+// Reine, testbare Bewertung IST vs. SOLL je Kennzahl — bewusst tag-typ- und
+// nährstoff-abhängig, damit die Farbe nicht in die Irre führt:
+//   • kcal   → Erfüllungslogik: Defizit „unter SOLL = gut", sonst ±5 %-Band
+//   • Protein→ Zieluntergrenze („mehr ist besser", Ziel erreichen)
+//   • KH/Fett→ im Defizit Budget/Obergrenze („unter = gut"), sonst ±-Band
+//
+// Grün = im Ziel, Gelb = knapp daneben (Toleranz), Rot = klar daneben.
+// =============================================================================
+
+export type Tone = 'good' | 'warn' | 'bad'
+
+/** Toleranzband der Erfüllung (±5 %), analog fulfillment.ts. */
+const TOL = 0.05
+
+/** kcal-Ampel, tag-typ-abhängig (isDeficitDay = Phase DEFICIT und kein Refeed). */
+export function kcalTone(ist: number, soll: number, isDeficitDay: boolean): Tone {
+  if (soll <= 0) return 'warn'
+  if (isDeficitDay) {
+    if (ist <= soll) return 'good'
+    if (ist <= soll * (1 + TOL)) return 'warn'
+    return 'bad'
+  }
+  const dev = Math.abs(ist - soll) / soll
+  if (dev <= TOL) return 'good'
+  if (dev <= 2 * TOL) return 'warn'
+  return 'bad'
+}
+
+/** Protein: Zieluntergrenze — Ziel treffen/überschreiten ist gut. */
+export function proteinTone(ist: number, soll: number): Tone {
+  if (soll <= 0) return 'warn'
+  const ratio = ist / soll
+  if (ratio >= 0.9) return 'good'
+  if (ratio >= 0.7) return 'warn'
+  return 'bad'
+}
+
+/**
+ * KH/Fett: im Defizit als Budget/Obergrenze („unter oder nah = gut"),
+ * sonst symmetrisches Nähe-Band ums SOLL.
+ */
+export function budgetTone(ist: number, soll: number, isDeficitDay: boolean): Tone {
+  if (soll <= 0) return 'warn'
+  if (isDeficitDay) {
+    if (ist <= soll * (1 + TOL)) return 'good'
+    if (ist <= soll * (1 + 3 * TOL)) return 'warn'
+    return 'bad'
+  }
+  const dev = Math.abs(ist - soll) / soll
+  if (dev <= 2 * TOL) return 'good'
+  if (dev <= 5 * TOL) return 'warn'
+  return 'bad'
+}
+
+// Hinweis: Die Tailwind-Klassen je Tone werden bewusst in der Komponente
+// (src/components/…) gehalten — nur dort greift der Tailwind-Content-Scan.


### PR DESCRIPTION
## Beschreibung

Zwei Quick Wins aus dem Feedback nach dem ersten Erfassungstag.

**Punkt 1 — Fotos aus der Galerie wählbar**
`PhotoEstimator`: `capture="environment"` an Teller- und Menü-Foto-Input entfernt. iOS erzwingt dadurch nicht mehr die Kamera, sondern bietet das Auswahl-Sheet „Fotomediathek / Foto aufnehmen / Datei wählen" — Restaurant-Fotos lassen sich jetzt aus der Galerie auswählen (Kamera weiterhin verfügbar).

**Punkt 3 — Ampel-Farben in der Tagesbilanz (Loggen-Seite)**
Jede Kennzahl-Kachel bekommt einen Ampel-Ton (grün/gelb/rot) + Punkt für den Status auf einen Blick. Die Semantik ist bewusst tag-typ- und nährstoff-abhängig, damit die Farbe nicht in die Irre führt:
- **kcal** → Erfüllungslogik: im Defizit „unter SOLL = grün", bis +5 % gelb, drüber rot; Erhalt/Refeed = ±5 %-Band
- **Protein** → Zieluntergrenze: Ziel treffen/überschreiten = grün (über SOLL ist gut)
- **KH/Fett** → im Defizit Budget/Obergrenze („unter/nah = grün"), sonst symmetrisches Band
- Neutral, solange der Tag noch keine Einträge hat

Reine Tone-Logik in `lib/nutrition/traffic-light.ts` (getestet); die Tailwind-Klassen-Maps liegen bewusst in der Komponente, damit der Tailwind-Content-Scan (`src/lib` ist nicht in den content-Globs) sie nicht wegpurged — im Build-CSS verifiziert.

## Verknüpftes Issue

Kein GitHub-Issue — direktes Feedback aus der Nutzung (Foto-Auswahl & Statusfarben).

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Code folgt den Projektkonventionen (CLAUDE.md)
- [x] TypeScript kompiliert ohne Fehler (`pnpm type-check`)
- [x] Linting bestanden (`pnpm lint`)
- [x] Tests geschrieben und bestanden (`pnpm test` — 193 grün, 7 neu)
- [ ] Responsive getestet (Mobile + Desktop) — Foto-Auswahl vor allem auf iPhone im Deploy zu sichten
- [x] Prisma-Migration erstellt (falls Schema geändert) — n. z., keine Schema-Änderung
- [x] Umgebungsvariablen dokumentiert (falls neue hinzugefügt) — n. z., keine neuen

## Screenshots

<!-- Tagesbilanz mit Ampel-Tönen; iOS-Foto-Auswahl-Sheet -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oFcbRQcQSKzFR3XNXX6RX

---
_Generated by [Claude Code](https://claude.ai/code/session_017oFcbRQcQSKzFR3XNXX6RX)_