### PR TITLE
feat(nutrition): Speisekarten-Foto vor der AI-Schätzung zuschneiden

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "papaparse": "^5.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-image-crop": "^11.1.2",
     "recharts": "^2.13.3",
     "rehype-highlight": "^7.0.1",
     "remark-gfm": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-image-crop:
+        specifier: ^11.1.2
+        version: 11.1.2(react@18.3.1)
       recharts:
         specifier: ^2.13.3
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3392,6 +3395,11 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-image-crop@11.1.2:
+    resolution: {integrity: sha512-+0Pc2fxpwKL4u4oLmdKBw8XSwUceFbXbKEHvFOlsl/MGB1OVNic4uBlAPmEHGXYgoJIq+b63xHbc/aJMG0AVkA==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -7746,6 +7754,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-image-crop@11.1.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 

--- a/src/components/nutrition/MenuCropModal.tsx
+++ b/src/components/nutrition/MenuCropModal.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import ReactCrop, { type Crop, type PixelCrop } from 'react-image-crop'
+import 'react-image-crop/dist/ReactCrop.css'
+import { computeCropRect } from '@/lib/nutrition/crop'
+
+interface Props {
+  file: File
+  onCancel: () => void
+  onCropped: (file: File) => void
+}
+
+/**
+ * Zuschneide-Modal fürs Speisekarten-Foto (Punkt 2). Der Nutzer wählt nur das
+ * relevante Gericht aus; das clientseitig zugeschnittene Bild ersetzt das
+ * Menü-Foto für die AI-Schätzung (schärferer Kontext, weniger Verwirrung).
+ */
+export function MenuCropModal({ file, onCancel, onCropped }: Props) {
+  const [url] = useState(() => URL.createObjectURL(file))
+  const imgRef = useRef<HTMLImageElement>(null)
+  const [crop, setCrop] = useState<Crop>()
+  const [completed, setCompleted] = useState<PixelCrop>()
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    return () => URL.revokeObjectURL(url)
+  }, [url])
+
+  function close() {
+    onCancel()
+  }
+
+  function apply() {
+    const image = imgRef.current
+    if (!image || !completed || completed.width === 0 || completed.height === 0) return
+    setBusy(true)
+
+    const rect = computeCropRect(
+      { x: completed.x, y: completed.y, width: completed.width, height: completed.height },
+      {
+        naturalWidth: image.naturalWidth,
+        naturalHeight: image.naturalHeight,
+        displayWidth: image.width,
+        displayHeight: image.height,
+      },
+    )
+
+    const canvas = document.createElement('canvas')
+    canvas.width = rect.outW
+    canvas.height = rect.outH
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      setBusy(false)
+      return
+    }
+    ctx.drawImage(image, rect.sx, rect.sy, rect.sw, rect.sh, 0, 0, rect.outW, rect.outH)
+
+    canvas.toBlob(
+      (blob) => {
+        setBusy(false)
+        if (!blob) return
+        const base = file.name.replace(/\.[^.]+$/, '')
+        onCropped(new File([blob], `${base}-crop.jpg`, { type: 'image/jpeg' }))
+      },
+      'image/jpeg',
+      0.92,
+    )
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Speisekarte zuschneiden"
+    >
+      <div className="bg-surface-container rounded-2xl border border-outline-variant/15 max-w-lg w-full max-h-[90vh] overflow-auto p-4 space-y-3">
+        <div>
+          <p className="text-sm font-headline font-semibold text-on-surface">Speisekarte zuschneiden</p>
+          <p className="text-xs text-on-surface-variant mt-0.5">
+            Nur das gewünschte Gericht markieren — das schärft den Kontext für die AI.
+          </p>
+        </div>
+
+        <div className="flex justify-center bg-surface-container-low rounded-lg overflow-hidden">
+          <ReactCrop crop={crop} onChange={(c) => setCrop(c)} onComplete={(c) => setCompleted(c)}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img ref={imgRef} src={url} alt="Speisekarte" className="max-h-[60vh] w-auto" />
+          </ReactCrop>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={close}
+            className="px-4 py-2 text-sm text-on-surface-variant hover:text-on-surface transition-colors"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            onClick={apply}
+            disabled={busy || !completed?.width}
+            className="px-4 py-2 bg-primary text-on-primary rounded-lg text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors"
+          >
+            {busy ? 'Schneide…' : 'Übernehmen'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/nutrition/PhotoEstimator.tsx
+++ b/src/components/nutrition/PhotoEstimator.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
+import { MenuCropModal } from './MenuCropModal'
 
 interface AiEstimate {
   dishName: string
@@ -30,6 +31,11 @@ export function PhotoEstimator({ date, mealSlot, onLogged }: Props) {
   const plateRef = useRef<HTMLInputElement>(null)
   const menuRef = useRef<HTMLInputElement>(null)
 
+  // Menü-Foto liegt im State, damit ein zugeschnittenes Bild es ersetzen kann.
+  const [menuFile, setMenuFile] = useState<File | null>(null)
+  const [menuCropped, setMenuCropped] = useState(false)
+  const [cropOpen, setCropOpen] = useState(false)
+
   const [title, setTitle] = useState('')
   const [busy, setBusy] = useState<null | 'estimate' | 'log'>(null)
   const [error, setError] = useState<string | null>(null)
@@ -45,7 +51,7 @@ export function PhotoEstimator({ date, mealSlot, onLogged }: Props) {
   function currentFiles(): { plate: File | null; menu: File | null } {
     return {
       plate: plateRef.current?.files?.[0] ?? null,
-      menu: menuRef.current?.files?.[0] ?? null,
+      menu: menuFile, // State: ggf. zugeschnittene Version
     }
   }
 
@@ -112,6 +118,8 @@ export function PhotoEstimator({ date, mealSlot, onLogged }: Props) {
       setTitle('')
       if (plateRef.current) plateRef.current.value = ''
       if (menuRef.current) menuRef.current.value = ''
+      setMenuFile(null)
+      setMenuCropped(false)
       onLogged(dishName)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Loggen fehlgeschlagen')
@@ -135,7 +143,17 @@ export function PhotoEstimator({ date, mealSlot, onLogged }: Props) {
             Speisekarte (optional)
           </label>
           <input ref={menuRef} type="file" accept="image/jpeg,image/png,image/webp"
+            onChange={(e) => { setMenuFile(e.target.files?.[0] ?? null); setMenuCropped(false) }}
             className="block w-full text-xs text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-xs file:bg-surface-container-high file:text-on-surface" />
+          {menuFile && (
+            <div className="flex items-center gap-2 mt-1.5">
+              <button type="button" onClick={() => setCropOpen(true)}
+                className="text-xs px-2.5 py-1 rounded-lg border border-surface-container-high text-on-surface-variant hover:text-on-surface hover:border-primary transition-colors">
+                ✂︎ {menuCropped ? 'Erneut zuschneiden' : 'Zuschneiden'}
+              </button>
+              {menuCropped && <span className="text-xs text-primary">✓ zugeschnitten</span>}
+            </div>
+          )}
         </div>
       </div>
 
@@ -183,6 +201,18 @@ export function PhotoEstimator({ date, mealSlot, onLogged }: Props) {
             {busy === 'log' ? 'Logge…' : `In ${mealSlot} loggen`}
           </button>
         </div>
+      )}
+
+      {cropOpen && menuFile && (
+        <MenuCropModal
+          file={menuFile}
+          onCancel={() => setCropOpen(false)}
+          onCropped={(f) => {
+            setMenuFile(f)
+            setMenuCropped(true)
+            setCropOpen(false)
+          }}
+        />
       )}
     </div>
   )

--- a/src/lib/nutrition/crop.test.ts
+++ b/src/lib/nutrition/crop.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { computeCropRect } from './crop'
+
+const dims = { naturalWidth: 2000, naturalHeight: 1000, displayWidth: 400, displayHeight: 200 }
+
+describe('computeCropRect', () => {
+  it('scales the displayed selection up to native resolution', () => {
+    // scale = 5x
+    const r = computeCropRect({ x: 40, y: 20, width: 100, height: 50 }, dims)
+    expect(r).toEqual({ sx: 200, sy: 100, sw: 500, sh: 250, outW: 500, outH: 250 })
+  })
+
+  it('clamps the rect to the image bounds', () => {
+    const r = computeCropRect({ x: 380, y: 190, width: 100, height: 100 }, dims)
+    // sx=1900, sy=950 -> width limited to 100, height to 50
+    expect(r.sx).toBe(1900)
+    expect(r.sy).toBe(950)
+    expect(r.sw).toBe(100)
+    expect(r.sh).toBe(50)
+  })
+
+  it('never returns a zero-size rect', () => {
+    const r = computeCropRect({ x: 0, y: 0, width: 0, height: 0 }, dims)
+    expect(r.sw).toBeGreaterThanOrEqual(1)
+    expect(r.sh).toBeGreaterThanOrEqual(1)
+  })
+
+  it('handles missing display dims without dividing by zero', () => {
+    const r = computeCropRect(
+      { x: 10, y: 10, width: 20, height: 20 },
+      { naturalWidth: 100, naturalHeight: 100, displayWidth: 0, displayHeight: 0 },
+    )
+    expect(Number.isFinite(r.sx)).toBe(true)
+    expect(r.sw).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/src/lib/nutrition/crop.ts
+++ b/src/lib/nutrition/crop.ts
@@ -1,0 +1,51 @@
+// =============================================================================
+// Crop-Geometrie (Punkt 2) — reine, testbare Umrechnung.
+//
+// react-image-crop liefert die Auswahl in *angezeigten* Bildpixeln. Fürs
+// verlustfreie Zuschneiden muss auf die native Bildauflösung skaliert werden.
+// =============================================================================
+
+export interface CropRectInput {
+  /** Auswahl in angezeigten Bildpixeln. */
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface ImageDims {
+  naturalWidth: number
+  naturalHeight: number
+  displayWidth: number
+  displayHeight: number
+}
+
+export interface SourceRect {
+  sx: number
+  sy: number
+  sw: number
+  sh: number
+  outW: number
+  outH: number
+}
+
+/**
+ * Rechnet eine Auswahl (angezeigte Pixel) in einen Quell-Ausschnitt der nativen
+ * Auflösung um (für ctx.drawImage). Clamped auf die Bildgrenzen; min. 1px.
+ */
+export function computeCropRect(crop: CropRectInput, dims: ImageDims): SourceRect {
+  const scaleX = dims.displayWidth > 0 ? dims.naturalWidth / dims.displayWidth : 1
+  const scaleY = dims.displayHeight > 0 ? dims.naturalHeight / dims.displayHeight : 1
+
+  let sx = Math.round(crop.x * scaleX)
+  let sy = Math.round(crop.y * scaleY)
+  let sw = Math.round(crop.width * scaleX)
+  let sh = Math.round(crop.height * scaleY)
+
+  sx = Math.max(0, Math.min(sx, dims.naturalWidth - 1))
+  sy = Math.max(0, Math.min(sy, dims.naturalHeight - 1))
+  sw = Math.max(1, Math.min(sw, dims.naturalWidth - sx))
+  sh = Math.max(1, Math.min(sh, dims.naturalHeight - sy))
+
+  return { sx, sy, sw, sh, outW: sw, outH: sh }
+}


### PR DESCRIPTION
## Beschreibung

Punkt 2 aus dem Feedback: Das Menü-Foto im Foto→AI-Flow lässt sich jetzt zuschneiden, damit nur das relevante Gericht sichtbar ist — volle Speisekarten verwirren die AI messbar.

**Ablauf:** Nach der Auswahl eines Speisekarten-Fotos erscheint ein „Zuschneiden"-Button → Modal mit Auswahl-Rechteck (Drag/Resize, touch-tauglich) → „Übernehmen". Das Bild wird **clientseitig in nativer Auflösung** per Canvas zugeschnitten; die zugeschnittene Datei ersetzt das Menü-Foto, das an den Vision-Endpoint geht. Zuschneiden ist optional und wiederholbar; nach dem Loggen wird der Zustand zurückgesetzt.

**Technik:**
- `react-image-crop` (v11) für die Touch-Auswahl-UI (neue Dependency)
- reine Displayed→Native-Crop-Mathematik in `lib/nutrition/crop.ts` — getestet, auf Bildgrenzen geclamped, div-by-zero-sicher
- `MenuCropModal.tsx` (Client) macht das Canvas-Cropping; `react-image-crop`-CSS im App-Router-Build verifiziert

## Verknüpftes Issue

Kein GitHub-Issue — direktes Nutzungs-Feedback (Menükarten-Zuschnitt für bessere AI-Schätzung).

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Code folgt den Projektkonventionen (CLAUDE.md)
- [x] TypeScript kompiliert ohne Fehler (`pnpm type-check`)
- [x] Linting bestanden (`pnpm lint`)
- [x] Tests geschrieben und bestanden (`pnpm test` — 197 grün, 4 neu)
- [ ] Responsive getestet (Mobile + Desktop) — Crop-Bedienung auf dem iPhone im Deploy zu sichten
- [x] Prisma-Migration erstellt (falls Schema geändert) — n. z., keine Schema-Änderung
- [x] Umgebungsvariablen dokumentiert (falls neue hinzugefügt) — n. z., keine neuen
- [x] Neue Dependency: `react-image-crop` (~klein, clientseitig)

## Screenshots

<!-- Crop-Modal mit Auswahl-Rechteck über einer Speisekarte -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oFcbRQcQSKzFR3XNXX6RX

---
_Generated by [Claude Code](https://claude.ai/code/session_017oFcbRQcQSKzFR3XNXX6RX)_