### PR TITLE
feat(nutrition): FoodItem-Anreicherung per Nährwerttabellen-Foto + „geprüft"-Badge

### DIFF
--- a/prisma/migrations/20260711180000_add_food_verification/migration.sql
+++ b/prisma/migrations/20260711180000_add_food_verification/migration.sql
@@ -1,0 +1,6 @@
+-- Punkt 4: FoodItem Daten-Qualität — geprüft/angereichert via Nährwerttabellen-Foto (AI)
+ALTER TABLE "FoodItem" ADD COLUMN "verified" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "FoodItem" ADD COLUMN "verifiedAt" TIMESTAMP(3);
+ALTER TABLE "FoodItem" ADD COLUMN "labelImagePath" TEXT;
+
+CREATE INDEX "FoodItem_verified_idx" ON "FoodItem"("verified");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -465,6 +465,11 @@ model FoodItem {
   isActive     Boolean @default(true) // false = archiviert (nie hart löschen wenn referenziert)
   externalDbId String? // z.B. Open-Food-Facts-Code
 
+  // Daten-Qualität (Punkt 4): via Nährwerttabellen-Foto + AI geprüft/angereichert.
+  verified       Boolean   @default(false) // true = Werte gegen Label bestätigt
+  verifiedAt     DateTime?
+  labelImagePath String? // privat gespeichertes Verpackungs-/Nährwerttabellen-Foto
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -474,6 +479,7 @@ model FoodItem {
 
   @@index([barcode])
   @@index([isActive])
+  @@index([verified])
 }
 
 // --- Gericht: benannte Kombination mehrerer FoodItems -----------------------

--- a/src/app/admin/food/actions.ts
+++ b/src/app/admin/food/actions.ts
@@ -42,6 +42,9 @@ export interface FoodFormData {
   vitaminDUg: string
   vitaminB12Ug: string
   vitaminCMg: string
+  // Punkt 4: Daten-Qualität (aus der AI-Anreicherung bzw. am Item gespeichert).
+  verified?: boolean
+  labelImagePath?: string | null
 }
 
 function req(val: string): number | null {
@@ -89,6 +92,8 @@ function parseForm(data: FoodFormData): { input: FoodItemInput } | { error: stri
       vitaminDUg: req(data.vitaminDUg),
       vitaminB12Ug: req(data.vitaminB12Ug),
       vitaminCMg: req(data.vitaminCMg),
+      verified: data.verified ?? false,
+      labelImagePath: data.labelImagePath ?? null,
     },
   }
 }

--- a/src/app/api/nutrition/food/enrich/route.ts
+++ b/src/app/api/nutrition/food/enrich/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { ALLOWED_IMAGE_TYPES } from '@/lib/nutrition/meal-photos'
+import { saveFoodLabel, readFoodLabel, deleteFoodLabel } from '@/lib/nutrition/food-photos'
+import { extractLabelNutrients } from '@/lib/nutrition/vision'
+
+// Punkt 4: Nährwerttabellen-/Verpackungsfoto → AI-Anreicherung.
+// Speichert das Bild privat, extrahiert die Werte je 100 g/ml (inkl. Mikros)
+// und gibt sie zur Prüfung im Katalog-Formular zurück. Keys bleiben serverseitig.
+export async function POST(request: NextRequest) {
+  const session = await requireAdmin()
+  if (!session) return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 })
+
+  let form: FormData
+  try {
+    form = await request.formData()
+  } catch {
+    return NextResponse.json({ error: 'Ungültige Anfrage' }, { status: 400 })
+  }
+
+  const label = form.get('label')
+  if (!(label instanceof File)) {
+    return NextResponse.json({ error: 'Label-Foto fehlt' }, { status: 400 })
+  }
+  const spec = ALLOWED_IMAGE_TYPES[label.type]
+  if (!spec) {
+    return NextResponse.json({ error: 'Nur JPEG, PNG oder WebP werden unterstützt' }, { status: 400 })
+  }
+
+  let filename: string
+  try {
+    filename = await saveFoodLabel(label)
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'Speichern fehlgeschlagen' }, { status: 400 })
+  }
+
+  try {
+    const stored = await readFoodLabel(filename)
+    if (!stored) throw new Error('Bild konnte nicht gelesen werden')
+    const nutrients = await extractLabelNutrients({
+      data: stored.buffer.toString('base64'),
+      mediaType: spec.media,
+    })
+    return NextResponse.json({ labelImagePath: filename, nutrients })
+  } catch (e) {
+    // Kein verwaistes Bild zurücklassen, wenn die Extraktion scheitert.
+    await deleteFoodLabel(filename)
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Analyse fehlgeschlagen' },
+      { status: 502 },
+    )
+  }
+}

--- a/src/app/api/nutrition/food/label/[filename]/route.ts
+++ b/src/app/api/nutrition/food/label/[filename]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { readFoodLabel } from '@/lib/nutrition/food-photos'
+
+// Geschützte Auslieferung eines FoodItem-Label-Fotos (liegt ausserhalb public/).
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ filename: string }> },
+) {
+  const session = await requireAdmin()
+  if (!session) return new NextResponse('Nicht autorisiert', { status: 401 })
+
+  const { filename } = await params
+  const file = await readFoodLabel(filename)
+  if (!file) return new NextResponse('Not Found', { status: 404 })
+
+  return new NextResponse(new Uint8Array(file.buffer), {
+    headers: {
+      'Content-Type': file.contentType,
+      'Cache-Control': 'private, max-age=31536000, immutable',
+    },
+  })
+}

--- a/src/components/admin/FoodCatalog.tsx
+++ b/src/components/admin/FoodCatalog.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import type { FoodItem } from '@prisma/client'
 import type { NormalizedFood } from '@/lib/nutrition/food-provider'
+import type { LabelNutrients } from '@/lib/nutrition/vision'
 import { BarcodeScanner } from '@/components/nutrition/BarcodeScanner'
 import {
   saveFoodItem,
@@ -20,6 +21,7 @@ const EMPTY: FoodFormData = {
   fiberG: '', sugarG: '', saturatedFatG: '', sodiumMg: '', potassiumMg: '',
   ironMg: '', magnesiumMg: '', calciumMg: '', zincMg: '',
   vitaminDUg: '', vitaminB12Ug: '', vitaminCMg: '',
+  verified: false, labelImagePath: null,
 }
 
 const s = (n: number | null | undefined) => (n === null || n === undefined ? '' : String(n))
@@ -32,6 +34,7 @@ function itemToForm(f: FoodItem): FoodFormData {
     sodiumMg: s(f.sodiumMg), potassiumMg: s(f.potassiumMg), ironMg: s(f.ironMg),
     magnesiumMg: s(f.magnesiumMg), calciumMg: s(f.calciumMg), zincMg: s(f.zincMg),
     vitaminDUg: s(f.vitaminDUg), vitaminB12Ug: s(f.vitaminB12Ug), vitaminCMg: s(f.vitaminCMg),
+    verified: f.verified, labelImagePath: f.labelImagePath,
   }
 }
 
@@ -136,6 +139,44 @@ export function FoodCatalog({
   const set = (k: keyof FoodFormData) => (v: string) => setForm((f) => ({ ...f, [k]: v }))
   const editing = Boolean(form.id)
 
+  // --- AI-Anreicherung aus Nährwerttabelle (Punkt 4) ------------------------
+  const [enriching, setEnriching] = useState(false)
+
+  async function enrich(file: File) {
+    setMsg(null)
+    setEnriching(true)
+    try {
+      const fd = new FormData()
+      fd.append('label', file)
+      const res = await fetch('/api/nutrition/food/enrich', { method: 'POST', body: fd })
+      const data = (await res.json()) as { labelImagePath: string; nutrients: LabelNutrients; error?: string }
+      if (!res.ok) throw new Error(data.error ?? 'Analyse fehlgeschlagen')
+      const n = data.nutrients
+      setForm((f) => ({
+        ...f,
+        name: f.name || n.name || '',
+        brand: f.brand || n.brand || '',
+        baseUnit: n.baseUnit,
+        kcal: s(n.kcal), proteinG: s(n.proteinG), carbsG: s(n.carbsG), fatG: s(n.fatG),
+        fiberG: s(n.fiberG), sugarG: s(n.sugarG), saturatedFatG: s(n.saturatedFatG),
+        sodiumMg: s(n.sodiumMg), potassiumMg: s(n.potassiumMg), ironMg: s(n.ironMg),
+        magnesiumMg: s(n.magnesiumMg), calciumMg: s(n.calciumMg), zincMg: s(n.zincMg),
+        vitaminDUg: s(n.vitaminDUg), vitaminB12Ug: s(n.vitaminB12Ug), vitaminCMg: s(n.vitaminCMg),
+        labelImagePath: data.labelImagePath,
+        verified: true, // wird beim Speichern persistiert
+      }))
+      setMsg({
+        kind: 'ok',
+        text: `Werte übernommen (Konfidenz ${Math.round(n.confidence * 100)} %)${n.note ? ` · ${n.note}` : ''}. Bitte prüfen und speichern.`,
+      })
+      if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'smooth' })
+    } catch (e) {
+      setMsg({ kind: 'err', text: e instanceof Error ? e.message : 'Analyse fehlgeschlagen' })
+    } finally {
+      setEnriching(false)
+    }
+  }
+
   function loadOff(food: NormalizedFood) {
     setForm({
       id: undefined, name: food.name, brand: food.brand ?? '', barcode: food.barcode ?? '',
@@ -145,6 +186,7 @@ export function FoodCatalog({
       ironMg: s(food.ironMg), magnesiumMg: s(food.magnesiumMg), calciumMg: s(food.calciumMg),
       zincMg: s(food.zincMg), vitaminDUg: s(food.vitaminDUg), vitaminB12Ug: s(food.vitaminB12Ug),
       vitaminCMg: s(food.vitaminCMg),
+      verified: false, labelImagePath: null,
     })
     setMsg(null)
     if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -322,6 +364,43 @@ export function FoodCatalog({
           )}
         </div>
 
+        {/* AI-Anreicherung aus Nährwerttabelle (Punkt 4) */}
+        <div className="rounded-xl bg-surface-container-high p-3 space-y-2">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold text-on-surface">AI-Anreicherung aus Nährwerttabelle</p>
+              <p className="text-[11px] text-on-surface-variant">
+                Verpackung/Tabelle fotografieren — Werte je 100 {form.baseUnit} inkl. Mikros werden übernommen (danach prüfen &amp; speichern).
+              </p>
+            </div>
+            {form.verified && (
+              <span className="shrink-0 inline-flex items-center gap-1 text-[10px] font-label font-bold tracking-widest uppercase px-2 py-0.5 rounded-full border bg-primary/15 text-primary border-primary/30">
+                ✓ geprüft
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              disabled={enriching}
+              onChange={(e) => { const file = e.target.files?.[0]; if (file) enrich(file); e.target.value = '' }}
+              className="block w-full text-xs text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-xs file:bg-surface-container file:text-on-surface disabled:opacity-50"
+            />
+            {enriching && <span className="shrink-0 text-xs text-on-surface-variant">Analysiere…</span>}
+          </div>
+          {form.labelImagePath && (
+            <a
+              href={`/api/nutrition/food/label/${form.labelImagePath}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-block text-[11px] text-primary hover:underline"
+            >
+              Label-Foto ansehen
+            </a>
+          )}
+        </div>
+
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <div className="col-span-2">
             <label className="block text-xs font-medium text-on-surface-variant mb-1">Name</label>
@@ -414,6 +493,11 @@ export function FoodCatalog({
                       <td className="px-4 py-3 text-on-surface">
                         {f.name}
                         {f.brand ? <span className="text-on-surface-variant"> · {f.brand}</span> : ''}
+                        {f.verified && (
+                          <span className="ml-2 text-[10px] font-label font-bold tracking-widest uppercase text-primary" title="Werte gegen Nährwerttabelle geprüft">
+                            ✓ geprüft
+                          </span>
+                        )}
                         {!f.isActive && <span className="ml-2 text-[10px] uppercase text-on-surface-variant">archiviert</span>}
                       </td>
                       <td className="px-4 py-3 text-on-surface tabular-nums">{f.kcal}</td>

--- a/src/components/nutrition/MealLogger.tsx
+++ b/src/components/nutrition/MealLogger.tsx
@@ -275,6 +275,7 @@ export function MealLogger({ date, entries, favorites, dishes, summary }: Props)
                         <button type="button" onClick={() => { setSelected(r); setAmount('100') }}
                           className="w-full text-left rounded-lg px-3 py-2 hover:bg-surface-container-high transition-colors">
                           <span className="text-sm text-on-surface">{r.name}</span>
+                          {r.verified && <span className="text-[10px] text-primary ml-1" title="geprüft">✓</span>}
                           {r.brand && <span className="text-xs text-on-surface-variant"> · {r.brand}</span>}
                           <span className="text-xs text-on-surface-variant"> — {r.kcal} kcal</span>
                         </button>

--- a/src/lib/nutrition/food-photos.ts
+++ b/src/lib/nutrition/food-photos.ts
@@ -1,0 +1,51 @@
+// =============================================================================
+// Speicherung der FoodItem-Label-/Verpackungsfotos (Punkt 4)
+// Bilder liegen ausserhalb von public/ → nur über geschützte Admin-Route
+// abrufbar. Nutzt dieselben Typ-/Grössen-Regeln wie die Mahlzeiten-Fotos.
+// =============================================================================
+
+import { writeFile, mkdir, readFile, unlink } from 'fs/promises'
+import path from 'path'
+import crypto from 'crypto'
+import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_BYTES, MIME_BY_EXT } from './meal-photos'
+
+export const FOOD_LABEL_DIR = path.join(process.cwd(), 'private', 'food-labels')
+
+/** Persistiert ein hochgeladenes Label-Bild und gibt den Dateinamen zurück. */
+export async function saveFoodLabel(file: File): Promise<string> {
+  const spec = ALLOWED_IMAGE_TYPES[file.type]
+  if (!spec) throw new Error('Nur JPEG, PNG oder WebP werden unterstützt')
+  if (file.size > MAX_IMAGE_BYTES) throw new Error('Bild darf maximal 12 MB gross sein')
+
+  const filename = `${crypto.randomUUID()}${spec.ext}`
+  await mkdir(FOOD_LABEL_DIR, { recursive: true })
+  const bytes = Buffer.from(await file.arrayBuffer())
+  await writeFile(path.join(FOOD_LABEL_DIR, filename), bytes)
+  return filename
+}
+
+/** Liest ein gespeichertes Label-Bild (mit Path-Traversal-Schutz). */
+export async function readFoodLabel(
+  filename: string,
+): Promise<{ buffer: Buffer; contentType: string } | null> {
+  const filePath = path.resolve(FOOD_LABEL_DIR, filename)
+  if (!filePath.startsWith(FOOD_LABEL_DIR + path.sep)) return null
+  try {
+    const buffer = await readFile(filePath)
+    const ext = path.extname(filename).toLowerCase()
+    return { buffer, contentType: MIME_BY_EXT[ext] ?? 'application/octet-stream' }
+  } catch {
+    return null
+  }
+}
+
+/** Löscht ein Label-Bild (best-effort, z.B. bei fehlgeschlagener Extraktion). */
+export async function deleteFoodLabel(filename: string): Promise<void> {
+  const filePath = path.resolve(FOOD_LABEL_DIR, filename)
+  if (!filePath.startsWith(FOOD_LABEL_DIR + path.sep)) return
+  try {
+    await unlink(filePath)
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/nutrition/food.ts
+++ b/src/lib/nutrition/food.ts
@@ -34,6 +34,9 @@ export interface FoodItemInput {
   vitaminDUg: number | null
   vitaminB12Ug: number | null
   vitaminCMg: number | null
+  // Punkt 4: Daten-Qualität. Optional — Default: nicht geprüft.
+  verified?: boolean
+  labelImagePath?: string | null
 }
 
 function toData(input: FoodItemInput): Prisma.FoodItemCreateInput {
@@ -60,6 +63,9 @@ function toData(input: FoodItemInput): Prisma.FoodItemCreateInput {
     vitaminDUg: input.vitaminDUg,
     vitaminB12Ug: input.vitaminB12Ug,
     vitaminCMg: input.vitaminCMg,
+    verified: input.verified ?? false,
+    verifiedAt: input.verified ? new Date() : null,
+    labelImagePath: input.labelImagePath ?? null,
   }
 }
 

--- a/src/lib/nutrition/vision-label.test.ts
+++ b/src/lib/nutrition/vision-label.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { parseLabelNutrients } from './vision'
+
+describe('parseLabelNutrients', () => {
+  it('parses per-100 macros and micros, nulling absent micros', () => {
+    const json = JSON.stringify({
+      name: 'Magerquark',
+      brand: 'Migros',
+      baseUnit: 'g',
+      kcal: 67,
+      proteinG: 12,
+      carbsG: 4,
+      fatG: 0.2,
+      fiberG: 0,
+      sugarG: 4,
+      saturatedFatG: 0.1,
+      sodiumMg: 40,
+      calciumMg: 120,
+      confidence: 0.9,
+      note: 'pro 100 g',
+    })
+    const r = parseLabelNutrients(json)
+    expect(r.name).toBe('Magerquark')
+    expect(r.brand).toBe('Migros')
+    expect(r.baseUnit).toBe('g')
+    expect(r.kcal).toBe(67)
+    expect(r.proteinG).toBe(12)
+    expect(r.calciumMg).toBe(120)
+    // not present in JSON -> null
+    expect(r.ironMg).toBeNull()
+    expect(r.vitaminB12Ug).toBeNull()
+    expect(r.confidence).toBe(0.9)
+  })
+
+  it('defaults baseUnit to g and tolerates surrounding text', () => {
+    const r = parseLabelNutrients('hier: {"baseUnit":"unknown","kcal":42,"proteinG":1,"carbsG":10,"fatG":0} fertig')
+    expect(r.baseUnit).toBe('g')
+    expect(r.kcal).toBe(42)
+  })
+
+  it('recognises ml base unit for drinks', () => {
+    const r = parseLabelNutrients('{"baseUnit":"ml","kcal":0,"proteinG":0,"carbsG":0,"fatG":0}')
+    expect(r.baseUnit).toBe('ml')
+  })
+
+  it('clamps negative values and non-numeric micros to safe values', () => {
+    const r = parseLabelNutrients('{"kcal":-5,"proteinG":"abc","carbsG":0,"fatG":0,"ironMg":"n/a"}')
+    expect(r.kcal).toBe(0)
+    expect(r.proteinG).toBe(0)
+    expect(r.ironMg).toBeNull()
+  })
+
+  it('throws on non-JSON', () => {
+    expect(() => parseLabelNutrients('kein json hier')).toThrow()
+  })
+})

--- a/src/lib/nutrition/vision.ts
+++ b/src/lib/nutrition/vision.ts
@@ -113,3 +113,124 @@ export async function estimateFromPhotos({ plate, menu, title }: EstimateArgs): 
     throw e
   }
 }
+
+// =============================================================================
+// Nährwerttabelle → AI-Anreicherung eines FoodItems (Punkt 4)
+//
+// Liest eine Verpackung/Nährwerttabelle und liefert die Werte JE 100 g/ml inkl.
+// des fokussierten 12er-Mikro-Satzes als strukturiertes JSON. Der Owner prüft
+// die Werte anschliessend im Katalog-Formular, bevor gespeichert wird.
+// =============================================================================
+
+export interface LabelNutrients {
+  name: string | null
+  brand: string | null
+  baseUnit: 'g' | 'ml'
+  kcal: number
+  proteinG: number
+  carbsG: number
+  fatG: number
+  fiberG: number | null
+  sugarG: number | null
+  saturatedFatG: number | null
+  sodiumMg: number | null
+  potassiumMg: number | null
+  ironMg: number | null
+  magnesiumMg: number | null
+  calciumMg: number | null
+  zincMg: number | null
+  vitaminDUg: number | null
+  vitaminB12Ug: number | null
+  vitaminCMg: number | null
+  confidence: number
+  note: string
+  raw: unknown
+}
+
+const LABEL_SYSTEM_PROMPT = `Du liest eine Nährwerttabelle bzw. Produktverpackung und gibst die Nährwerte JE 100 g (feste Lebensmittel) bzw. JE 100 ml (Getränke) zurück.
+
+Regeln:
+- Werte IMMER pro 100 g/ml, nicht pro Portion. Zeigt die Tabelle nur "pro Portion", rechne mit der angegebenen Portionsgrösse auf 100 um.
+- baseUnit: "g" für feste, "ml" für flüssige Produkte.
+- Ist nur Salz angegeben, rechne Natrium = Salz(g) / 2,5 und gib es in mg an.
+- Einheiten: g für Makros/Ballaststoffe/Zucker/gesättigte Fettsäuren; mg für Natrium/Kalium/Eisen/Magnesium/Calcium/Zink/Vitamin C; µg für Vitamin D/B12.
+- Fülle nur klar ablesbare Werte. Nicht vorhandene Mikros = null (nicht raten).
+- Produktname/Marke von der Verpackung, wenn erkennbar, sonst null.
+- Ehrliche Konfidenz (0.0–1.0).
+- Antworte AUSSCHLIESSLICH mit einem einzigen minifizierten JSON-Objekt, ohne Markdown, ohne Erklärtext.
+
+JSON-Schema:
+{"name": string|null, "brand": string|null, "baseUnit": "g"|"ml", "kcal": number, "proteinG": number, "carbsG": number, "fatG": number, "fiberG": number|null, "sugarG": number|null, "saturatedFatG": number|null, "sodiumMg": number|null, "potassiumMg": number|null, "ironMg": number|null, "magnesiumMg": number|null, "calciumMg": number|null, "zincMg": number|null, "vitaminDUg": number|null, "vitaminB12Ug": number|null, "vitaminCMg": number|null, "confidence": number, "note": string}`
+
+function numOrNull(v: unknown): number | null {
+  if (v == null || v === '') return null
+  const n = typeof v === 'number' ? v : parseFloat(String(v))
+  if (isNaN(n)) return null
+  return Math.max(0, Math.round(n * 100) / 100)
+}
+
+function strOrNull(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() ? v.trim() : null
+}
+
+/** Robustes Parsen der Label-Antwort (erstes {...}-Objekt). */
+export function parseLabelNutrients(text: string): LabelNutrients {
+  const start = text.indexOf('{')
+  const end = text.lastIndexOf('}')
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('Keine JSON-Antwort vom Modell erhalten')
+  }
+  const raw = JSON.parse(text.slice(start, end + 1)) as Record<string, unknown>
+  return {
+    name: strOrNull(raw.name),
+    brand: strOrNull(raw.brand),
+    baseUnit: raw.baseUnit === 'ml' ? 'ml' : 'g',
+    kcal: num(raw.kcal),
+    proteinG: num(raw.proteinG),
+    carbsG: num(raw.carbsG),
+    fatG: num(raw.fatG),
+    fiberG: numOrNull(raw.fiberG),
+    sugarG: numOrNull(raw.sugarG),
+    saturatedFatG: numOrNull(raw.saturatedFatG),
+    sodiumMg: numOrNull(raw.sodiumMg),
+    potassiumMg: numOrNull(raw.potassiumMg),
+    ironMg: numOrNull(raw.ironMg),
+    magnesiumMg: numOrNull(raw.magnesiumMg),
+    calciumMg: numOrNull(raw.calciumMg),
+    zincMg: numOrNull(raw.zincMg),
+    vitaminDUg: numOrNull(raw.vitaminDUg),
+    vitaminB12Ug: numOrNull(raw.vitaminB12Ug),
+    vitaminCMg: numOrNull(raw.vitaminCMg),
+    confidence: clamp01(raw.confidence),
+    note: typeof raw.note === 'string' ? raw.note.trim() : '',
+    raw,
+  }
+}
+
+export async function extractLabelNutrients(label: VisionImage): Promise<LabelNutrients> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY nicht konfiguriert')
+  }
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+  const content: Anthropic.MessageParam['content'] = [
+    { type: 'text', text: 'Foto der Nährwerttabelle / Produktverpackung:' },
+    { type: 'image', source: { type: 'base64', media_type: label.mediaType, data: label.data } },
+    { type: 'text', text: 'Antworte nur mit dem JSON-Objekt.' },
+  ]
+
+  try {
+    const message = await client.messages.create({
+      model: MODEL,
+      max_tokens: 700,
+      system: LABEL_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content }],
+    })
+    const block = message.content[0]
+    if (!block || block.type !== 'text') throw new Error('Unerwartete API-Antwort')
+    return parseLabelNutrients(block.text)
+  } catch (e) {
+    if (e instanceof APIError) throw new Error(`Claude API Fehler: ${e.message}`)
+    throw e
+  }
+}


### PR DESCRIPTION
## Beschreibung

Punkt 4 aus dem Feedback: Zu einem Lebensmittel lässt sich ein **Foto der Verpackung/Nährwerttabelle** hochladen; die AI liest die Werte (inkl. der 12 Mikros) aus und reichert das FoodItem an. So steigt die Datenqualität dort, wo Open Food Facts lückenhaft ist (v. a. Mikros). Anschliessend gilt das Lebensmittel als **„geprüft"**.

**Datenmodell (Migration, additiv):** `FoodItem.verified`, `verifiedAt`, `labelImagePath` (+ Index).

**Vision:** `extractLabelNutrients()` liest ein Label und liefert Werte **je 100 g/ml** (Makros + 12 Mikros) plus `baseUnit`, Name-/Marken-Hinweise und Konfidenz. Robuster Parser (getestet), null-sicher bei fehlenden Mikros, Salz→Natrium-Hinweis.

**Speicherung:** Label-Fotos privat unter `private/food-labels`, Auslieferung nur über Admin-Route; bei fehlgeschlagener Extraktion wird das Bild wieder gelöscht (kein Waisen-Bild).

**Endpoint:** `POST /api/nutrition/food/enrich` (speichern + extrahieren).

**UI (Lebensmittel-Katalog):** Abschnitt „AI-Anreicherung" — Foto wählen/aufnehmen → **alle Nährwertfelder werden vorbefüllt** → prüfen/korrigieren → speichern. Beim Speichern nach Anreicherung wird `verified=true` (+ `verifiedAt`) gesetzt und der Label-Pfad gespeichert. **„✓ geprüft"-Badge** in der Katalog-Liste und ein ✓ in den Logger-Suchergebnissen.

Umgesetzt gemäss den abgestimmten Entscheidungen: alle Felder vorbefüllen · „geprüft" automatisch beim Speichern nach Anreicherung · Foto privat speichern.

## Verknüpftes Issue

Kein GitHub-Issue — direktes Nutzungs-Feedback (Daten-Anreicherung via Nährwerttabelle).

## Art der Änderung

- [x] ✨ Neues Feature

## Checkliste

- [x] Code folgt den Projektkonventionen (CLAUDE.md)
- [x] TypeScript kompiliert ohne Fehler (`pnpm type-check`)
- [x] Linting bestanden (`pnpm lint`)
- [x] Tests geschrieben und bestanden (`pnpm test` — 202 grün, 5 neu)
- [ ] Responsive getestet (Mobile + Desktop) — Upload/Prüf-Flow im Deploy zu sichten
- [x] Prisma-Migration erstellt (`20260711180000_add_food_verification`, additiv: ADD COLUMN + Index)
- [x] Umgebungsvariablen dokumentiert (falls neue hinzugefügt) — n. z., nutzt bestehenden `ANTHROPIC_API_KEY`

## Hinweise für den Merge/Deploy

- **Migration** muss laufen (`prisma migrate deploy`) — rein additiv, kein Datenverlust.
- Label-Fotos landen unter `private/food-labels` (bereits via `.gitignore` ausgeschlossen); Verzeichnis wird zur Laufzeit angelegt.
- `import type { LabelNutrients }` in der Client-Komponente ist bewusst type-only — das Anthropic-SDK wird nicht ins Client-Bundle gezogen (im Build verifiziert, `/admin/food` bleibt klein).

## Screenshots

<!-- AI-Anreicherung-Abschnitt + „✓ geprüft"-Badge im Katalog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oFcbRQcQSKzFR3XNXX6RX

---
_Generated by [Claude Code](https://claude.ai/code/session_017oFcbRQcQSKzFR3XNXX6RX)_